### PR TITLE
feat(restframework): add DRF-style throttling classes

### DIFF
--- a/docs/django-comparison.md
+++ b/docs/django-comparison.md
@@ -51,22 +51,22 @@ differences, and features unique to Alexi.
 
 ### REST Framework
 
-| Feature             | Django REST Framework | Alexi REST Framework | Notes                              |
-| ------------------- | --------------------- | -------------------- | ---------------------------------- |
-| Serializers         | ✅                    | ✅                   | Similar API                        |
-| ModelSerializer     | ✅                    | ✅                   | Auto-generates fields from model   |
-| ViewSets            | ✅                    | ✅                   | ModelViewSet, ReadOnlyModelViewSet |
-| Routers             | ✅                    | ✅                   | DefaultRouter                      |
-| `@action` decorator | ✅                    | ✅                   | Custom actions on ViewSets         |
-| Filter backends     | ✅                    | ✅                   | QueryParamFilterBackend, etc.      |
-| Ordering            | ✅                    | ✅                   | OrderingFilter                     |
-| Search              | ✅                    | ✅                   | SearchFilter                       |
-| Pagination          | ✅                    | ✅                   | PageNumber, LimitOffset, Cursor    |
-| Throttling          | ✅                    | ❌                   | —                                  |
-| Permissions         | ✅                    | ✅                   | ViewSet permission_classes         |
-| Versioning          | ✅                    | ❌                   | —                                  |
-| Content negotiation | ✅                    | ❌                   | JSON only                          |
-| Browsable API       | ✅                    | ❌                   | —                                  |
+| Feature             | Django REST Framework | Alexi REST Framework | Notes                                                  |
+| ------------------- | --------------------- | -------------------- | ------------------------------------------------------ |
+| Serializers         | ✅                    | ✅                   | Similar API                                            |
+| ModelSerializer     | ✅                    | ✅                   | Auto-generates fields from model                       |
+| ViewSets            | ✅                    | ✅                   | ModelViewSet, ReadOnlyModelViewSet                     |
+| Routers             | ✅                    | ✅                   | DefaultRouter                                          |
+| `@action` decorator | ✅                    | ✅                   | Custom actions on ViewSets                             |
+| Filter backends     | ✅                    | ✅                   | QueryParamFilterBackend, etc.                          |
+| Ordering            | ✅                    | ✅                   | OrderingFilter                                         |
+| Search              | ✅                    | ✅                   | SearchFilter                                           |
+| Pagination          | ✅                    | ✅                   | PageNumber, LimitOffset, Cursor                        |
+| Throttling          | ✅                    | ✅                   | AnonRateThrottle, UserRateThrottle, ScopedRateThrottle |
+| Permissions         | ✅                    | ✅                   | ViewSet permission_classes                             |
+| Versioning          | ✅                    | ❌                   | —                                                      |
+| Content negotiation | ✅                    | ❌                   | JSON only                                              |
+| Browsable API       | ✅                    | ❌                   | —                                                      |
 
 ### URL Routing
 
@@ -185,7 +185,7 @@ Features available in Django that Alexi does not currently provide:
 | **GIS support**            | GeoDjango for geographic data                  |
 | **Content types**          | Generic relations framework                    |
 | **Browsable API**          | Interactive API documentation (DRF)            |
-| **Throttling**             | Rate limiting (DRF)                            |
+| ~~**Throttling**~~         | ~~Rate limiting (DRF)~~ ✅ Implemented         |
 
 ---
 

--- a/src/restframework/mod.ts
+++ b/src/restframework/mod.ts
@@ -178,3 +178,18 @@ export type {
   PaginationClass,
   PaginationContext,
 } from "./pagination/mod.ts";
+
+// ============================================================================
+// Throttling
+// ============================================================================
+
+export {
+  AnonRateThrottle,
+  BaseThrottle,
+  clearThrottleCache,
+  parseRate,
+  ScopedRateThrottle,
+  UserRateThrottle,
+} from "./throttling/mod.ts";
+
+export type { ParsedRate, ThrottleClass } from "./throttling/mod.ts";

