### PR TITLE
refactor: ModelEndpoint now requires explicit path property

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -3,6 +3,7 @@
   "specifiers": {
     "jsr:@luca/esbuild-deno-loader@~0.11.1": "0.11.1",
     "jsr:@std/assert@*": "1.0.18",
+    "jsr:@std/assert@1": "1.0.18",
     "jsr:@std/bytes@^1.0.2": "1.0.6",
     "jsr:@std/encoding@^1.0.5": "1.0.10",
     "jsr:@std/fs@^1.0.19": "1.0.22",


### PR DESCRIPTION
## Summary

`ModelEndpoint` classes now require an explicit `path` property instead of the optional `endpoint` segment. This removes auto-derivation and makes endpoint configuration fully explicit.

**BREAKING CHANGE**: `ModelEndpoint.endpoint` is replaced with `ModelEndpoint.path`

## Changes

- **`endpoint` → `path`**: Renamed property and made it abstract (required)
- **Full path required**: `path` must be the full API path with leading/trailing slashes (e.g., `/projects/`)
- **No auto-derivation**: Removed logic that derived endpoints from model name or `dbTable`
- **Removed `_dbTableToEndpoint`**: This mapping is no longer needed
- **Simplified `getEndpointForModel`**: Now throws an error if no endpoint is registered instead of falling back to auto-derivation
- **Updated tests**: All test endpoint classes now use explicit `path`
- **Updated documentation**: `AGENTS.md` reflects the new API

## Migration

```typescript
// Before
class EmployeeEndpoint extends ModelEndpoint {
  model = EmployeeModel;
  endpoint = "employees";  // or auto-derived from dbTable
}

// After
class EmployeeEndpoint extends ModelEndpoint {
  model = EmployeeModel;
  path = "/employees/";  // Required - full path with slashes
}
```

## Benefits

- **Explicit**: Full path visible in the code
- **No magic**: What you write is what gets called
- **Debuggable**: Easy to understand and trace
- **Flexible**: Full control over path structure (e.g., `/api/v2/project-roles/`)

Closes #21