### PR TITLE
feat(db): add reverse relations support (RelatedManager)

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -8,6 +8,7 @@
     "jsr:@std/encoding@^1.0.5": "1.0.10",
     "jsr:@std/fs@^1.0.19": "1.0.22",
     "jsr:@std/internal@^1.0.12": "1.0.12",
+    "jsr:@std/path@1": "1.1.4",
     "jsr:@std/path@^1.0.6": "1.1.4",
     "jsr:@std/path@^1.1.2": "1.1.4",
     "jsr:@std/path@^1.1.4": "1.1.4",

--- a/src/db/fields/mod.ts
+++ b/src/db/fields/mod.ts
@@ -39,6 +39,7 @@ export {
   ManyToManyManager,
   OnDelete,
   OneToOneField,
+  RelatedManager,
 } from "./relations.ts";
 
 export type {

--- a/src/db/mod.ts
+++ b/src/db/mod.ts
@@ -98,6 +98,7 @@ export {
   ManyToManyManager,
   OnDelete,
   OneToOneField,
+  RelatedManager,
 } from "./fields/mod.ts";
 
 export type {

--- a/src/db/models/mod.ts
+++ b/src/db/models/mod.ts
@@ -13,6 +13,7 @@ export type {
   ModelData,
   ModelMeta,
   PartialModelData,
+  ReverseRelationDef,
 } from "./model.ts";
 
 // Manager class and exceptions

--- a/src/db/query/queryset.ts
+++ b/src/db/query/queryset.ts
@@ -278,12 +278,39 @@ export class QuerySet<T extends Model> implements AsyncIterable<T> {
       }
     }
 
+    // Translate ForeignKey field names to column names for database filtering
+    // e.g., "projectRole" -> "projectRole_id"
+    const columnField = this._getColumnNameForField(field);
+
     return {
-      field,
+      field: columnField,
       lookup,
       value,
       negated: false,
     };
+  }
+
+  /**
+   * Get the column name for a field (handles ForeignKey translation)
+   *
+   * For ForeignKey fields, this returns the column name (e.g., "projectRole_id")
+   * instead of the field name (e.g., "projectRole").
+   */
+  private _getColumnNameForField(fieldName: string): string {
+    try {
+      const instance = new this._state.model();
+      const fields = instance.getFields();
+      const field = fields[fieldName];
+
+      if (field instanceof ForeignKey) {
+        return field.getColumnName();
+      }
+
+      return fieldName;
+    } catch {
+      // If we can't instantiate the model, just return the field name
+      return fieldName;
+    }
   }
 
   /**

--- a/src/db/tests/reverse_relations_test.ts
+++ b/src/db/tests/reverse_relations_test.ts
@@ -1,0 +1,662 @@
+/**
+ * Tests for ForeignKey reverse relations (RelatedManager)
+ *
+ * Tests for Issue #39: Add reverse relations support (Django-style RelatedManager)
+ *
+ * @module
+ */
+
+import {
+  assertEquals,
+  assertExists,
+  assertInstanceOf,
+} from "jsr:@std/assert@1";
+import {
+  AutoField,
+  CharField,
+  IntegerField,
+  Manager,
+  Model,
+  ModelRegistry,
+  RelatedManager,
+  TextField,
+} from "../mod.ts";
+import { ForeignKey, OnDelete } from "../fields/relations.ts";
+import { reset, setup } from "../setup.ts";
+import { DenoKVBackend } from "../backends/denokv/mod.ts";
+
+// ============================================================================
+// Test Models
+// ============================================================================
+
+class ProjectRole extends Model {
+  id = new AutoField({ primaryKey: true });
+  name = new CharField({ maxLength: 255 });
+  description = new TextField({ blank: true, default: "" });
+
+  // TypeScript type declaration for reverse relation
+  // Runtime populates this based on relatedName in ProjectRoleCompetence
+  declare roleCompetences: RelatedManager<ProjectRoleCompetence>;
+
+  static objects = new Manager(ProjectRole);
+  static override meta = {
+    dbTable: "project_roles",
+  };
+}
+
+class Competence extends Model {
+  id = new AutoField({ primaryKey: true });
+  name = new CharField({ maxLength: 100 });
+
+  // Reverse relation from ProjectRoleCompetence
+  declare roleCompetences: RelatedManager<ProjectRoleCompetence>;
+
+  static objects = new Manager(Competence);
+  static override meta = {
+    dbTable: "competences",
+  };
+}
+
+class ProjectRoleCompetence extends Model {
+  id = new AutoField({ primaryKey: true });
+  projectRole = new ForeignKey<ProjectRole>("ProjectRole", {
+    onDelete: OnDelete.CASCADE,
+    relatedName: "roleCompetences",
+  });
+  competence = new ForeignKey<Competence>("Competence", {
+    onDelete: OnDelete.CASCADE,
+    relatedName: "roleCompetences",
+  });
+  level = new IntegerField({ default: 1 });
+
+  static objects = new Manager(ProjectRoleCompetence);
+  static override meta = {
+    dbTable: "project_role_competences",
+  };
+}
+
+// Additional test models for edge cases
+class Author extends Model {
+  id = new AutoField({ primaryKey: true });
+  name = new CharField({ maxLength: 100 });
+
+  declare articles: RelatedManager<Article>;
+  declare books: RelatedManager<Book>;
+
+  static objects = new Manager(Author);
+  static override meta = {
+    dbTable: "authors",
+  };
+}
+
+class Article extends Model {
+  id = new AutoField({ primaryKey: true });
+  title = new CharField({ maxLength: 200 });
+  author = new ForeignKey<Author>("Author", {
+    onDelete: OnDelete.CASCADE,
+    relatedName: "articles",
+  });
+
+  static objects = new Manager(Article);
+  static override meta = {
+    dbTable: "articles",
+  };
+}
+
+class Book extends Model {
+  id = new AutoField({ primaryKey: true });
+  title = new CharField({ maxLength: 200 });
+  pages = new IntegerField({ default: 0 });
+  author = new ForeignKey<Author>("Author", {
+    onDelete: OnDelete.CASCADE,
+    relatedName: "books",
+  });
+
+  static objects = new Manager(Book);
+  static override meta = {
+    dbTable: "books",
+  };
+}
+
+// ============================================================================
+// Test Setup/Teardown Helpers
+// ============================================================================
+
+async function setupTestBackend(): Promise<DenoKVBackend> {
+  const backend = new DenoKVBackend({
+    name: "reverse-relations-test",
+    path: ":memory:",
+  });
+  await backend.connect();
+  await setup({ backend });
+  return backend;
+}
+
+async function teardown(backend: DenoKVBackend): Promise<void> {
+  await reset();
+  await backend.disconnect();
+}
+
+// ============================================================================
+// Registry Tests
+// ============================================================================
+
+Deno.test({
+  name: "RelatedManager - ModelRegistry tracks reverse relations",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = await setupTestBackend();
+
+    try {
+      // Force model registration by creating instances and calling getFields()
+      // getFields() triggers _ensureFieldsInitialized() which registers the model
+      new ProjectRole().getFields();
+      new Competence().getFields();
+      new ProjectRoleCompetence().getFields();
+
+      // Check that reverse relations are registered for ProjectRole
+      const projectRoleRelations = ModelRegistry.instance.getReverseRelations(
+        "ProjectRole",
+      );
+      assertExists(projectRoleRelations);
+      assertEquals(projectRoleRelations.length, 1);
+      assertEquals(projectRoleRelations[0].relatedName, "roleCompetences");
+      assertEquals(
+        projectRoleRelations[0].relatedModelName,
+        "ProjectRoleCompetence",
+      );
+      assertEquals(projectRoleRelations[0].fieldName, "projectRole");
+
+      // Check that reverse relations are registered for Competence
+      const competenceRelations = ModelRegistry.instance.getReverseRelations(
+        "Competence",
+      );
+      assertExists(competenceRelations);
+      assertEquals(competenceRelations.length, 1);
+      assertEquals(competenceRelations[0].relatedName, "roleCompetences");
+      assertEquals(
+        competenceRelations[0].relatedModelName,
+        "ProjectRoleCompetence",
+      );
+      assertEquals(competenceRelations[0].fieldName, "competence");
+    } finally {
+      await teardown(backend);
+    }
+  },
+});
+
+Deno.test({
+  name: "RelatedManager - Multiple reverse relations on same model",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = await setupTestBackend();
+
+    try {
+      // Force model registration by calling getFields()
+      new Author().getFields();
+      new Article().getFields();
+      new Book().getFields();
+
+      // Author should have two reverse relations
+      const authorRelations = ModelRegistry.instance.getReverseRelations(
+        "Author",
+      );
+      assertExists(authorRelations);
+      assertEquals(authorRelations.length, 2);
+
+      const articleRelation = authorRelations.find(
+        (r) => r.relatedName === "articles",
+      );
+      const bookRelation = authorRelations.find(
+        (r) => r.relatedName === "books",
+      );
+
+      assertExists(articleRelation);
+      assertEquals(articleRelation.relatedModelName, "Article");
+      assertEquals(articleRelation.fieldName, "author");
+
+      assertExists(bookRelation);
+      assertEquals(bookRelation.relatedModelName, "Book");
+      assertEquals(bookRelation.fieldName, "author");
+    } finally {
+      await teardown(backend);
+    }
+  },
+});
+
+// ============================================================================
+// RelatedManager Instance Tests
+// ============================================================================
+
+Deno.test({
+  name: "RelatedManager - Instance has RelatedManager property",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = await setupTestBackend();
+
+    try {
+      // Create a project role
+      const role = await ProjectRole.objects.create({
+        name: "Software Engineer",
+        description: "Builds software",
+      });
+
+      // Reload from database
+      const loadedRole = await ProjectRole.objects.get({ id: role.id.get() });
+
+      // Check that roleCompetences is a RelatedManager
+      assertExists(loadedRole.roleCompetences);
+      assertInstanceOf(loadedRole.roleCompetences, RelatedManager);
+    } finally {
+      await teardown(backend);
+    }
+  },
+});
+
+Deno.test({
+  name: "RelatedManager - all() returns QuerySet",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = await setupTestBackend();
+
+    try {
+      // Create test data
+      const role = await ProjectRole.objects.create({
+        name: "Backend Developer",
+      });
+
+      const competence1 = await Competence.objects.create({ name: "Python" });
+      const competence2 = await Competence.objects.create({
+        name: "PostgreSQL",
+      });
+
+      await ProjectRoleCompetence.objects.create({
+        projectRole: role,
+        competence: competence1,
+        level: 3,
+      });
+
+      await ProjectRoleCompetence.objects.create({
+        projectRole: role,
+        competence: competence2,
+        level: 2,
+      });
+
+      // Reload role
+      const loadedRole = await ProjectRole.objects.get({ id: role.id.get() });
+
+      // Get all related competences
+      const roleCompetences = await loadedRole.roleCompetences.all().fetch();
+
+      assertEquals(roleCompetences.length(), 2);
+    } finally {
+      await teardown(backend);
+    }
+  },
+});
+
+Deno.test({
+  name: "RelatedManager - filter() works correctly",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = await setupTestBackend();
+
+    try {
+      // Create test data
+      const role = await ProjectRole.objects.create({
+        name: "Full Stack Developer",
+      });
+
+      const competence1 = await Competence.objects.create({ name: "React" });
+      const competence2 = await Competence.objects.create({ name: "Node.js" });
+
+      await ProjectRoleCompetence.objects.create({
+        projectRole: role,
+        competence: competence1,
+        level: 5,
+      });
+
+      await ProjectRoleCompetence.objects.create({
+        projectRole: role,
+        competence: competence2,
+        level: 3,
+      });
+
+      // Reload role
+      const loadedRole = await ProjectRole.objects.get({ id: role.id.get() });
+
+      // Filter by level
+      const highLevelCompetences = await loadedRole.roleCompetences
+        .filter({ level: 5 })
+        .fetch();
+
+      assertEquals(highLevelCompetences.length(), 1);
+
+      const first = highLevelCompetences.array()[0];
+      assertEquals(first.level.get(), 5);
+    } finally {
+      await teardown(backend);
+    }
+  },
+});
+
+Deno.test({
+  name: "RelatedManager - count() returns correct count",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = await setupTestBackend();
+
+    try {
+      // Create test data
+      const role = await ProjectRole.objects.create({
+        name: "DevOps Engineer",
+      });
+
+      const comp1 = await Competence.objects.create({ name: "Docker" });
+      const comp2 = await Competence.objects.create({ name: "Kubernetes" });
+      const comp3 = await Competence.objects.create({ name: "AWS" });
+
+      await ProjectRoleCompetence.objects.create({
+        projectRole: role,
+        competence: comp1,
+      });
+      await ProjectRoleCompetence.objects.create({
+        projectRole: role,
+        competence: comp2,
+      });
+      await ProjectRoleCompetence.objects.create({
+        projectRole: role,
+        competence: comp3,
+      });
+
+      // Reload role
+      const loadedRole = await ProjectRole.objects.get({ id: role.id.get() });
+
+      // Count related
+      const count = await loadedRole.roleCompetences.count();
+      assertEquals(count, 3);
+    } finally {
+      await teardown(backend);
+    }
+  },
+});
+
+Deno.test({
+  name: "RelatedManager - exists() returns correct boolean",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = await setupTestBackend();
+
+    try {
+      // Create role without competences
+      const emptyRole = await ProjectRole.objects.create({
+        name: "Empty Role",
+      });
+
+      // Create role with competences
+      const filledRole = await ProjectRole.objects.create({
+        name: "Filled Role",
+      });
+
+      const comp = await Competence.objects.create({ name: "Skill" });
+      await ProjectRoleCompetence.objects.create({
+        projectRole: filledRole,
+        competence: comp,
+      });
+
+      // Reload roles
+      const loadedEmptyRole = await ProjectRole.objects.get({
+        id: emptyRole.id.get(),
+      });
+      const loadedFilledRole = await ProjectRole.objects.get({
+        id: filledRole.id.get(),
+      });
+
+      // Check exists
+      const emptyExists = await loadedEmptyRole.roleCompetences.exists();
+      const filledExists = await loadedFilledRole.roleCompetences.exists();
+
+      assertEquals(emptyExists, false);
+      assertEquals(filledExists, true);
+    } finally {
+      await teardown(backend);
+    }
+  },
+});
+
+Deno.test({
+  name: "RelatedManager - create() sets FK automatically",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = await setupTestBackend();
+
+    try {
+      // Create test data
+      const role = await ProjectRole.objects.create({
+        name: "Data Scientist",
+      });
+
+      const comp = await Competence.objects.create({
+        name: "Machine Learning",
+      });
+
+      // Reload role
+      const loadedRole = await ProjectRole.objects.get({ id: role.id.get() });
+
+      // Create via RelatedManager - FK should be set automatically
+      const newRoleComp = await loadedRole.roleCompetences.create({
+        competence: comp,
+        level: 4,
+      });
+
+      // Verify FK was set correctly
+      assertEquals(newRoleComp.projectRole.id, role.id.get());
+      assertEquals(newRoleComp.level.get(), 4);
+
+      // Verify it's in the database
+      const fromDb = await ProjectRoleCompetence.objects.get({
+        id: newRoleComp.id.get(),
+      });
+      assertEquals(fromDb.projectRole.id, role.id.get());
+    } finally {
+      await teardown(backend);
+    }
+  },
+});
+
+Deno.test({
+  name: "RelatedManager - first() and last() work correctly",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = await setupTestBackend();
+
+    try {
+      // Create author with multiple articles
+      const author = await Author.objects.create({ name: "Jane Doe" });
+
+      await Article.objects.create({
+        title: "First Article",
+        author: author,
+      });
+
+      await Article.objects.create({
+        title: "Second Article",
+        author: author,
+      });
+
+      await Article.objects.create({
+        title: "Third Article",
+        author: author,
+      });
+
+      // Reload author
+      const loadedAuthor = await Author.objects.get({ id: author.id.get() });
+
+      // Test first() and last()
+      const first = await loadedAuthor.articles.first();
+      const last = await loadedAuthor.articles.last();
+
+      assertExists(first);
+      assertExists(last);
+      // Note: Order depends on default ordering, but both should exist
+    } finally {
+      await teardown(backend);
+    }
+  },
+});
+
+Deno.test({
+  name: "RelatedManager - exclude() works correctly",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = await setupTestBackend();
+
+    try {
+      // Create author with multiple books
+      const author = await Author.objects.create({ name: "John Smith" });
+
+      await Book.objects.create({
+        title: "Short Book",
+        pages: 100,
+        author: author,
+      });
+
+      await Book.objects.create({
+        title: "Long Book",
+        pages: 500,
+        author: author,
+      });
+
+      await Book.objects.create({
+        title: "Medium Book",
+        pages: 250,
+        author: author,
+      });
+
+      // Reload author
+      const loadedAuthor = await Author.objects.get({ id: author.id.get() });
+
+      // Exclude short books (100 pages)
+      const longBooks = await loadedAuthor.books
+        .exclude({ pages: 100 })
+        .fetch();
+
+      assertEquals(longBooks.length(), 2);
+    } finally {
+      await teardown(backend);
+    }
+  },
+});
+
+// ============================================================================
+// Edge Cases
+// ============================================================================
+
+Deno.test({
+  name: "RelatedManager - Empty result set",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = await setupTestBackend();
+
+    try {
+      // Create role without any competences
+      const role = await ProjectRole.objects.create({
+        name: "New Role",
+      });
+
+      // Reload role
+      const loadedRole = await ProjectRole.objects.get({ id: role.id.get() });
+
+      // Should return empty queryset
+      const roleCompetences = await loadedRole.roleCompetences.all().fetch();
+      assertEquals(roleCompetences.length(), 0);
+
+      const count = await loadedRole.roleCompetences.count();
+      assertEquals(count, 0);
+    } finally {
+      await teardown(backend);
+    }
+  },
+});
+
+Deno.test({
+  name: "RelatedManager - Only returns related objects (not all)",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = await setupTestBackend();
+
+    try {
+      // Create two roles
+      const role1 = await ProjectRole.objects.create({ name: "Role 1" });
+      const role2 = await ProjectRole.objects.create({ name: "Role 2" });
+
+      const comp1 = await Competence.objects.create({ name: "Skill A" });
+      const comp2 = await Competence.objects.create({ name: "Skill B" });
+
+      // Assign comp1 to role1, comp2 to role2
+      await ProjectRoleCompetence.objects.create({
+        projectRole: role1,
+        competence: comp1,
+        level: 1,
+      });
+
+      await ProjectRoleCompetence.objects.create({
+        projectRole: role2,
+        competence: comp2,
+        level: 2,
+      });
+
+      // Reload roles
+      const loadedRole1 = await ProjectRole.objects.get({ id: role1.id.get() });
+      const loadedRole2 = await ProjectRole.objects.get({ id: role2.id.get() });
+
+      // Each role should only see its own competences
+      const role1Comps = await loadedRole1.roleCompetences.all().fetch();
+      const role2Comps = await loadedRole2.roleCompetences.all().fetch();
+
+      assertEquals(role1Comps.length(), 1);
+      assertEquals(role2Comps.length(), 1);
+
+      // Verify they're different
+      assertEquals(role1Comps.array()[0].level.get(), 1);
+      assertEquals(role2Comps.array()[0].level.get(), 2);
+    } finally {
+      await teardown(backend);
+    }
+  },
+});
+
+Deno.test({
+  name: "RelatedManager - Properties return correct values",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = await setupTestBackend();
+
+    try {
+      const role = await ProjectRole.objects.create({ name: "Test Role" });
+      const loadedRole = await ProjectRole.objects.get({ id: role.id.get() });
+
+      const manager = loadedRole.roleCompetences;
+
+      // Check properties
+      assertEquals(manager.sourceInstance, loadedRole);
+      assertEquals(manager.relatedModel, ProjectRoleCompetence);
+      assertEquals(manager.fieldName, "projectRole");
+    } finally {
+      await teardown(backend);
+    }
+  },
+});


