### PR TITLE
feat(db): make QuerySet.length() synchronous method

### DIFF
--- a/src/db/query/queryset.ts
+++ b/src/db/query/queryset.ts
@@ -864,16 +864,26 @@ export class QuerySet<T extends Model> implements AsyncIterable<T> {
   }
 
   /**
-   * Get the count of objects
+   * Get the count of objects currently loaded in memory
    *
-   * If the QuerySet has been fetched, returns the length of the cached array.
-   * Otherwise, executes a count query against the database.
+   * This is a synchronous method that returns the number of objects
+   * in the QuerySet's cache. Returns 0 if the QuerySet has not been fetched.
+   *
+   * For database count, use count() instead.
+   *
+   * @example
+   * ```ts
+   * const qs = await Article.objects.all().fetch();
+   * const loaded = qs.length();  // Synchronous, in-memory count
+   *
+   * const total = await Article.objects.count();  // Async, database count
+   * ```
    */
-  async length(): Promise<number> {
+  length(): number {
     if (this._isFetched && this._cache !== null) {
       return this._cache.length;
     }
-    return this.count();
+    return 0;
   }
 
   // ============================================================================

--- a/src/db/tests/foreignkey_test.ts
+++ b/src/db/tests/foreignkey_test.ts
@@ -714,12 +714,12 @@ Deno.test({
 
       // With fetch - uses in-memory data
       const fetched = await Organisation.objects.all().fetch();
-      const count2 = await fetched.length();
+      const count2 = fetched.length();
       assertEquals(count2, 3);
 
       // After in-memory filter
       const filtered = fetched.filter({ country: "Finland" });
-      const count3 = await filtered.length();
+      const count3 = filtered.length();
       assertEquals(count3, 1);
     } finally {
       await reset();


### PR DESCRIPTION
## Summary

Changes `QuerySet.length()` from an async method returning `Promise<number>` to a synchronous method returning `number`.

## Problem

The previous implementation was problematic:
- A method that returns a Promise is unexpected for a "length" operation
- It triggered a database query when you might just want to know how many items are loaded
- Cannot be used in synchronous code paths (e.g., render methods, conditionals)

## Changes

- `length()` is now synchronous and returns `number`
- Returns the count of objects currently loaded in memory
- Returns 0 if the QuerySet has not been fetched
- No hidden database queries

## Usage

```typescript
// For in-memory count (synchronous method)
const qs = await Article.objects.all().fetch();
const loaded = qs.length();  // Returns number, no await needed

// For database count (async method)
const total = await Article.objects.count();  // Returns Promise<number>
```

## Migration

Users need to update their code:
- `await queryset.length()` → `queryset.length()` for in-memory count
- `await queryset.length()` → `await queryset.count()` if database count was intended

## Rationale

- Matches JavaScript Array behavior where `.length` is synchronous
- Consistent with ORM pattern where all operations are explicit methods
- Django doesn't have `.length` - it uses `.count()` for database count
- No hidden queries - predictable behavior

Closes #36