### PR TITLE
fix(create): Remove SyncBackend - use REST + IndexedDB pattern

### DIFF
--- a/src/create/templates/root/deno_jsonc.ts
+++ b/src/create/templates/root/deno_jsonc.ts
@@ -33,7 +33,6 @@ export function generateDenoJsonc(name: string): string {
       "@alexi/db/backends/denokv": "jsr:@alexi/db@^0.15/backends/denokv",
       "@alexi/db/backends/indexeddb": "jsr:@alexi/db@^0.15/backends/indexeddb",
       "@alexi/db/backends/rest": "jsr:@alexi/db@^0.15/backends/rest",
-      "@alexi/db/backends/sync": "jsr:@alexi/db@^0.15/backends/sync",
       "@alexi/urls": "jsr:@alexi/urls@^0.15",
       "@alexi/http": "jsr:@alexi/http@^0.15",
       "@alexi/middleware": "jsr:@alexi/middleware@^0.15",

--- a/src/create/templates/root/readme.ts
+++ b/src/create/templates/root/readme.ts
@@ -19,7 +19,7 @@ A full-stack Todo application built with [Alexi](https://github.com/atzufuki/ale
 - **REST API Backend** - Django-style REST framework with DenoKV
 - **Frontend SPA** - Built with HTML Props custom elements
 - **Desktop App** - Native-like window using WebUI
-- **Offline-first** - SyncBackend with IndexedDB + REST API
+- **Offline-first** - IndexedDB cache with REST API sync
 
 ## Quick Start
 

--- a/src/create/templates/ui/models_ts.ts
+++ b/src/create/templates/ui/models_ts.ts
@@ -12,7 +12,7 @@ export function generateUiModelsTs(name: string): string {
  * ${toPascalCase(name)} UI Models
  *
  * Frontend ORM models for the Todo application.
- * These mirror the backend models for use with SyncBackend.
+ * These mirror the backend models for use with IndexedDB and REST backends.
  *
  * @module ${name}-ui/models
  */

--- a/src/create/templates/ui/views_ts.ts
+++ b/src/create/templates/ui/views_ts.ts
@@ -42,8 +42,10 @@ export async function home(
     fetch: async (): Promise<void> => {
       const template = templateRef.current!;
       try {
-        // Fetch fresh data from REST API via sync backend
-        const fresh = await TodoModel.objects.using("sync").all().fetch();
+        // Fetch fresh data from REST API
+        const fresh = await TodoModel.objects.using("rest").all().fetch();
+        // Save to IndexedDB for offline access
+        await fresh.using("indexeddb").save();
         template.todos = fresh;
       } catch (error) {
         console.error("Error fetching todos:", error);


### PR DESCRIPTION
## Summary

Remove all SyncBackend references from the create package. SyncBackend is deprecated and will be removed entirely.

## Changes

- **settings_ts.ts**: Remove `SyncBackend` import and instance, remove `sync` from DATABASES
- **views_ts.ts**: Change `.using("sync")` → `.using("rest")` + `.save()` to IDB
- **home_ts.ts**: Update CRUD operations to use `rest` backend + IDB cache:
  - Create: REST → save to IDB
  - Update: `rest.update()` → `todo.using("indexeddb").save()`
  - Delete: `rest.delete()` → delete from IDB
- **deno_jsonc.ts**: Remove `@alexi/db/backends/sync` from import map
- **readme.ts**: Update "SyncBackend with IndexedDB" → "IndexedDB cache with REST API sync"
- **models_ts.ts**: Update documentation

## New Pattern

The generated project now uses the correct sync pattern:

```typescript
// 1. Load cached data from IndexedDB first (instant, works offline)
const cached = await Model.objects.using("indexeddb").all().fetch();

// 2. Fetch fresh data from REST API
const fresh = await Model.objects.using("rest").all().fetch();

// 3. Save to IndexedDB for offline access
await fresh.using("indexeddb").save();
```

Closes #53