### PR DESCRIPTION
## Summary

Implements Django-style reverse relations for ForeignKey fields. When a ForeignKey defines `relatedName`, the target model automatically gets a `RelatedManager` that allows querying related objects.

Closes #39

## Features

- **RelatedManager class** with Django-like API:
  - `all()` - Returns QuerySet of all related objects
  - `filter(conditions)` - Filter related objects
  - `exclude(conditions)` - Exclude related objects
  - `first()` / `last()` - Get first/last related object
  - `count()` - Count related objects
  - `exists()` - Check if any related objects exist
  - `create(data)` - Create related object (FK set automatically)
  - `getOrCreate(defaults, lookup)` - Get or create related object

- **ModelRegistry tracking** - Reverse relations are tracked in the registry and provided to model instances

- **Lazy initialization** - RelatedManagers are created lazily via getters for proper model registration order handling

- **Backend sync** - Backend is retrieved lazily from source instance for proper SyncBackend support

- **ForeignKey filtering fix** - QuerySet now properly translates field names to column names for ForeignKey filtering (e.g., `projectRole` → `projectRole_id`)

## Usage

```typescript
import { RelatedManager, ForeignKey, OnDelete } from "@alexi/db";

// Target model - declare reverse relation type
class ProjectRole extends Model {
  id = new AutoField({ primaryKey: true });
  name = new CharField({ maxLength: 255 });

  // TypeScript type declaration - runtime populates this
  declare roleCompetences: RelatedManager<ProjectRoleCompetence>;

  static objects = new Manager(ProjectRole);
}

// Source model - defines ForeignKey with relatedName
class ProjectRoleCompetence extends Model {
  id = new AutoField({ primaryKey: true });
  projectRole = new ForeignKey<ProjectRole>("ProjectRole", {
    onDelete: OnDelete.CASCADE,
    relatedName: "roleCompetences",  // Creates reverse relation
  });
  competence = new ForeignKey<Competence>("Competence", {
    onDelete: OnDelete.CASCADE,
  });
  level = new IntegerField({ default: 1 });

  static objects = new Manager(ProjectRoleCompetence);
}

// Usage
const role = await ProjectRole.objects.get({ id: 1 });
const competences = await role.roleCompetences.all().fetch();
const highLevel = await role.roleCompetences.filter({ level__gte: 3 }).fetch();
const count = await role.roleCompetences.count();
const newComp = await role.roleCompetences.create({ competence: c, level: 4 });
```

