### PR TITLE
fix(db): register models at class definition time via Manager constructor

### DIFF
--- a/src/db/models/manager.ts
+++ b/src/db/models/manager.ts
@@ -7,7 +7,7 @@
  * @module
  */
 
-import { Model } from "./model.ts";
+import { Model, ModelRegistry } from "./model.ts";
 import { QuerySet } from "../query/queryset.ts";
 import type { DatabaseBackend } from "../backends/backend.ts";
 import type { FilterConditions, OrderByField } from "../query/types.ts";
@@ -62,6 +62,11 @@ export class Manager<T extends Model> {
 
   constructor(modelClass: new () => T) {
     this._modelClass = modelClass;
+
+    // Register model at class definition time (Django-style)
+    // This ensures reverse relations are available before any instances are created
+    // See: https://github.com/atzufuki/alexi/issues/41
+    ModelRegistry.instance.register(modelClass);
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #41 - Reverse relations don't work when related model is registered after instance creation.

## Problem

Previously, models were registered lazily when the first instance was created (`_initializeFields()`). This meant reverse relations from Model B to Model A wouldn't be available if Model A instances were created before Model B was ever instantiated.

```typescript
// Before fix: This would fail with "Cannot read properties of undefined (reading 'all')"
const roles = await ProjectRoleModel.objects.filter({ project_id: id }).fetch();
for (const role of roles.array()) {
  // ProjectRoleCompetenceModel not instantiated yet → reverse relation undefined
  const competences = await role.roleCompetences.all().fetch();
}
```

## Solution

Register models in the `Manager` constructor instead of lazily in `_initializeFields()`. Since every model has `static objects = new Manager(MyModel)`, this runs at **class definition time** (when the file is imported), not when instances are created.

This is the Django-style approach - Django uses a metaclass that registers models immediately when the class is defined.

## Changes

1. **`Manager` constructor** now calls `ModelRegistry.instance.register(modelClass)`
2. **`ModelRegistry.register()`** now has early return to prevent duplicate registrations and avoid redundant `_resolveRelations()` calls
3. Added **2 new tests** verifying Issue #41 is fixed:
   - `Issue #41 - Models registered at class definition time via Manager`
   - `Issue #41 - Reverse relations work without prior instantiation`

## Test Results

All 543 tests pass, including:
- 15 reverse relations tests (13 existing + 2 new)
- 171 total db tests

```
ok | 543 passed (108 steps) | 0 failed (2s)
```

## Backward Compatibility

- No breaking changes to model definition syntax
- The fallback registration in `_initializeFields()` is kept for edge cases (models without Manager)
- `register()` is now idempotent - calling it multiple times has no effect