--- a/src/restframework/throttling/mod.ts
+++ b/src/restframework/throttling/mod.ts
@@ -1,0 +1,17 @@
+/**
+ * Throttling module for Alexi REST Framework
+ *
+ * @module @alexi/restframework/throttling
+ */
+
+export {
+  AnonRateThrottle,
+  BaseThrottle,
+  clearThrottleCache,
+  getCacheEntry,
+  parseRate,
+  ScopedRateThrottle,
+  UserRateThrottle,
+} from "./throttle.ts";
+
+export type { ParsedRate, ThrottleClass } from "./throttle.ts";

--- a/src/restframework/throttling/throttle.ts
+++ b/src/restframework/throttling/throttle.ts
@@ -1,0 +1,432 @@
+/**
+ * Throttling classes for Alexi REST Framework
+ *
+ * Provides DRF-style request throttling/rate limiting for API endpoints.
+ * Returns 429 Too Many Requests when the rate limit is exceeded.
+ *
+ * @module @alexi/restframework/throttling/throttle
+ */
+
+import type { ViewSetContext } from "../viewsets/viewset.ts";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Throttle class constructor type
+ */
+export interface ThrottleClass {
+  new (): BaseThrottle;
+}
+
+/**
+ * Parsed rate (number of requests allowed per duration in seconds)
+ */
+export interface ParsedRate {
+  /** Maximum number of requests allowed */
+  numRequests: number;
+  /** Time window in seconds */
+  duration: number;
+}
+
+// ============================================================================
+// Rate Parsing
+// ============================================================================
+
+/**
+ * Duration names mapped to seconds
+ */
+const DURATION_MAP: Record<string, number> = {
+  second: 1,
+  minute: 60,
+  hour: 3600,
+  day: 86400,
+};
+
+/**
+ * Parse a rate string like "100/day", "10/minute", "5/second"
+ *
+ * @param rate - Rate string in the format "N/period" where period is
+ *               second, minute, hour, or day
+ * @returns Parsed rate object or null if rate is null/undefined
+ * @throws Error if the rate format is invalid
+ *
+ * @example
+ * ```ts
+ * parseRate("100/day")    // { numRequests: 100, duration: 86400 }
+ * parseRate("10/minute")  // { numRequests: 10, duration: 60 }
+ * parseRate("5/second")   // { numRequests: 5, duration: 1 }
+ * ```
+ */
+export function parseRate(rate: string | null | undefined): ParsedRate | null {
+  if (rate == null) {
+    return null;
+  }
+
+  const parts = rate.split("/");
+  if (parts.length !== 2) {
+    throw new Error(
+      `Invalid throttle rate format: "${rate}". Expected "N/period" (e.g. "100/day")`,
+    );
+  }
+
+  const numRequests = parseInt(parts[0], 10);
+  if (isNaN(numRequests) || numRequests <= 0) {
+    throw new Error(
+      `Invalid throttle rate: "${rate}". Number of requests must be a positive integer.`,
+    );
+  }
+
+  const periodStr = parts[1].toLowerCase();
+  const duration = DURATION_MAP[periodStr];
+  if (duration == null) {
+    throw new Error(
+      `Invalid throttle period: "${
+        parts[1]
+      }". Must be one of: second, minute, hour, day`,
+    );
+  }
+
+  return { numRequests, duration };
+}
+
+// ============================================================================
+// Throttle Cache (in-memory)
+// ============================================================================
+
+/**
+ * In-memory throttle cache entry
+ */
+interface CacheEntry {
+  /** Timestamps of recent requests (Unix time in seconds) */
+  history: number[];
+}
+
+/**
+ * Global in-memory throttle cache
+ *
+ * Maps cache key → entry. This is suitable for single-process servers.
+ * For multi-process deployments, use a shared cache (e.g., Redis/DenoKV).
+ */
+const throttleCache = new Map<string, CacheEntry>();
+
+/**
+ * Get throttle history for a cache key
+ */
+export function getCacheEntry(key: string): CacheEntry {
+  let entry = throttleCache.get(key);
+  if (!entry) {
+    entry = { history: [] };
+    throttleCache.set(key, entry);
+  }
+  return entry;
+}
+
+/**
+ * Clear the throttle cache (used in tests)
+ */
+export function clearThrottleCache(): void {
+  throttleCache.clear();
+}
+
+// ============================================================================
+// Base Throttle
+// ============================================================================
+
+/**
+ * Base throttle class
+ *
+ * All throttle classes should extend this class and implement
+ * the `getCache()` and `getRate()` methods.
+ *
+ * @example
+ * ```ts
+ * class CustomThrottle extends BaseThrottle {
+ *   scope = "custom";
+ *
+ *   override getRate(): string | null {
+ *     return "50/hour";
+ *   }
+ *
+ *   override getCacheKey(context: ViewSetContext): string | null {
+ *     return `throttle_custom_${context.user?.id ?? "anon"}`;
+ *   }
+ * }
+ * ```
+ */
+export abstract class BaseThrottle {
+  /**
+   * Human-readable message shown when the rate limit is exceeded
+   */
+  message = "Request was throttled.";
+
+  /**
+   * The parsed rate (number of requests per duration)
+   * Cached after first parse. `undefined` means not yet parsed.
+   */
+  protected parsedRate: ParsedRate | null | undefined = undefined;
+
+  /**
+   * Get the rate string for this throttle (e.g., "100/day")
+   *
+   * Return null to disable throttling.
+   */
+  abstract getRate(): string | null;
+
+  /**
+   * Get the cache key for this request
+   *
+   * Return null to not throttle this request.
+   */
+  abstract getCacheKey(context: ViewSetContext): string | null;
+
+  /**
+   * Get the parsed rate, caching the result
+   */
+  protected getParsedRate(): ParsedRate | null {
+    if (this.parsedRate !== undefined) {
+      return this.parsedRate;
+    }
+    this.parsedRate = parseRate(this.getRate());
+    return this.parsedRate;
+  }
+
+  /**
+   * Check if the request is allowed
+   *
+   * Returns true if the request should be allowed, false to throttle.
+   * Also updates the throttle history when allowed.
+   *
+   * @param context - The ViewSet context
+   * @returns true if the request is allowed, false if throttled
+   */
+  allowRequest(context: ViewSetContext): boolean {
+    const rate = this.getParsedRate();
+    if (!rate) {
+      return true; // No rate limit configured - allow all
+    }
+
+    const cacheKey = this.getCacheKey(context);
+    if (!cacheKey) {
+      return true; // No cache key - allow (e.g., unauthenticated but UserRateThrottle)
+    }
+
+    const now = Date.now() / 1000;
+    const entry = getCacheEntry(cacheKey);
+
+    // Remove timestamps outside the current window
+    const windowStart = now - rate.duration;
+    entry.history = entry.history.filter((t) => t > windowStart);
+
+    if (entry.history.length >= rate.numRequests) {
+      // Rate limit exceeded - record when the next request will be allowed
+      this.message = `Request was throttled. Expected available in ${
+        Math.ceil(entry.history[0] + rate.duration - now)
+      } seconds.`;
+      return false;
+    }
+
+    // Allow request and record timestamp
+    entry.history.push(now);
+    return true;
+  }
+
+  /**
+   * Calculate seconds until the next allowed request
+   *
+   * Used for the Retry-After response header.
+   *
+   * @param context - The ViewSet context
+   * @returns Seconds until next allowed request, or null if not throttled
+   */
+  waitTime(context: ViewSetContext): number | null {
+    const rate = this.getParsedRate();
+    if (!rate) {
+      return null;
+    }
+
+    const cacheKey = this.getCacheKey(context);
+    if (!cacheKey) {
+      return null;
+    }
+
+    const now = Date.now() / 1000;
+    const entry = getCacheEntry(cacheKey);
+
+    const windowStart = now - rate.duration;
+    const recentHistory = entry.history.filter((t) => t > windowStart);
+
+    if (recentHistory.length < rate.numRequests) {
+      return null; // Not throttled
+    }
+
+    // Time until the oldest request in the window expires
+    return Math.ceil(recentHistory[0] + rate.duration - now);
+  }
+}
+
+// ============================================================================
+// Built-in Throttle Classes
+// ============================================================================
+
+/**
+ * Rate limit unauthenticated (anonymous) requests by IP address
+ *
+ * The default rate can be set via the `rate` property. Override `getRate()`
+ * to return the rate dynamically (e.g., from settings).
+ *
+ * @example
+ * ```ts
+ * class MyViewSet extends ModelViewSet {
+ *   throttle_classes = [AnonRateThrottle];
+ *   throttle_rates = { anon: "100/day" };
+ * }
+ * ```
+ */
+export class AnonRateThrottle extends BaseThrottle {
+  /**
+   * Throttle scope name - used to look up the rate in throttle_rates
+   */
+  scope = "anon";
+
+  /**
+   * Default rate (null = disabled unless set via throttle_rates)
+   */
+  protected _rate: string | null = null;
+
+  getRate(): string | null {
+    return this._rate;
+  }
+
+  /**
+   * Set the rate (called by ViewSet when throttle_rates is configured)
+   */
+  setRate(rate: string): void {
+    this._rate = rate;
+    this.parsedRate = undefined; // Reset cached parsed rate
+  }
+
+  /**
+   * Get the client IP address from the request
+   */
+  protected getClientIp(request: Request): string {
+    // Check common proxy headers first
+    const forwarded = request.headers.get("X-Forwarded-For");
+    if (forwarded) {
+      return forwarded.split(",")[0].trim();
+    }
+    const realIp = request.headers.get("X-Real-IP");
+    if (realIp) {
+      return realIp.trim();
+    }
+    // Fall back to a placeholder (in Deno, remote addr is not on Request)
+    return "unknown";
+  }
+
+  getCacheKey(context: ViewSetContext): string | null {
+    // Only throttle anonymous (unauthenticated) requests
+    if (context.user != null) {
+      return null;
+    }
+    const ip = this.getClientIp(context.request);
+    return `throttle_anon_${ip}`;
+  }
+}
+
+/**
+ * Rate limit authenticated requests by user ID
+ *
+ * @example
+ * ```ts
+ * class MyViewSet extends ModelViewSet {
+ *   throttle_classes = [UserRateThrottle];
+ *   throttle_rates = { user: "1000/day" };
+ * }
+ * ```
+ */
+export class UserRateThrottle extends BaseThrottle {
+  /**
+   * Throttle scope name - used to look up the rate in throttle_rates
+   */
+  scope = "user";
+
+  /**
+   * Default rate (null = disabled unless set via throttle_rates)
+   */
+  protected _rate: string | null = null;
+
+  getRate(): string | null {
+    return this._rate;
+  }
+
+  /**
+   * Set the rate (called by ViewSet when throttle_rates is configured)
+   */
+  setRate(rate: string): void {
+    this._rate = rate;
+    this.parsedRate = undefined; // Reset cached parsed rate
+  }
+
+  getCacheKey(context: ViewSetContext): string | null {
+    // Only throttle authenticated requests
+    if (context.user == null) {
+      return null;
+    }
+    return `throttle_user_${context.user.id}`;
+  }
+}
+
+/**
+ * Rate limit requests by a named scope
+ *
+ * Useful for applying different rate limits to different parts of the API.
+ * Set the `scope` property to identify the rate in `throttle_rates`.
+ *
+ * @example
+ * ```ts
+ * class BurstThrottle extends ScopedRateThrottle {
+ *   override scope = "burst";
+ * }
+ *
+ * class SustainedThrottle extends ScopedRateThrottle {
+ *   override scope = "sustained";
+ * }
+ *
+ * class MyViewSet extends ModelViewSet {
+ *   throttle_classes = [BurstThrottle, SustainedThrottle];
+ *   throttle_rates = {
+ *     burst: "60/minute",
+ *     sustained: "1000/day",
+ *   };
+ * }
+ * ```
+ */
+export class ScopedRateThrottle extends BaseThrottle {
+  /**
+   * Throttle scope name - must match a key in throttle_rates
+   */
+  scope = "default";
+
+  /**
+   * Default rate (null = disabled unless set via throttle_rates)
+   */
+  protected _rate: string | null = null;
+
+  getRate(): string | null {
+    return this._rate;
+  }
+
+  /**
+   * Set the rate (called by ViewSet when throttle_rates is configured)
+   */
+  setRate(rate: string): void {
+    this._rate = rate;
+    this.parsedRate = undefined; // Reset cached parsed rate
+  }
+
+  getCacheKey(context: ViewSetContext): string | null {
+    const userId = context.user?.id ?? "anon";
+    return `throttle_${this.scope}_${userId}`;
+  }
+}