## TypeScript Typing Pattern

Use `declare` to inform TypeScript about reverse relation properties:

```typescript
class Author extends Model {
  // Declare reverse relations - runtime creates RelatedManager
  declare articles: RelatedManager<Article>;
  declare books: RelatedManager<Book>;
}
```

The `declare` keyword informs TypeScript without generating JavaScript code. The runtime automatically creates `RelatedManager` instances based on `relatedName` values from ForeignKey definitions.

## Files Changed

- `src/db/fields/relations.ts` - Added `RelatedManager` class
- `src/db/fields/mod.ts` - Export `RelatedManager`
- `src/db/mod.ts` - Export `RelatedManager`
- `src/db/models/model.ts` - Added reverse relation tracking in `ModelRegistry`, lazy getter initialization
- `src/db/models/mod.ts` - Export `ReverseRelationDef` type
- `src/db/query/queryset.ts` - Added ForeignKey field-to-column name translation for proper filtering
- `src/db/tests/reverse_relations_test.ts` - Comprehensive test suite (13 tests)
- `AGENTS.md` - Documentation

## Test Results

All 543 tests pass, including 13 new tests for reverse relations:

- ModelRegistry tracks reverse relations
- Multiple reverse relations on same model
- Instance has RelatedManager property
- all() returns QuerySet
- filter() works correctly
- count() returns correct count
- exists() returns correct boolean
- create() sets FK automatically
- first() and last() work correctly
- exclude() works correctly
- Empty result set
- Only returns related objects (not all)
- Properties return correct values