### PR TITLE
feat: ForeignKey improvements and QuerySet chainable fetch

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -3,6 +3,7 @@
   "specifiers": {
     "jsr:@luca/esbuild-deno-loader@~0.11.1": "0.11.1",
     "jsr:@std/assert@*": "1.0.18",
+    "jsr:@std/assert@1": "1.0.18",
     "jsr:@std/bytes@^1.0.2": "1.0.6",
     "jsr:@std/encoding@^1.0.5": "1.0.10",
     "jsr:@std/fs@^1.0.19": "1.0.22",

--- a/src/db/fields/relations.ts
+++ b/src/db/fields/relations.ts
@@ -54,6 +54,52 @@ export interface ForeignKeyOptions<T> extends FieldOptions<T> {
 
 /**
  * ForeignKey - Reference to another model (many-to-one relationship)
+ *
+ * This field stores a reference to another model. It provides Django-like
+ * access patterns for working with related objects.
+ *
+ * @example
+ * ```ts
+ * // Define models
+ * class Organisation extends Model {
+ *   id = new AutoField({ primaryKey: true });
+ *   name = new CharField({ maxLength: 100 });
+ *   static objects = new Manager(Organisation);
+ * }
+ *
+ * class Project extends Model {
+ *   id = new AutoField({ primaryKey: true });
+ *   name = new CharField({ maxLength: 100 });
+ *   organisation = new ForeignKey<Organisation>(Organisation, { onDelete: OnDelete.CASCADE });
+ *   static objects = new Manager(Project);
+ * }
+ *
+ * // Usage
+ * const project = await Project.objects.get({ id: 1 });
+ *
+ * // Get the ID directly (no fetch needed)
+ * project.organisation.id; // 42
+ *
+ * // Fetch the related object (lazy load)
+ * await project.organisation.fetch();
+ *
+ * // Now get() returns the instance
+ * project.organisation.get(); // Organisation instance
+ * project.organisation.get().name.get(); // "Acme Inc"
+ *
+ * // Check if loaded
+ * project.organisation.isLoaded(); // true
+ *
+ * // With selectRelated (avoid N+1)
+ * const projects = await Project.objects
+ *   .selectRelated('organisation')
+ *   .fetch();
+ *
+ * for (const p of projects.array()) {
+ *   // No additional fetch needed - already loaded
+ *   console.log(p.organisation.get().name.get());
+ * }
+ * ```
  */
 export class ForeignKey<T> extends Field<T> {
   readonly relatedModel: LazyModelRef<T>;
@@ -62,6 +108,13 @@ export class ForeignKey<T> extends Field<T> {
   readonly toField: string;
 
   private _resolvedModel?: ModelClass<T>;
+  private _foreignKeyId: unknown = null;
+  private _relatedInstance: T | null = null;
+  private _isLoaded = false;
+
+  // Reference to backend (set by Model when hydrating)
+  // deno-lint-ignore no-explicit-any
+  private _backend?: any;
 
   constructor(model: LazyModelRef<T>, options: ForeignKeyOptions<T>) {
     super(options);
@@ -69,6 +122,195 @@ export class ForeignKey<T> extends Field<T> {
     this.onDelete = options.onDelete;
     this.relatedName = options.relatedName;
     this.toField = options.toField ?? "id";
+  }
+
+  /**
+   * Get the foreign key ID without fetching the related object
+   *
+   * @example
+   * ```ts
+   * const project = await Project.objects.get({ id: 1 });
+   * const orgId = project.organisation.id; // 42 (no fetch needed)
+   * ```
+   */
+  get id(): unknown {
+    return this._foreignKeyId;
+  }
+
+  /**
+   * Get the related model instance
+   *
+   * @throws Error if the related object has not been fetched yet
+   *
+   * @example
+   * ```ts
+   * await project.organisation.fetch();
+   * const org = project.organisation.get();
+   * console.log(org.name.get());
+   * ```
+   */
+  override get(): T {
+    if (!this._isLoaded) {
+      throw new Error(
+        `Related object '${this._name}' not fetched. Call .fetch() first or use selectRelated().`,
+      );
+    }
+    return this._relatedInstance as T;
+  }
+
+  /**
+   * Set the related object or foreign key ID
+   *
+   * Can accept either:
+   * - A model instance (extracts the ID and caches the instance)
+   * - A raw ID value (clears any cached instance)
+   *
+   * @example
+   * ```ts
+   * // Set with instance
+   * const org = await Organisation.objects.get({ id: 1 });
+   * project.organisation.set(org);
+   *
+   * // Set with ID
+   * project.organisation.set(42);
+   * ```
+   */
+  override set(value: T | null): void {
+    if (value === null) {
+      this._foreignKeyId = null;
+      this._relatedInstance = null;
+      this._isLoaded = false;
+      this._value = null;
+      return;
+    }
+
+    // Check if value is a model instance
+    // deno-lint-ignore no-explicit-any
+    const instance = value as any;
+    if (instance && typeof instance === "object" && this.toField in instance) {
+      const field = instance[this.toField];
+      // If it's a Field instance, get its value
+      if (field && typeof field.get === "function") {
+        this._foreignKeyId = field.get();
+      } else {
+        this._foreignKeyId = field;
+      }
+      this._relatedInstance = value;
+      this._isLoaded = true;
+    } else {
+      // Value is a raw ID
+      this._foreignKeyId = value;
+      this._relatedInstance = null;
+      this._isLoaded = false;
+    }
+
+    // Store the ID in _value for compatibility
+    this._value = this._foreignKeyId as T | null;
+  }
+
+  /**
+   * Check if the related object has been loaded
+   *
+   * @example
+   * ```ts
+   * project.organisation.isLoaded(); // false
+   * await project.organisation.fetch();
+   * project.organisation.isLoaded(); // true
+   * ```
+   */
+  isLoaded(): boolean {
+    return this._isLoaded;
+  }
+
+  /**
+   * Fetch and cache the related object
+   *
+   * This is a lazy-loading method that fetches the related object
+   * from the database if it hasn't been loaded yet.
+   *
+   * @returns The related object, or null if the foreign key is null
+   *
+   * @example
+   * ```ts
+   * const org = await project.organisation.fetch();
+   * console.log(org?.name.get());
+   * ```
+   */
+  async fetch(): Promise<T | null> {
+    if (this._foreignKeyId === null || this._foreignKeyId === undefined) {
+      return null;
+    }
+
+    if (this._isLoaded && this._relatedInstance !== null) {
+      return this._relatedInstance;
+    }
+
+    const modelClass = this.getRelatedModel();
+    if (!modelClass) {
+      throw new Error(
+        `Related model for '${this._name}' could not be resolved. ` +
+          `Make sure the model is registered.`,
+      );
+    }
+
+    // Get the backend - try instance backend first, then global
+    let backend = this._backend;
+    if (!backend) {
+      // Import dynamically to avoid circular dependency
+      const { getBackend, isInitialized } = await import("../setup.ts");
+      if (!isInitialized()) {
+        throw new Error(
+          `Database not initialized. Call setup() before fetching related objects.`,
+        );
+      }
+      backend = getBackend();
+    }
+
+    // Fetch the related object
+    const data = await backend.getById(modelClass, this._foreignKeyId);
+    if (data) {
+      const instance = new modelClass();
+      // deno-lint-ignore no-explicit-any
+      (instance as any).fromDB(data);
+      // deno-lint-ignore no-explicit-any
+      (instance as any)._backend = backend;
+      this._relatedInstance = instance;
+      this._isLoaded = true;
+      return instance;
+    }
+
+    return null;
+  }
+
+  /**
+   * Set the related instance directly (used by selectRelated)
+   *
+   * This is an internal method used by QuerySet.selectRelated()
+   * to populate the related object without an additional fetch.
+   */
+  setRelatedInstance(instance: T | null): void {
+    this._relatedInstance = instance;
+    this._isLoaded = instance !== null;
+    if (instance !== null) {
+      // deno-lint-ignore no-explicit-any
+      const inst = instance as any;
+      if (inst && typeof inst === "object" && this.toField in inst) {
+        const field = inst[this.toField];
+        if (field && typeof field.get === "function") {
+          this._foreignKeyId = field.get();
+        } else {
+          this._foreignKeyId = field;
+        }
+      }
+    }
+  }
+
+  /**
+   * Set the backend reference (called by Model when hydrating)
+   */
+  // deno-lint-ignore no-explicit-any
+  setBackend(backend: any): void {
+    this._backend = backend;
   }
 
   /**
@@ -101,28 +343,33 @@ export class ForeignKey<T> extends Field<T> {
     return this.options.dbColumn ?? `${this.name}_id`;
   }
 
-  toDB(value: T | null): unknown {
-    if (value === null) return null;
-
-    // If value is a model instance, extract the referenced field value
-    // deno-lint-ignore no-explicit-any
-    const instance = value as any;
-    if (instance && typeof instance === "object" && this.toField in instance) {
-      const field = instance[this.toField];
-      // If it's a Field instance, get its value
-      if (field && typeof field.get === "function") {
-        return field.get();
+  toDB(_value: T | null): unknown {
+    // If we have a cached instance, use its ID
+    if (this._isLoaded && this._relatedInstance !== null) {
+      // deno-lint-ignore no-explicit-any
+      const instance = this._relatedInstance as any;
+      if (
+        instance && typeof instance === "object" && this.toField in instance
+      ) {
+        const field = instance[this.toField];
+        if (field && typeof field.get === "function") {
+          return field.get();
+        }
+        return field;
       }
-      return field;
     }
 
-    // If value is already the ID, return it directly
-    return value;
+    // Use the stored foreign key ID (this is the primary source)
+    // This handles both raw ID values and IDs extracted from instances via set()
+    return this._foreignKeyId;
   }
 
   fromDB(value: unknown): T | null {
-    // ForeignKey fromDB returns the raw ID value
-    // The actual model instance is loaded lazily or via select_related
+    // ForeignKey fromDB stores the raw ID value
+    // The actual model instance is loaded lazily or via selectRelated
+    this._foreignKeyId = value;
+    this._relatedInstance = null;
+    this._isLoaded = false;
     return value as T | null;
   }
 
@@ -133,13 +380,22 @@ export class ForeignKey<T> extends Field<T> {
   }
 
   clone(options?: Partial<ForeignKeyOptions<T>>): ForeignKey<T> {
-    return new ForeignKey<T>(this.relatedModel, {
+    const cloned = new ForeignKey<T>(this.relatedModel, {
       ...this.options,
       onDelete: this.onDelete,
       relatedName: this.relatedName,
       toField: this.toField,
       ...options,
     } as ForeignKeyOptions<T>);
+
+    // Copy state
+    cloned._foreignKeyId = this._foreignKeyId;
+    cloned._relatedInstance = this._relatedInstance;
+    cloned._isLoaded = this._isLoaded;
+    cloned._backend = this._backend;
+    cloned._resolvedModel = this._resolvedModel;
+
+    return cloned;
   }
 
   override serialize(): Record<string, unknown> {
@@ -171,13 +427,27 @@ export class OneToOneField<T> extends ForeignKey<T> {
   }
 
   override clone(options?: Partial<ForeignKeyOptions<T>>): OneToOneField<T> {
-    return new OneToOneField<T>(this.relatedModel, {
+    const cloned = new OneToOneField<T>(this.relatedModel, {
       ...this.options,
       onDelete: this.onDelete,
       relatedName: this.relatedName,
       toField: this.toField,
       ...options,
     } as ForeignKeyOptions<T>);
+
+    // Copy state from parent
+    // deno-lint-ignore no-explicit-any
+    (cloned as any)._foreignKeyId = (this as any)._foreignKeyId;
+    // deno-lint-ignore no-explicit-any
+    (cloned as any)._relatedInstance = (this as any)._relatedInstance;
+    // deno-lint-ignore no-explicit-any
+    (cloned as any)._isLoaded = (this as any)._isLoaded;
+    // deno-lint-ignore no-explicit-any
+    (cloned as any)._backend = (this as any)._backend;
+    // deno-lint-ignore no-explicit-any
+    (cloned as any)._resolvedModel = (this as any)._resolvedModel;
+
+    return cloned;
   }
 }
 

--- a/src/db/tests/basic_test.ts
+++ b/src/db/tests/basic_test.ts
@@ -226,7 +226,7 @@ Deno.test("DenoKVBackend - CRUD operations", async () => {
     assertEquals(author.email.get(), "john@example.com");
 
     // Read
-    const fetchedAuthors = await authors.all().fetch();
+    const fetchedAuthors = (await authors.all().fetch()).array();
     assertEquals(fetchedAuthors.length, 1);
     assertEquals(fetchedAuthors[0].name.get(), "John Doe");
 
@@ -243,7 +243,7 @@ Deno.test("DenoKVBackend - CRUD operations", async () => {
 
     // Delete
     await backend.delete(found);
-    const remaining = await authors.all().fetch();
+    const remaining = (await authors.all().fetch()).array();
     assertEquals(remaining.length, 0);
   } finally {
     await backend.disconnect();
@@ -282,37 +282,37 @@ Deno.test("DenoKVBackend - filter operations", async () => {
     });
 
     // Filter by exact match
-    const typescript = await articles
+    const typescript = (await articles
       .filter({ title: "TypeScript Guide" })
-      .fetch();
+      .fetch()).array();
     assertEquals(typescript.length, 1);
     assertEquals(typescript[0].title.get(), "TypeScript Guide");
 
     // Filter by contains
-    const learnArticles = await articles
+    const learnArticles = (await articles
       .filter({ title__contains: "Guide" })
-      .fetch();
+      .fetch()).array();
     assertEquals(learnArticles.length, 1);
 
     // Filter by gte
-    const popularArticles = await articles
+    const popularArticles = (await articles
       .filter({ views__gte: 100 })
-      .fetch();
+      .fetch()).array();
     assertEquals(popularArticles.length, 2);
 
     // Filter by lt
-    const unpopularArticles = await articles
+    const unpopularArticles = (await articles
       .filter({ views__lt: 100 })
-      .fetch();
+      .fetch()).array();
     assertEquals(unpopularArticles.length, 1);
 
     // Ordering
-    const orderedByViews = await articles.orderBy("-views").fetch();
+    const orderedByViews = (await articles.orderBy("-views").fetch()).array();
     assertEquals(orderedByViews[0].views.get(), 200);
     assertEquals(orderedByViews[2].views.get(), 50);
 
     // Limit
-    const limited = await articles.orderBy("-views").limit(2).fetch();
+    const limited = (await articles.orderBy("-views").limit(2).fetch()).array();
     assertEquals(limited.length, 2);
 
     // Count
@@ -433,7 +433,7 @@ Deno.test("DenoKVBackend - unique field constraint", async () => {
     await backend.insert(record3);
 
     // Verify we have 2 records
-    const all = await UniqueEmail.objects.all().fetch();
+    const all = (await UniqueEmail.objects.all().fetch()).array();
     assertEquals(all.length, 2);
 
     // Test case-insensitive uniqueness
@@ -511,8 +511,9 @@ Deno.test("Model.fromDB - ForeignKey with column name format (employee_id)", () 
   });
 
   assertEquals(empComp.id.get(), 1);
-  assertEquals(empComp.employee.get(), 5);
-  assertEquals(empComp.competence.get(), 3);
+  // Use .id to get the foreign key ID (new API)
+  assertEquals(empComp.employee.id, 5);
+  assertEquals(empComp.competence.id, 3);
   assertEquals(empComp.isPersisted, true);
 });
 
@@ -528,8 +529,9 @@ Deno.test("Model.fromDB - ForeignKey with field name format (employee)", () => {
   });
 
   assertEquals(empComp.id.get(), 2);
-  assertEquals(empComp.employee.get(), 10);
-  assertEquals(empComp.competence.get(), 7);
+  // Use .id to get the foreign key ID (new API)
+  assertEquals(empComp.employee.id, 10);
+  assertEquals(empComp.competence.id, 7);
   assertEquals(empComp.isPersisted, true);
 });
 
@@ -547,8 +549,9 @@ Deno.test("Model.fromDB - ForeignKey column name takes precedence over field nam
   });
 
   assertEquals(empComp.id.get(), 3);
-  assertEquals(empComp.employee.get(), 5); // column name value
-  assertEquals(empComp.competence.get(), 3); // column name value
+  // Use .id to get the foreign key ID (new API)
+  assertEquals(empComp.employee.id, 5); // column name value
+  assertEquals(empComp.competence.id, 3); // column name value
 });
 
 Deno.test("Model.fromDB - ForeignKey with null values", () => {
@@ -562,8 +565,9 @@ Deno.test("Model.fromDB - ForeignKey with null values", () => {
   });
 
   assertEquals(empComp.id.get(), 4);
-  assertEquals(empComp.employee.get(), null);
-  assertEquals(empComp.competence.get(), null);
+  // Use .id to get the foreign key ID (new API)
+  assertEquals(empComp.employee.id, null);
+  assertEquals(empComp.competence.id, null);
 });
 
 Deno.test("Model.toDB - ForeignKey outputs column name format", () => {
@@ -571,8 +575,9 @@ Deno.test("Model.toDB - ForeignKey outputs column name format", () => {
   empComp.getFields();
 
   empComp.id.set(1);
-  empComp.employee.set(5);
-  empComp.competence.set(3);
+  // Use .set() with raw ID values (new API supports this)
+  empComp.employee.set(5 as unknown as Employee);
+  empComp.competence.set(3 as unknown as Competence);
 
   const data = empComp.toDB();
 

--- a/src/db/tests/foreignkey_test.ts
+++ b/src/db/tests/foreignkey_test.ts
@@ -1,0 +1,820 @@
+/**
+ * Tests for ForeignKey improvements and QuerySet chainable fetch
+ *
+ * Tests for:
+ * - Issue #24: ForeignKey improvements - related object access
+ * - Issue #25: QuerySet.fetch() returns QuerySet for chainable in-memory filtering
+ *
+ * @module
+ */
+
+import { assertEquals, assertExists, assertRejects } from "jsr:@std/assert@1";
+import {
+  AutoField,
+  BooleanField,
+  CharField,
+  IntegerField,
+  Manager,
+  Model,
+} from "../mod.ts";
+import { ForeignKey, OnDelete } from "../fields/relations.ts";
+import { reset, setup } from "../setup.ts";
+import { DenoKVBackend } from "../backends/denokv/mod.ts";
+
+// ============================================================================
+// Test Models
+// ============================================================================
+
+class Organisation extends Model {
+  id = new AutoField({ primaryKey: true });
+  name = new CharField({ maxLength: 100 });
+  country = new CharField({ maxLength: 100, blank: true, default: "" });
+
+  static objects = new Manager(Organisation);
+  static override meta = {
+    dbTable: "organisations",
+  };
+}
+
+class Project extends Model {
+  id = new AutoField({ primaryKey: true });
+  name = new CharField({ maxLength: 100 });
+  organisation = new ForeignKey<Organisation>(Organisation, {
+    onDelete: OnDelete.CASCADE,
+  });
+  isPublished = new BooleanField({ default: false });
+  views = new IntegerField({ default: 0 });
+
+  static objects = new Manager(Project);
+  static override meta = {
+    dbTable: "projects",
+  };
+}
+
+class Employee extends Model {
+  id = new AutoField({ primaryKey: true });
+  firstName = new CharField({ maxLength: 100 });
+  lastName = new CharField({ maxLength: 100 });
+  organisation = new ForeignKey<Organisation>(Organisation, {
+    onDelete: OnDelete.CASCADE,
+  });
+
+  static objects = new Manager(Employee);
+  static override meta = {
+    dbTable: "employees",
+  };
+}
+
+// ============================================================================
+// ForeignKey Tests (Issue #24)
+// ============================================================================
+
+Deno.test({
+  name: "ForeignKey - .id returns foreign key ID without loading",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = new DenoKVBackend({ name: "fk-test-1", path: ":memory:" });
+    await backend.connect();
+    await setup({ backend });
+
+    try {
+      // Create organisation
+      const org = await Organisation.objects.create({
+        name: "Acme Inc",
+        country: "Finland",
+      });
+
+      // Create project with organisation
+      const project = await Project.objects.create({
+        name: "Website Redesign",
+        organisation: org,
+        isPublished: true,
+      });
+
+      // Reload project from database
+      const loadedProject = await Project.objects.get({ id: project.id.get() });
+
+      // .id should return the FK ID without fetching the related object
+      assertEquals(loadedProject.organisation.id, org.id.get());
+
+      // Related object should NOT be loaded yet
+      assertEquals(loadedProject.organisation.isLoaded(), false);
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});
+
+Deno.test({
+  name: "ForeignKey - .get() throws if not loaded",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = new DenoKVBackend({ name: "fk-test-2", path: ":memory:" });
+    await backend.connect();
+    await setup({ backend });
+
+    try {
+      const org = await Organisation.objects.create({
+        name: "Test Org",
+        country: "Sweden",
+      });
+
+      const project = await Project.objects.create({
+        name: "Test Project",
+        organisation: org,
+      });
+
+      const loadedProject = await Project.objects.get({ id: project.id.get() });
+
+      // .get() should throw because related object is not loaded
+      try {
+        loadedProject.organisation.get();
+        throw new Error("Expected error was not thrown");
+      } catch (error) {
+        assertEquals(
+          (error as Error).message.includes("not fetched"),
+          true,
+          "Error message should mention object not fetched",
+        );
+      }
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});
+
+Deno.test({
+  name: "ForeignKey - .fetch() lazy loads related object",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = new DenoKVBackend({ name: "fk-test-3", path: ":memory:" });
+    await backend.connect();
+    await setup({ backend });
+
+    try {
+      const org = await Organisation.objects.create({
+        name: "Lazy Load Corp",
+        country: "Norway",
+      });
+
+      const project = await Project.objects.create({
+        name: "Lazy Project",
+        organisation: org,
+      });
+
+      const loadedProject = await Project.objects.get({ id: project.id.get() });
+
+      // Before fetch
+      assertEquals(loadedProject.organisation.isLoaded(), false);
+
+      // Fetch the related object
+      const fetchedOrg = await loadedProject.organisation.fetch();
+
+      // After fetch
+      assertEquals(loadedProject.organisation.isLoaded(), true);
+      assertExists(fetchedOrg);
+      assertEquals(fetchedOrg!.name.get(), "Lazy Load Corp");
+      assertEquals(fetchedOrg!.country.get(), "Norway");
+
+      // Now .get() should work
+      const gotOrg = loadedProject.organisation.get();
+      assertEquals(gotOrg.name.get(), "Lazy Load Corp");
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});
+
+Deno.test({
+  name: "ForeignKey - .fetch() returns null for null FK",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = new DenoKVBackend({ name: "fk-test-4", path: ":memory:" });
+    await backend.connect();
+    await setup({ backend });
+
+    try {
+      // Create project without organisation (null FK)
+      const project = new Project();
+      project.getFields();
+      project.name.set("Orphan Project");
+      // organisation is null by default
+
+      const result = await project.organisation.fetch();
+      assertEquals(result, null);
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});
+
+Deno.test({
+  name: "ForeignKey - .set() with model instance",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = new DenoKVBackend({ name: "fk-test-5", path: ":memory:" });
+    await backend.connect();
+    await setup({ backend });
+
+    try {
+      const org = await Organisation.objects.create({
+        name: "Set Test Org",
+        country: "Denmark",
+      });
+
+      const project = new Project();
+      project.getFields();
+      project.name.set("Set Test Project");
+
+      // Set with model instance
+      project.organisation.set(org);
+
+      // ID should be available
+      assertEquals(project.organisation.id, org.id.get());
+
+      // Instance should be loaded
+      assertEquals(project.organisation.isLoaded(), true);
+
+      // .get() should return the instance
+      assertEquals(project.organisation.get().name.get(), "Set Test Org");
+
+      // Save and verify
+      const savedData = await backend.insert(project);
+      project.fromDB(savedData);
+
+      const loaded = await Project.objects.get({ id: project.id.get() });
+      assertEquals(loaded.organisation.id, org.id.get());
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});
+
+Deno.test({
+  name: "ForeignKey - .set() with null clears the relation",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = new DenoKVBackend({ name: "fk-test-6", path: ":memory:" });
+    await backend.connect();
+    await setup({ backend });
+
+    try {
+      const org = await Organisation.objects.create({
+        name: "Clear Test Org",
+        country: "Iceland",
+      });
+
+      const project = new Project();
+      project.getFields();
+      project.name.set("Clear Test Project");
+      project.organisation.set(org);
+
+      // Verify set
+      assertEquals(project.organisation.id, org.id.get());
+      assertEquals(project.organisation.isLoaded(), true);
+
+      // Clear with null
+      project.organisation.set(null);
+
+      // Should be cleared
+      assertEquals(project.organisation.id, null);
+      assertEquals(project.organisation.isLoaded(), false);
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});
+
+// ============================================================================
+// QuerySet selectRelated Tests (Issue #24)
+// ============================================================================
+
+Deno.test({
+  name: "QuerySet - selectRelated() preloads ForeignKey relations",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = new DenoKVBackend({ name: "sr-test-1", path: ":memory:" });
+    await backend.connect();
+    await setup({ backend });
+
+    try {
+      // Create organisations
+      const org1 = await Organisation.objects.create({
+        name: "Org One",
+        country: "Finland",
+      });
+      const org2 = await Organisation.objects.create({
+        name: "Org Two",
+        country: "Sweden",
+      });
+
+      // Create projects
+      await Project.objects.create({
+        name: "Project A",
+        organisation: org1,
+        isPublished: true,
+      });
+      await Project.objects.create({
+        name: "Project B",
+        organisation: org2,
+        isPublished: true,
+      });
+      await Project.objects.create({
+        name: "Project C",
+        organisation: org1,
+        isPublished: false,
+      });
+
+      // Fetch with selectRelated
+      const projects = await Project.objects
+        .selectRelated("organisation")
+        .fetch();
+
+      const projectArray = projects.array();
+      assertEquals(projectArray.length, 3);
+
+      // All projects should have organisation pre-loaded
+      for (const project of projectArray) {
+        assertEquals(
+          project.organisation.isLoaded(),
+          true,
+          `Project ${project.name.get()} should have organisation loaded`,
+        );
+
+        // .get() should work without additional fetch
+        const org = project.organisation.get();
+        assertExists(org);
+        assertExists(org.name.get());
+      }
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});
+
+Deno.test({
+  name: "QuerySet - selectRelated() with filter",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = new DenoKVBackend({ name: "sr-test-2", path: ":memory:" });
+    await backend.connect();
+    await setup({ backend });
+
+    try {
+      const org = await Organisation.objects.create({
+        name: "Filter Test Org",
+        country: "Norway",
+      });
+
+      await Project.objects.create({
+        name: "Published Project",
+        organisation: org,
+        isPublished: true,
+      });
+      await Project.objects.create({
+        name: "Draft Project",
+        organisation: org,
+        isPublished: false,
+      });
+
+      // Fetch published projects with selectRelated
+      const projects = await Project.objects
+        .filter({ isPublished: true })
+        .selectRelated("organisation")
+        .fetch();
+
+      const projectArray = projects.array();
+      assertEquals(projectArray.length, 1);
+      assertEquals(projectArray[0].name.get(), "Published Project");
+      assertEquals(projectArray[0].organisation.isLoaded(), true);
+      assertEquals(
+        projectArray[0].organisation.get().name.get(),
+        "Filter Test Org",
+      );
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});
+
+// ============================================================================
+// QuerySet Chainable Fetch Tests (Issue #25)
+// ============================================================================
+
+Deno.test({
+  name: "QuerySet - fetch() returns QuerySet",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = new DenoKVBackend({ name: "qs-test-1", path: ":memory:" });
+    await backend.connect();
+    await setup({ backend });
+
+    try {
+      await Organisation.objects.create({
+        name: "Test Org",
+        country: "Finland",
+      });
+
+      const result = await Organisation.objects.all().fetch();
+
+      // Result should be a QuerySet, not an array
+      assertEquals(typeof result.array, "function");
+      assertEquals(typeof result.filter, "function");
+      assertEquals(typeof result.isFetched, "function");
+
+      // isFetched() should return true
+      assertEquals(result.isFetched(), true);
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});
+
+Deno.test({
+  name: "QuerySet - .array() returns model array",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = new DenoKVBackend({ name: "qs-test-2", path: ":memory:" });
+    await backend.connect();
+    await setup({ backend });
+
+    try {
+      await Organisation.objects.create({ name: "Org A", country: "Finland" });
+      await Organisation.objects.create({ name: "Org B", country: "Sweden" });
+
+      const qs = await Organisation.objects.all().fetch();
+      const arr = qs.array();
+
+      assertEquals(Array.isArray(arr), true);
+      assertEquals(arr.length, 2);
+      assertExists(arr[0].name);
+      assertExists(arr[1].name);
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});
+
+Deno.test({
+  name: "QuerySet - .array() throws if not fetched",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = new DenoKVBackend({ name: "qs-test-3", path: ":memory:" });
+    await backend.connect();
+    await setup({ backend });
+
+    try {
+      await Organisation.objects.create({ name: "Test", country: "Finland" });
+
+      const qs = Organisation.objects.all(); // Not fetched
+
+      try {
+        qs.array();
+        throw new Error("Expected error was not thrown");
+      } catch (error) {
+        assertEquals(
+          (error as Error).message.includes("not fetched"),
+          true,
+          "Error should mention QuerySet not fetched",
+        );
+      }
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});
+
+Deno.test({
+  name: "QuerySet - in-memory filtering after fetch()",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = new DenoKVBackend({ name: "qs-test-4", path: ":memory:" });
+    await backend.connect();
+    await setup({ backend });
+
+    try {
+      await Project.objects.create({
+        name: "Published 1",
+        organisation: null as unknown as Organisation,
+        isPublished: true,
+        views: 100,
+      });
+      await Project.objects.create({
+        name: "Published 2",
+        organisation: null as unknown as Organisation,
+        isPublished: true,
+        views: 200,
+      });
+      await Project.objects.create({
+        name: "Draft",
+        organisation: null as unknown as Organisation,
+        isPublished: false,
+        views: 50,
+      });
+
+      // Fetch all projects
+      const allProjects = await Project.objects.all().fetch();
+      assertEquals(allProjects.array().length, 3);
+
+      // In-memory filter for published
+      const published = allProjects.filter({ isPublished: true });
+      assertEquals(published.isFetched(), true);
+      assertEquals(published.array().length, 2);
+
+      // Further in-memory filter for high views
+      const popular = published.filter({ views__gte: 150 });
+      assertEquals(popular.array().length, 1);
+      assertEquals(popular.array()[0].name.get(), "Published 2");
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});
+
+Deno.test({
+  name: "QuerySet - in-memory filtering with various lookups",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = new DenoKVBackend({ name: "qs-test-5", path: ":memory:" });
+    await backend.connect();
+    await setup({ backend });
+
+    try {
+      await Organisation.objects.create({
+        name: "Acme Corp",
+        country: "Finland",
+      });
+      await Organisation.objects.create({
+        name: "Beta Industries",
+        country: "Sweden",
+      });
+      await Organisation.objects.create({
+        name: "Gamma Solutions",
+        country: "Norway",
+      });
+      await Organisation.objects.create({
+        name: "Delta Corp",
+        country: "Finland",
+      });
+
+      const all = await Organisation.objects.all().fetch();
+
+      // Test contains
+      const corpOrgs = all.filter({ name__contains: "Corp" });
+      assertEquals(corpOrgs.array().length, 2);
+
+      // Test icontains (case-insensitive)
+      const acmeOrgs = all.filter({ name__icontains: "ACME" });
+      assertEquals(acmeOrgs.array().length, 1);
+
+      // Test startswith
+      const betaOrgs = all.filter({ name__startswith: "Beta" });
+      assertEquals(betaOrgs.array().length, 1);
+
+      // Test exact
+      const finlandOrgs = all.filter({ country: "Finland" });
+      assertEquals(finlandOrgs.array().length, 2);
+
+      // Test in
+      const nordicOrgs = all.filter({ country__in: ["Finland", "Sweden"] });
+      assertEquals(nordicOrgs.array().length, 3);
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});
+
+Deno.test({
+  name: "QuerySet - chained in-memory filtering",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = new DenoKVBackend({ name: "qs-test-6", path: ":memory:" });
+    await backend.connect();
+    await setup({ backend });
+
+    try {
+      await Project.objects.create({
+        name: "Alpha",
+        organisation: null as unknown as Organisation,
+        isPublished: true,
+        views: 100,
+      });
+      await Project.objects.create({
+        name: "Beta",
+        organisation: null as unknown as Organisation,
+        isPublished: true,
+        views: 250,
+      });
+      await Project.objects.create({
+        name: "Gamma",
+        organisation: null as unknown as Organisation,
+        isPublished: false,
+        views: 300,
+      });
+      await Project.objects.create({
+        name: "Delta",
+        organisation: null as unknown as Organisation,
+        isPublished: true,
+        views: 50,
+      });
+
+      // Fetch all, then chain multiple filters
+      const result = (await Project.objects.all().fetch())
+        .filter({ isPublished: true }) // 3 results
+        .filter({ views__gte: 100 }) // 2 results
+        .filter({ name__startswith: "B" }); // 1 result
+
+      assertEquals(result.array().length, 1);
+      assertEquals(result.array()[0].name.get(), "Beta");
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});
+
+Deno.test({
+  name: "QuerySet - first() works with fetched data",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = new DenoKVBackend({ name: "qs-test-7", path: ":memory:" });
+    await backend.connect();
+    await setup({ backend });
+
+    try {
+      await Organisation.objects.create({
+        name: "First Org",
+        country: "Finland",
+      });
+      await Organisation.objects.create({
+        name: "Second Org",
+        country: "Sweden",
+      });
+
+      // Without fetch - hits database
+      const first1 = await Organisation.objects.orderBy("name").first();
+      assertEquals(first1?.name.get(), "First Org");
+
+      // With fetch - uses in-memory data
+      const fetched = await Organisation.objects.orderBy("name").fetch();
+      const first2 = await fetched.first();
+      assertEquals(first2?.name.get(), "First Org");
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});
+
+Deno.test({
+  name: "QuerySet - length() returns count of fetched data",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = new DenoKVBackend({ name: "qs-test-8", path: ":memory:" });
+    await backend.connect();
+    await setup({ backend });
+
+    try {
+      await Organisation.objects.create({ name: "Org 1", country: "Finland" });
+      await Organisation.objects.create({ name: "Org 2", country: "Sweden" });
+      await Organisation.objects.create({ name: "Org 3", country: "Norway" });
+
+      // Without fetch - hits database
+      const count1 = await Organisation.objects.all().count();
+      assertEquals(count1, 3);
+
+      // With fetch - uses in-memory data
+      const fetched = await Organisation.objects.all().fetch();
+      const count2 = await fetched.length();
+      assertEquals(count2, 3);
+
+      // After in-memory filter
+      const filtered = fetched.filter({ country: "Finland" });
+      const count3 = await filtered.length();
+      assertEquals(count3, 1);
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});
+
+Deno.test({
+  name: "QuerySet - exists() works with fetched data",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = new DenoKVBackend({ name: "qs-test-9", path: ":memory:" });
+    await backend.connect();
+    await setup({ backend });
+
+    try {
+      await Organisation.objects.create({
+        name: "Test Org",
+        country: "Finland",
+      });
+
+      // With fetch and filter
+      const fetched = await Organisation.objects.all().fetch();
+
+      const exists1 = await fetched.filter({ country: "Finland" }).exists();
+      assertEquals(exists1, true);
+
+      const exists2 = await fetched.filter({ country: "Japan" }).exists();
+      assertEquals(exists2, false);
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});
+
+Deno.test({
+  name: "QuerySet - clearCache() resets fetched state",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = new DenoKVBackend({ name: "qs-test-10", path: ":memory:" });
+    await backend.connect();
+    await setup({ backend });
+
+    try {
+      await Organisation.objects.create({ name: "Test", country: "Finland" });
+
+      const qs = await Organisation.objects.all().fetch();
+      assertEquals(qs.isFetched(), true);
+
+      qs.clearCache();
+      assertEquals(qs.isFetched(), false);
+
+      // array() should throw now
+      try {
+        qs.array();
+        throw new Error("Expected error was not thrown");
+      } catch (error) {
+        assertEquals(
+          (error as Error).message.includes("not fetched"),
+          true,
+        );
+      }
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});
+
+Deno.test({
+  name: "QuerySet - async iteration works",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = new DenoKVBackend({ name: "qs-test-11", path: ":memory:" });
+    await backend.connect();
+    await setup({ backend });
+
+    try {
+      await Organisation.objects.create({ name: "Org A", country: "Finland" });
+      await Organisation.objects.create({ name: "Org B", country: "Sweden" });
+
+      const names: string[] = [];
+      for await (const org of Organisation.objects.orderBy("name")) {
+        names.push(org.name.get()!);
+      }
+
+      assertEquals(names, ["Org A", "Org B"]);
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});

--- a/src/db/tests/indexeddb_test.ts
+++ b/src/db/tests/indexeddb_test.ts
@@ -143,7 +143,7 @@ Deno.test("IndexedDBBackend - insert and retrieve", async () => {
     assertEquals(author.email.get(), "john@example.com");
 
     // Retrieve all
-    const fetchedAuthors = await authors.all().fetch();
+    const fetchedAuthors = (await authors.all().fetch()).array();
     assertEquals(fetchedAuthors.length, 1);
     assertEquals(fetchedAuthors[0].name.get(), "John Doe");
   } finally {
@@ -194,14 +194,14 @@ Deno.test("IndexedDBBackend - delete", async () => {
     });
 
     // Verify created
-    let all = await authors.all().fetch();
+    let all = (await authors.all().fetch()).array();
     assertEquals(all.length, 1);
 
     // Delete
     await backend.delete(author);
 
     // Verify deleted
-    all = await authors.all().fetch();
+    all = (await authors.all().fetch()).array();
     assertEquals(all.length, 0);
   } finally {
     await backend.disconnect();
@@ -234,7 +234,8 @@ Deno.test("IndexedDBBackend - filter exact match", async () => {
     });
 
     // Filter by exact match
-    const result = await articles.filter({ title: "TypeScript Guide" }).fetch();
+    const result =
+      (await articles.filter({ title: "TypeScript Guide" }).fetch()).array();
     assertEquals(result.length, 1);
     assertEquals(result[0].title.get(), "TypeScript Guide");
   } finally {
@@ -268,8 +269,8 @@ Deno.test("IndexedDBBackend - filter contains", async () => {
     });
 
     // Filter by contains
-    const scriptArticles = await articles.filter({ title__contains: "Script" })
-      .fetch();
+    const scriptArticles =
+      (await articles.filter({ title__contains: "Script" }).fetch()).array();
     assertEquals(scriptArticles.length, 2);
   } finally {
     await backend.disconnect();
@@ -290,21 +291,21 @@ Deno.test("IndexedDBBackend - filter comparison operators", async () => {
     await articles.create({ title: "Article 3", content: "C3", views: 200 });
 
     // Greater than or equal
-    const gte100 = await articles.filter({ views__gte: 100 }).fetch();
+    const gte100 = (await articles.filter({ views__gte: 100 }).fetch()).array();
     assertEquals(gte100.length, 2);
 
     // Less than
-    const lt100 = await articles.filter({ views__lt: 100 }).fetch();
+    const lt100 = (await articles.filter({ views__lt: 100 }).fetch()).array();
     assertEquals(lt100.length, 1);
     assertEquals(lt100[0].views.get(), 50);
 
     // Greater than
-    const gt100 = await articles.filter({ views__gt: 100 }).fetch();
+    const gt100 = (await articles.filter({ views__gt: 100 }).fetch()).array();
     assertEquals(gt100.length, 1);
     assertEquals(gt100[0].views.get(), 200);
 
     // Less than or equal
-    const lte100 = await articles.filter({ views__lte: 100 }).fetch();
+    const lte100 = (await articles.filter({ views__lte: 100 }).fetch()).array();
     assertEquals(lte100.length, 2);
   } finally {
     await backend.disconnect();
@@ -325,7 +326,8 @@ Deno.test("IndexedDBBackend - filter in operator", async () => {
     await articles.create({ title: "Article 3", content: "C3", views: 200 });
 
     // In operator
-    const inValues = await articles.filter({ views__in: [50, 200] }).fetch();
+    const inValues = (await articles.filter({ views__in: [50, 200] }).fetch())
+      .array();
     assertEquals(inValues.length, 2);
   } finally {
     await backend.disconnect();
@@ -349,7 +351,7 @@ Deno.test("IndexedDBBackend - ordering ascending", async () => {
     await articles.create({ title: "A Article", content: "C", views: 100 });
     await articles.create({ title: "C Article", content: "C", views: 50 });
 
-    const ordered = await articles.orderBy("title").fetch();
+    const ordered = (await articles.orderBy("title").fetch()).array();
     assertEquals(ordered[0].title.get(), "A Article");
     assertEquals(ordered[1].title.get(), "B Article");
     assertEquals(ordered[2].title.get(), "C Article");
@@ -371,7 +373,7 @@ Deno.test("IndexedDBBackend - ordering descending", async () => {
     await articles.create({ title: "B", content: "C", views: 200 });
     await articles.create({ title: "C", content: "C", views: 50 });
 
-    const ordered = await articles.orderBy("-views").fetch();
+    const ordered = (await articles.orderBy("-views").fetch()).array();
     assertEquals(ordered[0].views.get(), 200);
     assertEquals(ordered[1].views.get(), 100);
     assertEquals(ordered[2].views.get(), 50);
@@ -397,7 +399,7 @@ Deno.test("IndexedDBBackend - limit", async () => {
     await articles.create({ title: "Article 2", content: "C", views: 200 });
     await articles.create({ title: "Article 3", content: "C", views: 300 });
 
-    const limited = await articles.orderBy("-views").limit(2).fetch();
+    const limited = (await articles.orderBy("-views").limit(2).fetch()).array();
     assertEquals(limited.length, 2);
     assertEquals(limited[0].views.get(), 300);
     assertEquals(limited[1].views.get(), 200);
@@ -419,7 +421,8 @@ Deno.test("IndexedDBBackend - offset", async () => {
     await articles.create({ title: "Article 2", content: "C", views: 200 });
     await articles.create({ title: "Article 3", content: "C", views: 300 });
 
-    const offsetted = await articles.orderBy("-views").offset(1).fetch();
+    const offsetted = (await articles.orderBy("-views").offset(1).fetch())
+      .array();
     assertEquals(offsetted.length, 2);
     assertEquals(offsetted[0].views.get(), 200);
     assertEquals(offsetted[1].views.get(), 100);
@@ -443,7 +446,8 @@ Deno.test("IndexedDBBackend - limit and offset combined", async () => {
     await articles.create({ title: "Article 4", content: "C", views: 400 });
 
     // Skip first, take 2
-    const result = await articles.orderBy("-views").offset(1).limit(2).fetch();
+    const result = (await articles.orderBy("-views").offset(1).limit(2).fetch())
+      .array();
     assertEquals(result.length, 2);
     assertEquals(result[0].views.get(), 300);
     assertEquals(result[1].views.get(), 200);
@@ -473,7 +477,7 @@ Deno.test("IndexedDBBackend - bulk create", async () => {
 
     assertEquals(created.length, 3);
 
-    const all = await articles.all().fetch();
+    const all = (await articles.all().fetch()).array();
     assertEquals(all.length, 3);
   } finally {
     await backend.disconnect();
@@ -502,10 +506,10 @@ Deno.test("IndexedDBBackend - updateMany", async () => {
     assertEquals(updated, 2);
 
     // Verify
-    const articles999 = await articles.filter({ views: 999 }).fetch();
+    const articles999 = (await articles.filter({ views: 999 }).fetch()).array();
     assertEquals(articles999.length, 2);
 
-    const articles300 = await articles.filter({ views: 300 }).fetch();
+    const articles300 = (await articles.filter({ views: 300 }).fetch()).array();
     assertEquals(articles300.length, 1);
   } finally {
     await backend.disconnect();
@@ -532,7 +536,7 @@ Deno.test("IndexedDBBackend - deleteMany", async () => {
     assertEquals(deleted, 2);
 
     // Verify
-    const remaining = await articles.all().fetch();
+    const remaining = (await articles.all().fetch()).array();
     assertEquals(remaining.length, 1);
     assertEquals(remaining[0].title.get(), "Keep");
   } finally {
@@ -827,7 +831,7 @@ Deno.test("IndexedDBBackend - atomic transaction", async () => {
     });
 
     // Verify all were created
-    const all = await authors.all().fetch();
+    const all = (await authors.all().fetch()).array();
     assertEquals(all.length, 3);
   } finally {
     await backend.disconnect();
@@ -855,7 +859,7 @@ Deno.test("IndexedDBBackend - transaction interface", async () => {
     assertEquals(tx.isActive, false);
 
     // Verify nothing changed
-    const all = await authors.all().fetch();
+    const all = (await authors.all().fetch()).array();
     assertEquals(all.length, 1);
     assertEquals(all[0].name.get(), "Keep Me");
   } finally {

--- a/src/db/tests/named_backends_test.ts
+++ b/src/db/tests/named_backends_test.ts
@@ -197,11 +197,11 @@ Deno.test({
       });
 
       // Query using named backend via QuerySet.using()
-      const articles = await Article.objects
+      const articles = (await Article.objects
         .all()
         .using("main")
         .filter({ views__gte: 100 })
-        .fetch();
+        .fetch()).array();
 
       assertEquals(articles.length, 1);
       assertEquals(articles[0].title.get(), "Article 2");
@@ -314,12 +314,13 @@ Deno.test({
       });
 
       // Query db1 - should only find db1 article
-      const db1Articles = await Article.objects.using("db1").all().fetch();
+      const db1Articles = (await Article.objects.using("db1").all().fetch())
+        .array();
       assertEquals(db1Articles.length, 1);
       assertEquals(db1Articles[0].title.get(), "DB1 Article");
 
-      // Query db2 - should only find db2 article
-      const db2Articles = await Article.objects.using("db2").all().fetch();
+      const db2Articles = (await Article.objects.using("db2").all().fetch())
+        .array();
       assertEquals(db2Articles.length, 1);
       assertEquals(db2Articles[0].title.get(), "DB2 Article");
     } finally {

--- a/src/db/tests/sync_backend_test.ts
+++ b/src/db/tests/sync_backend_test.ts
@@ -230,10 +230,10 @@ Deno.test({
 
     try {
       // Query for only published projects
-      const results = await Project.objects
+      const results = (await Project.objects
         .using(syncBackend)
         .filter({ isPublished: true })
-        .fetch();
+        .fetch()).array();
 
       // Even though the mock API returned all 4 projects,
       // SyncBackend should apply the local filter and return only published ones
@@ -295,10 +295,10 @@ Deno.test({
 
     try {
       // Query for published projects in organisation 1 only
-      const results = await Project.objects
+      const results = (await Project.objects
         .using(syncBackend)
         .filter({ organisationId: 1, isPublished: true })
-        .fetch();
+        .fetch()).array();
 
       // Should return only projects that match BOTH filters
       assertEquals(
@@ -359,10 +359,10 @@ Deno.test({
       });
 
       // Query through SyncBackend - should use local since not authenticated
-      const results = await Project.objects
+      const results = (await Project.objects
         .using(syncBackend)
         .filter({ isPublished: true })
-        .fetch();
+        .fetch()).array();
 
       // Should return local data, not remote mock data
       assertEquals(results.length, 1);


### PR DESCRIPTION
## Summary

This PR implements two related enhancements to the Alexi ORM:

- **Issue #24**: ForeignKey improvements - related object access
- **Issue #25**: QuerySet.fetch() returns QuerySet for chainable in-memory filtering

## Changes

### ForeignKey Improvements (Issue #24)

The ForeignKey field now provides Django-like access patterns:

```typescript
const project = await Project.objects.get({ id: 1 });

// Get the ID directly (no fetch needed)
project.organisation.id; // 42

// Fetch the related object (lazy load)
await project.organisation.fetch();

// Now get() returns the instance
project.organisation.get(); // Organisation instance
project.organisation.get().name.get(); // "Acme Inc"

// Check if loaded
project.organisation.isLoaded(); // true
```

**New API:**
| Property/Method | Returns | Description |
|----------------|---------|-------------|
| `.id` | `unknown` | The foreign key ID (no fetch) |
| `.get()` | `T` | The related instance (throws if not loaded) |
| `.fetch()` | `Promise<T \| null>` | Fetches and caches the related object |
| `.isLoaded()` | `boolean` | Whether the related object is loaded |
| `.set(instance)` | `void` | Sets the related object (existing behavior) |

### QuerySet Chainable Fetch (Issue #25)

`fetch()` now returns the QuerySet instead of an array, enabling chainable in-memory filtering:

```typescript
// Fetch from database
const projects = await Project.objects
  .filter({ organisation: myOrg })
  .fetch();

// Further filtering is done in-memory (no DB call)
const published = projects.filter({ isPublished: true });

// More filtering
const popular = published.filter({ views__gte: 100 });

// Get the array when needed
const arr = popular.array();
```

**New/Updated API:**
| Method | Returns | Description |
|--------|---------|-------------|
| `.fetch()` | `Promise<QuerySet<T>>` | Loads data into memory, returns self |
| `.array()` | `T[]` | Returns the loaded models as array |
| `.isFetched()` | `boolean` | Whether data is loaded |
| `.length()` | `Promise<number>` | Count of loaded/queried items |
| `.filter()` | `QuerySet<T>` | If fetched: filters in memory. Otherwise: adds to query state |

### selectRelated() Implementation

`selectRelated()` now works with the new ForeignKey API:

```typescript
const projects = await Project.objects
  .selectRelated('organisation')
  .fetch();

for (const project of projects.array()) {
  // No additional fetch needed - already loaded
  console.log(project.organisation.get().name.get());
}
```

## Breaking Changes

- **`fetch()` returns `QuerySet<T>` instead of `T[]`** - Use `.array()` to get the array:
  ```typescript
  // Before
  const articles = await Article.objects.all().fetch();
  
  // After
  const articles = (await Article.objects.all().fetch()).array();
  ```

- **`ForeignKey.get()` now returns the related instance** - Use `.id` to get the FK ID:
  ```typescript
  // Before
  const orgId = project.organisation.get();
  
  // After
  const orgId = project.organisation.id;
  ```

## Tests

- Added 19 comprehensive tests in `foreignkey_test.ts`
- Updated all existing tests to use `.array()` after `fetch()`
- All 137 db tests pass

## Files Changed

- `src/db/fields/relations.ts` - ForeignKey improvements
- `src/db/models/model.ts` - Handle ForeignKey in toDB/fromDB
- `src/db/query/queryset.ts` - Chainable fetch and in-memory filtering
- `src/db/tests/foreignkey_test.ts` - New test file
- `src/db/tests/*.ts` - Updated existing tests

Closes #24
Closes #25