### PR TITLE
ci: add GitHub Actions workflow to publish to JSR on version bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,81 @@
+name: Publish to JSR
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "deno.json"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write # Required for JSR publishing
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2 # Need previous commit to check version change
+
+      - name: Check if version changed
+        id: version-check
+        run: |
+          # Get current version
+          CURRENT_VERSION=$(jq -r '.version' deno.json)
+          echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+
+          # Get previous version
+          git show HEAD~1:deno.json > /tmp/prev_deno.json 2>/dev/null || echo '{"version":"0.0.0"}' > /tmp/prev_deno.json
+          PREVIOUS_VERSION=$(jq -r '.version' /tmp/prev_deno.json)
+          echo "previous_version=$PREVIOUS_VERSION" >> $GITHUB_OUTPUT
+
+          # Check if version changed
+          if [ "$CURRENT_VERSION" != "$PREVIOUS_VERSION" ]; then
+            echo "Version changed from $PREVIOUS_VERSION to $CURRENT_VERSION"
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "Version unchanged ($CURRENT_VERSION)"
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup Deno
+        if: steps.version-check.outputs.changed == 'true'
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Verify formatting
+        if: steps.version-check.outputs.changed == 'true'
+        run: deno fmt --check
+
+      - name: Run linter
+        if: steps.version-check.outputs.changed == 'true'
+        run: deno lint
+
+      - name: Run tests
+        if: steps.version-check.outputs.changed == 'true'
+        run: deno task test
+
+      - name: Publish to JSR
+        if: steps.version-check.outputs.changed == 'true'
+        run: deno publish
+
+      - name: Summary
+        if: steps.version-check.outputs.changed == 'true'
+        run: |
+          echo "## 🚀 Published to JSR" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Package:** @atzufuki/alexi" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** ${{ steps.version-check.outputs.current_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "[View on JSR](https://jsr.io/@atzufuki/alexi)" >> $GITHUB_STEP_SUMMARY
+
+      - name: Skip summary
+        if: steps.version-check.outputs.changed == 'false'
+        run: |
+          echo "## ⏭️ Publish skipped" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Version unchanged (${{ steps.version-check.outputs.current_version }})" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Adds automatic publishing to JSR when version is bumped in `deno.json`.

## New Workflow: `publish.yml`

### Trigger
- Push to `main` branch
- Only when `deno.json` is modified

### Steps
1. **Check if version changed** - Compares current version with previous commit
2. **Setup Deno** - Only if version changed
3. **Verify formatting** - `deno fmt --check`
4. **Run linter** - `deno lint`
5. **Run tests** - `deno task test`
6. **Publish to JSR** - `deno publish` with OIDC authentication
7. **Summary** - Adds link to JSR package

### Version Detection
```bash
# Get current version from deno.json
CURRENT_VERSION=$(jq -r '.version' deno.json)

# Get previous version from last commit
git show HEAD~1:deno.json > /tmp/prev_deno.json
PREVIOUS_VERSION=$(jq -r '.version' /tmp/prev_deno.json)
```

### Usage

To publish a new version:
1. Update `version` in `deno.json`
2. Commit and push to `main`
3. Workflow automatically publishes to JSR

## Permissions

Requires `id-token: write` for JSR OIDC authentication (no API key needed).