--- a/src/restframework/throttling/throttle_test.ts
+++ b/src/restframework/throttling/throttle_test.ts
@@ -1,0 +1,441 @@
+/**
+ * Tests for Throttling classes
+ *
+ * @module @alexi/restframework/throttling/throttle_test
+ */
+
+import { assertEquals, assertExists } from "jsr:@std/assert@1";
+import {
+  AnonRateThrottle,
+  clearThrottleCache,
+  parseRate,
+  ScopedRateThrottle,
+  UserRateThrottle,
+} from "./throttle.ts";
+import { ViewSet } from "../viewsets/viewset.ts";
+import type { ViewSetContext } from "../viewsets/viewset.ts";
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeContext(overrides: Partial<ViewSetContext> = {}): ViewSetContext {
+  return {
+    request: new Request("http://localhost/api/test/"),
+    params: {},
+    action: "list",
+    ...overrides,
+  };
+}
+
+function makeAuthContext(
+  userId: number | string = 1,
+): ViewSetContext {
+  return makeContext({ user: { id: userId, email: "user@test.com" } });
+}
+
+function makeAnonContext(ip?: string): ViewSetContext {
+  const headers: Record<string, string> = {};
+  if (ip) {
+    headers["X-Forwarded-For"] = ip;
+  }
+  return {
+    request: new Request("http://localhost/api/test/", { headers }),
+    params: {},
+    action: "list",
+  };
+}
+
+// ============================================================================
+// parseRate tests
+// ============================================================================
+
+Deno.test("parseRate: parses per-second rate", () => {
+  const rate = parseRate("5/second");
+  assertExists(rate);
+  assertEquals(rate.numRequests, 5);
+  assertEquals(rate.duration, 1);
+});
+
+Deno.test("parseRate: parses per-minute rate", () => {
+  const rate = parseRate("60/minute");
+  assertExists(rate);
+  assertEquals(rate.numRequests, 60);
+  assertEquals(rate.duration, 60);
+});
+
+Deno.test("parseRate: parses per-hour rate", () => {
+  const rate = parseRate("1000/hour");
+  assertExists(rate);
+  assertEquals(rate.numRequests, 1000);
+  assertEquals(rate.duration, 3600);
+});
+
+Deno.test("parseRate: parses per-day rate", () => {
+  const rate = parseRate("100/day");
+  assertExists(rate);
+  assertEquals(rate.numRequests, 100);
+  assertEquals(rate.duration, 86400);
+});
+
+Deno.test("parseRate: returns null for null input", () => {
+  assertEquals(parseRate(null), null);
+  assertEquals(parseRate(undefined), null);
+});
+
+Deno.test("parseRate: throws on invalid format", () => {
+  let threw = false;
+  try {
+    parseRate("invalid");
+  } catch (_e) {
+    threw = true;
+  }
+  assertEquals(threw, true);
+});
+
+Deno.test("parseRate: throws on invalid period", () => {
+  let threw = false;
+  try {
+    parseRate("100/week");
+  } catch (_e) {
+    threw = true;
+  }
+  assertEquals(threw, true);
+});
+
+Deno.test("parseRate: throws on non-positive number", () => {
+  let threw = false;
+  try {
+    parseRate("0/day");
+  } catch (_e) {
+    threw = true;
+  }
+  assertEquals(threw, true);
+});
+
+// ============================================================================
+// AnonRateThrottle tests
+// ============================================================================
+
+Deno.test({
+  name: "AnonRateThrottle: allows requests within limit",
+  fn() {
+    clearThrottleCache();
+    const throttle = new AnonRateThrottle();
+    throttle.setRate("3/minute");
+    const ctx = makeAnonContext("192.168.1.1");
+
+    assertEquals(throttle.allowRequest(ctx), true);
+    assertEquals(throttle.allowRequest(ctx), true);
+    assertEquals(throttle.allowRequest(ctx), true);
+  },
+});
+
+Deno.test({
+  name: "AnonRateThrottle: blocks after limit exceeded",
+  fn() {
+    clearThrottleCache();
+    const throttle = new AnonRateThrottle();
+    throttle.setRate("3/minute");
+    const ctx = makeAnonContext("10.0.0.1");
+
+    assertEquals(throttle.allowRequest(ctx), true);
+    assertEquals(throttle.allowRequest(ctx), true);
+    assertEquals(throttle.allowRequest(ctx), true);
+    assertEquals(throttle.allowRequest(ctx), false); // 4th request blocked
+  },
+});
+
+Deno.test({
+  name: "AnonRateThrottle: does not throttle authenticated users",
+  fn() {
+    clearThrottleCache();
+    const throttle = new AnonRateThrottle();
+    throttle.setRate("1/minute");
+    const ctx = makeAuthContext(42);
+
+    // Authenticated requests are not throttled by AnonRateThrottle
+    assertEquals(throttle.allowRequest(ctx), true);
+    assertEquals(throttle.allowRequest(ctx), true);
+    assertEquals(throttle.allowRequest(ctx), true);
+  },
+});
+
+Deno.test({
+  name: "AnonRateThrottle: uses X-Forwarded-For header for IP",
+  fn() {
+    clearThrottleCache();
+    const throttle = new AnonRateThrottle();
+    throttle.setRate("2/minute");
+
+    const ctx1 = makeAnonContext("1.2.3.4");
+    const ctx2 = makeAnonContext("5.6.7.8");
+
+    // Two different IPs should have separate limits
+    assertEquals(throttle.allowRequest(ctx1), true);
+    assertEquals(throttle.allowRequest(ctx1), true);
+    assertEquals(throttle.allowRequest(ctx1), false); // 1.2.3.4 exceeded
+
+    assertEquals(throttle.allowRequest(ctx2), true); // 5.6.7.8 not affected
+  },
+});
+
+Deno.test({
+  name: "AnonRateThrottle: allows all when no rate set",
+  fn() {
+    clearThrottleCache();
+    const throttle = new AnonRateThrottle();
+    // No rate set
+    const ctx = makeAnonContext("1.1.1.1");
+
+    assertEquals(throttle.allowRequest(ctx), true);
+    assertEquals(throttle.allowRequest(ctx), true);
+    assertEquals(throttle.allowRequest(ctx), true);
+  },
+});
+
+Deno.test({
+  name: "AnonRateThrottle: scope is 'anon'",
+  fn() {
+    const throttle = new AnonRateThrottle();
+    assertEquals(throttle.scope, "anon");
+  },
+});
+
+// ============================================================================
+// UserRateThrottle tests
+// ============================================================================
+
+Deno.test({
+  name: "UserRateThrottle: allows requests within limit",
+  fn() {
+    clearThrottleCache();
+    const throttle = new UserRateThrottle();
+    throttle.setRate("3/minute");
+    const ctx = makeAuthContext(1);
+
+    assertEquals(throttle.allowRequest(ctx), true);
+    assertEquals(throttle.allowRequest(ctx), true);
+    assertEquals(throttle.allowRequest(ctx), true);
+  },
+});
+
+Deno.test({
+  name: "UserRateThrottle: blocks after limit exceeded",
+  fn() {
+    clearThrottleCache();
+    const throttle = new UserRateThrottle();
+    throttle.setRate("2/minute");
+    const ctx = makeAuthContext(99);
+
+    assertEquals(throttle.allowRequest(ctx), true);
+    assertEquals(throttle.allowRequest(ctx), true);
+    assertEquals(throttle.allowRequest(ctx), false); // 3rd request blocked
+  },
+});
+
+Deno.test({
+  name: "UserRateThrottle: different users have separate limits",
+  fn() {
+    clearThrottleCache();
+    const throttle = new UserRateThrottle();
+    throttle.setRate("2/minute");
+
+    const ctx1 = makeAuthContext(1);
+    const ctx2 = makeAuthContext(2);
+
+    assertEquals(throttle.allowRequest(ctx1), true);
+    assertEquals(throttle.allowRequest(ctx1), true);
+    assertEquals(throttle.allowRequest(ctx1), false); // user 1 exceeded
+
+    assertEquals(throttle.allowRequest(ctx2), true); // user 2 not affected
+  },
+});
+
+Deno.test({
+  name: "UserRateThrottle: does not throttle anonymous users",
+  fn() {
+    clearThrottleCache();
+    const throttle = new UserRateThrottle();
+    throttle.setRate("1/minute");
+    const ctx = makeAnonContext();
+
+    // Anonymous requests not throttled by UserRateThrottle
+    assertEquals(throttle.allowRequest(ctx), true);
+    assertEquals(throttle.allowRequest(ctx), true);
+    assertEquals(throttle.allowRequest(ctx), true);
+  },
+});
+
+Deno.test({
+  name: "UserRateThrottle: scope is 'user'",
+  fn() {
+    const throttle = new UserRateThrottle();
+    assertEquals(throttle.scope, "user");
+  },
+});
+
+// ============================================================================
+// ScopedRateThrottle tests
+// ============================================================================
+
+Deno.test({
+  name: "ScopedRateThrottle: allows requests within limit (anon)",
+  fn() {
+    clearThrottleCache();
+    const throttle = new ScopedRateThrottle();
+    throttle.scope = "burst";
+    throttle.setRate("3/minute");
+    const ctx = makeAnonContext();
+
+    assertEquals(throttle.allowRequest(ctx), true);
+    assertEquals(throttle.allowRequest(ctx), true);
+    assertEquals(throttle.allowRequest(ctx), true);
+  },
+});
+
+Deno.test({
+  name: "ScopedRateThrottle: blocks after limit exceeded",
+  fn() {
+    clearThrottleCache();
+    const throttle = new ScopedRateThrottle();
+    throttle.scope = "sustained";
+    throttle.setRate("2/day");
+    const ctx = makeAuthContext(5);
+
+    assertEquals(throttle.allowRequest(ctx), true);
+    assertEquals(throttle.allowRequest(ctx), true);
+    assertEquals(throttle.allowRequest(ctx), false);
+  },
+});
+
+Deno.test({
+  name: "ScopedRateThrottle: different scopes are independent",
+  fn() {
+    clearThrottleCache();
+    const burst = new ScopedRateThrottle();
+    burst.scope = "burst";
+    burst.setRate("2/minute");
+
+    const sustained = new ScopedRateThrottle();
+    sustained.scope = "sustained";
+    sustained.setRate("10/day");
+
+    const ctx = makeAuthContext(1);
+
+    assertEquals(burst.allowRequest(ctx), true);
+    assertEquals(burst.allowRequest(ctx), true);
+    assertEquals(burst.allowRequest(ctx), false); // burst exceeded
+
+    assertEquals(sustained.allowRequest(ctx), true); // sustained not affected
+  },
+});
+
+Deno.test({
+  name: "ScopedRateThrottle: default scope is 'default'",
+  fn() {
+    const throttle = new ScopedRateThrottle();
+    assertEquals(throttle.scope, "default");
+  },
+});
+
+// ============================================================================
+// waitTime tests
+// ============================================================================
+
+Deno.test({
+  name: "waitTime: returns null when not throttled",
+  fn() {
+    clearThrottleCache();
+    const throttle = new UserRateThrottle();
+    throttle.setRate("5/minute");
+    const ctx = makeAuthContext(10);
+
+    throttle.allowRequest(ctx);
+    assertEquals(throttle.waitTime(ctx), null);
+  },
+});
+
+Deno.test({
+  name: "waitTime: returns positive number when throttled",
+  fn() {
+    clearThrottleCache();
+    const throttle = new UserRateThrottle();
+    throttle.setRate("2/minute");
+    const ctx = makeAuthContext(20);
+
+    throttle.allowRequest(ctx);
+    throttle.allowRequest(ctx);
+    throttle.allowRequest(ctx); // throttled
+
+    const wait = throttle.waitTime(ctx);
+    assertExists(wait);
+    assertEquals(wait > 0, true);
+    assertEquals(wait <= 60, true);
+  },
+});
+
+// ============================================================================
+// ViewSet integration tests
+// ============================================================================
+
+Deno.test({
+  name: "ViewSet.checkThrottles: returns null when no throttle_classes",
+  fn() {
+    clearThrottleCache();
+    const vs = new ViewSet();
+    const ctx = makeContext();
+    assertEquals(vs.checkThrottles(ctx), null);
+  },
+});
+
+Deno.test({
+  name: "ViewSet.checkThrottles: returns null when throttle allows",
+  fn() {
+    clearThrottleCache();
+    const vs = new ViewSet();
+    vs.throttle_classes = [AnonRateThrottle];
+    vs.throttle_rates = { anon: "10/minute" };
+    const ctx = makeAnonContext("2.2.2.2");
+    assertEquals(vs.checkThrottles(ctx), null);
+  },
+});
+
+Deno.test({
+  name: "ViewSet.checkThrottles: returns 429 when throttled",
+  fn() {
+    clearThrottleCache();
+    const vs = new ViewSet();
+    vs.throttle_classes = [AnonRateThrottle];
+    vs.throttle_rates = { anon: "2/minute" };
+    const ctx = makeAnonContext("3.3.3.3");
+
+    vs.checkThrottles(ctx); // 1
+    vs.checkThrottles(ctx); // 2
+
+    // Re-create viewset to reset throttle instance (but cache persists)
+    const vs2 = new ViewSet();
+    vs2.throttle_classes = [AnonRateThrottle];
+    vs2.throttle_rates = { anon: "2/minute" };
+
+    const response = vs2.checkThrottles(ctx); // 3 - should be throttled
+    assertExists(response);
+    assertEquals(response!.status, 429);
+    assertExists(response!.headers.get("Retry-After"));
+  },
+});
+
+Deno.test({
+  name: "ViewSet.getThrottles: applies throttle_rates to scoped throttles",
+  fn() {
+    clearThrottleCache();
+    const vs = new ViewSet();
+    vs.throttle_classes = [AnonRateThrottle, UserRateThrottle];
+    vs.throttle_rates = { anon: "50/hour", user: "500/hour" };
+
+    const throttles = vs.getThrottles();
+    assertEquals(throttles.length, 2);
+    assertEquals(throttles[0].getRate(), "50/hour");
+    assertEquals(throttles[1].getRate(), "500/hour");
+  },
+});


### PR DESCRIPTION
Closes #69

## Summary

- Adds `BaseThrottle`, `AnonRateThrottle`, `UserRateThrottle`, and `ScopedRateThrottle` classes in `src/restframework/throttling/`
- `AnonRateThrottle` rate-limits unauthenticated requests by client IP (via `X-Forwarded-For` / `X-Real-IP` headers)
- `UserRateThrottle` rate-limits authenticated requests by user ID
- `ScopedRateThrottle` rate-limits by a custom named scope (useful for per-endpoint limits like burst/sustained)
- `parseRate()` parses rate strings in the format `"N/period"` (second, minute, hour, day)
- In-memory throttle cache (`throttleCache` Map) with sliding window algorithm; `clearThrottleCache()` exported for tests
- ViewSet integration: `throttle_classes`, `throttle_rates`, `getThrottles()`, `checkThrottles()` added to `ViewSet`
- Throttle check happens before permission check in `asView()`
- Returns `429 Too Many Requests` with `Retry-After` header and JSON error body when throttled
- 29 tests, all passing
- AGENTS.md and `docs/django-comparison.md` updated

## Bug Fixed

The `parsedRate` property was initialized as `null` but the cache check used `!== undefined`, causing the cache to always return `null` (skipping rate parsing). Changed the sentinel value to `undefined` to correctly distinguish "not yet parsed" from "no rate configured".