### PR TITLE
feat(restframework): add browsable API renderer (#72)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1125,6 +1125,96 @@ import {
 } from "@alexi/restframework";
 ```
 
+### Browsable API
+
+`BrowsableAPIRenderer` produces an interactive HTML interface for the API when
+requests are made with `Accept: text/html` (e.g., from a browser). It is similar
+to Django REST Framework's browsable API.
+
+Features:
+
+- Syntax-highlighted JSON response display
+- Auto-generated JSON request forms for POST/PUT/PATCH
+- Breadcrumb navigation and HTTP method badge
+- Pagination controls (next/previous links)
+- Login/logout with JWT token management
+- Copy-to-clipboard for response data
+- Mobile-responsive design
+
+```typescript
+import {
+  BrowsableAPIRenderer,
+  JSONRenderer,
+  ModelViewSet,
+} from "@alexi/restframework";
+
+// ViewSet that renders HTML in browsers, JSON for API clients
+class ArticleViewSet extends ModelViewSet {
+  model = ArticleModel;
+  serializer_class = ArticleSerializer;
+  renderer_classes = [JSONRenderer, BrowsableAPIRenderer];
+}
+// Browser (Accept: text/html) → Interactive HTML page
+// API client (Accept: application/json) → JSON response
+```
+
+#### Customization
+
+```typescript
+import { BrowsableAPIRenderer } from "@alexi/restframework";
+
+class MyBrowsableRenderer extends BrowsableAPIRenderer {
+  override title = "My Project API";
+  override tokenStorageKey = "my_project_tokens";
+  override loginUrl = "/api/v2/auth/login/";
+  override logoutUrl = "/api/v2/auth/logout/";
+  override meUrl = "/api/v2/auth/me/";
+}
+
+class ArticleViewSet extends ModelViewSet {
+  renderer_classes = [JSONRenderer, MyBrowsableRenderer];
+}
+```
+
+Or pass options to the constructor (e.g., for factory patterns):
+
+```typescript
+const renderer = new BrowsableAPIRenderer({
+  title: "My API",
+  tokenStorageKey: "my_tokens",
+  loginUrl: "/api/auth/login/",
+});
+```
+
+#### RenderContext
+
+The viewset automatically passes a `RenderContext` to renderers with:
+
+| Field            | Type       | Description                      |
+| ---------------- | ---------- | -------------------------------- |
+| `request`        | `Request`  | The original HTTP request        |
+| `method`         | `string`   | HTTP method (GET, POST, etc.)    |
+| `allowedMethods` | `string[]` | Methods allowed on this endpoint |
+| `statusCode`     | `number`   | Response status code             |
+| `action`         | `string`   | The ViewSet action name          |
+| `params`         | `object`   | URL path parameters              |
+
+Custom renderers can use `RenderContext` by accepting it in their `render()`:
+
+```typescript
+import { BaseRenderer, type RenderContext } from "@alexi/restframework";
+
+class MyRenderer extends BaseRenderer {
+  readonly mediaType = "text/plain";
+  readonly format = "txt";
+
+  override render(data: unknown, context?: RenderContext): string {
+    const method = context?.method ?? "GET";
+    return `${method} ${JSON.stringify(data)}`;
+  }
+}
+```
+
 ---
 
 ## URL Routing

--- a/docs/django-comparison.md
+++ b/docs/django-comparison.md
@@ -51,22 +51,22 @@ differences, and features unique to Alexi.
 
 ### REST Framework
 
-| Feature             | Django REST Framework | Alexi REST Framework | Notes                              |
-| ------------------- | --------------------- | -------------------- | ---------------------------------- |
-| Serializers         | ✅                    | ✅                   | Similar API                        |
-| ModelSerializer     | ✅                    | ✅                   | Auto-generates fields from model   |
-| ViewSets            | ✅                    | ✅                   | ModelViewSet, ReadOnlyModelViewSet |
-| Routers             | ✅                    | ✅                   | DefaultRouter                      |
-| `@action` decorator | ✅                    | ✅                   | Custom actions on ViewSets         |
-| Filter backends     | ✅                    | ✅                   | QueryParamFilterBackend, etc.      |
-| Ordering            | ✅                    | ✅                   | OrderingFilter                     |
-| Search              | ✅                    | ✅                   | SearchFilter                       |
-| Pagination          | ✅                    | ✅                   | PageNumber, LimitOffset, Cursor    |
-| Throttling          | ✅                    | ❌                   | —                                  |
-| Permissions         | ✅                    | ✅                   | ViewSet permission_classes         |
-| Versioning          | ✅                    | ❌                   | —                                  |
-| Content negotiation | ✅                    | ✅                   | JSON, XML, CSV; custom renderers   |
-| Browsable API       | ✅                    | ❌                   | —                                  |
+| Feature             | Django REST Framework | Alexi REST Framework | Notes                               |
+| ------------------- | --------------------- | -------------------- | ----------------------------------- |
+| Serializers         | ✅                    | ✅                   | Similar API                         |
+| ModelSerializer     | ✅                    | ✅                   | Auto-generates fields from model    |
+| ViewSets            | ✅                    | ✅                   | ModelViewSet, ReadOnlyModelViewSet  |
+| Routers             | ✅                    | ✅                   | DefaultRouter                       |
+| `@action` decorator | ✅                    | ✅                   | Custom actions on ViewSets          |
+| Filter backends     | ✅                    | ✅                   | QueryParamFilterBackend, etc.       |
+| Ordering            | ✅                    | ✅                   | OrderingFilter                      |
+| Search              | ✅                    | ✅                   | SearchFilter                        |
+| Pagination          | ✅                    | ✅                   | PageNumber, LimitOffset, Cursor     |
+| Throttling          | ✅                    | ❌                   | —                                   |
+| Permissions         | ✅                    | ✅                   | ViewSet permission_classes          |
+| Versioning          | ✅                    | ❌                   | —                                   |
+| Content negotiation | ✅                    | ✅                   | JSON, XML, CSV; custom renderers    |
+| Browsable API       | ✅                    | ✅                   | HTML interface; login/logout; forms |
 
 ### URL Routing
 
@@ -184,8 +184,6 @@ Features available in Django that Alexi does not currently provide:
 | **Sitemaps**               | XML sitemap generation                         |
 | **GIS support**            | GeoDjango for geographic data                  |
 | **Content types**          | Generic relations framework                    |
-| **Browsable API**          | Interactive API documentation (DRF)            |
-| **Throttling**             | Rate limiting (DRF)                            |
 
 ---
 

--- a/src/restframework/mod.ts
+++ b/src/restframework/mod.ts
@@ -185,6 +185,7 @@ export type {
 
 export {
   BaseRenderer,
+  BrowsableAPIRenderer,
   CSVRenderer,
   JSONRenderer,
   parseAcceptHeader,
@@ -193,7 +194,9 @@ export {
 } from "./renderers/mod.ts";
 
 export type {
+  BrowsableAPIRendererOptions,
   ContentNegotiationOptions,
   NegotiationResult,
+  RenderContext,
   RendererClass,
 } from "./renderers/mod.ts";

--- a/src/restframework/renderers/browsable_api.ts
+++ b/src/restframework/renderers/browsable_api.ts
@@ -1,0 +1,618 @@
+/**
+ * Browsable API Renderer for Alexi REST Framework
+ *
+ * Provides a web-based HTML interface for exploring and interacting with the API,
+ * similar to Django REST Framework's browsable API.
+ *
+ * @module @alexi/restframework/renderers/browsable_api
+ */
+
+import { BaseRenderer, type RenderContext } from "./renderers.ts";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Options for the BrowsableAPIRenderer
+ */
+export interface BrowsableAPIRendererOptions {
+  /** API title shown in the page header */
+  title?: string;
+  /** Token storage key in localStorage (default: "alexi_auth_tokens") */
+  tokenStorageKey?: string;
+  /** Login URL for the login form (default: "/api/auth/login/") */
+  loginUrl?: string;
+  /** Logout URL (default: "/api/auth/logout/") */
+  logoutUrl?: string;
+  /** "Me" URL to fetch current user info (default: "/api/auth/me/") */
+  meUrl?: string;
+}
+
+/**
+ * Render context passed from the ViewSet to the renderer
+ */
+export interface BrowsableAPIContext {
+  /** HTTP request that produced this response */
+  request?: Request;
+  /** HTTP method */
+  method?: string;
+  /** Allowed HTTP methods for the current URL */
+  allowedMethods?: string[];
+  /** Response status code */
+  statusCode?: number;
+  /** Name of the current action */
+  action?: string;
+  /** URL path parameters */
+  params?: Record<string, string>;
+  /** Extra renderer context */
+  [key: string]: unknown;
+}
+
+// ============================================================================
+// BrowsableAPIRenderer
+// ============================================================================
+
+/**
+ * Browsable API Renderer
+ *
+ * Produces an HTML page that allows developers to browse and interact with the
+ * REST API directly from a web browser, similar to DRF's browsable API.
+ *
+ * Features:
+ * - Formatted JSON response with syntax highlighting
+ * - Auto-generated forms for POST/PUT/PATCH requests
+ * - Login/logout with JWT token management
+ * - Pagination controls (next/previous)
+ * - Responsive design
+ *
+ * @example
+ * ```ts
+ * class MyViewSet extends ModelViewSet {
+ *   renderer_classes = [JSONRenderer, BrowsableAPIRenderer];
+ * }
+ * // Browser request (Accept: text/html) → HTML interface
+ * // API request (Accept: application/json) → JSON response
+ * ```
+ */
+export class BrowsableAPIRenderer extends BaseRenderer {
+  readonly mediaType = "text/html";
+  readonly format = "api";
+  override charset = "utf-8";
+
+  /** API title shown in the page header */
+  title = "Alexi REST Framework";
+
+  /** localStorage key for JWT tokens */
+  tokenStorageKey = "alexi_auth_tokens";
+
+  /** Login URL */
+  loginUrl = "/api/auth/login/";
+
+  /** Logout URL */
+  logoutUrl = "/api/auth/logout/";
+
+  /** Current user "me" URL */
+  meUrl = "/api/auth/me/";
+
+  constructor(options?: BrowsableAPIRendererOptions) {
+    super();
+    if (options?.title) this.title = options.title;
+    if (options?.tokenStorageKey) {
+      this.tokenStorageKey = options.tokenStorageKey;
+    }
+    if (options?.loginUrl) this.loginUrl = options.loginUrl;
+    if (options?.logoutUrl) this.logoutUrl = options.logoutUrl;
+    if (options?.meUrl) this.meUrl = options.meUrl;
+  }
+
+  override render(data: unknown, context?: RenderContext): string {
+    const method = context?.method ?? "GET";
+    const url = context?.request?.url ?? "";
+    const urlPath = url ? new URL(url).pathname : "";
+    const statusCode = context?.statusCode ?? 200;
+    const allowedMethods = context?.allowedMethods ?? ["GET"];
+
+    const jsonString = JSON.stringify(data, null, 2);
+    const paginated = isPaginatedResponse(data);
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escapeHtml(urlPath)} – ${escapeHtml(this.title)}</title>
+  <style>${CSS}</style>
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <span class="site-title">${escapeHtml(this.title)}</span>
+      <div class="auth-controls" id="auth-controls">
+        <span class="user-info" id="user-info"></span>
+        <button class="btn btn-sm btn-outline" id="login-btn" onclick="showLoginForm()">Log in</button>
+        <button class="btn btn-sm btn-danger" id="logout-btn" onclick="doLogout()" style="display:none">Log out</button>
+      </div>
+    </div>
+  </header>
+
+  <main class="container">
+    <div class="endpoint-header">
+      <div class="breadcrumb">${buildBreadcrumb(urlPath)}</div>
+      <div class="method-url">
+        <span class="badge badge-${method.toLowerCase()}">${
+      escapeHtml(method)
+    }</span>
+        <span class="url-path">${escapeHtml(urlPath)}</span>
+        <span class="status-code status-${
+      Math.floor(statusCode / 100)
+    }xx">${statusCode}</span>
+      </div>
+    </div>
+
+    ${paginated ? buildPaginationControls(data as PaginatedData) : ""}
+
+    <div class="panel">
+      <div class="panel-header">
+        <h3>Response</h3>
+        <button class="btn btn-sm btn-copy" onclick="copyJson()">Copy</button>
+      </div>
+      <pre class="json-display" id="json-display"><code id="json-code">${
+      syntaxHighlight(jsonString)
+    }</code></pre>
+    </div>
+
+    ${buildRequestForms(urlPath, allowedMethods, data)}
+
+    <div class="panel" id="login-panel" style="display:none">
+      <div class="panel-header"><h3>Log in</h3></div>
+      <form class="api-form" onsubmit="doLogin(event)">
+        <div class="form-group">
+          <label for="login-email">Email</label>
+          <input id="login-email" type="email" class="form-input" required autocomplete="username">
+        </div>
+        <div class="form-group">
+          <label for="login-password">Password</label>
+          <input id="login-password" type="password" class="form-input" required autocomplete="current-password">
+        </div>
+        <div class="form-actions">
+          <button type="submit" class="btn btn-primary">Log in</button>
+          <button type="button" class="btn btn-outline" onclick="hideLoginForm()">Cancel</button>
+        </div>
+        <div class="form-error" id="login-error"></div>
+      </form>
+    </div>
+  </main>
+
+  <script>
+    const TOKEN_KEY = ${JSON.stringify(this.tokenStorageKey)};
+    const LOGIN_URL = ${JSON.stringify(this.loginUrl)};
+    const LOGOUT_URL = ${JSON.stringify(this.logoutUrl)};
+    const ME_URL = ${JSON.stringify(this.meUrl)};
+
+    ${JAVASCRIPT}
+  </script>
+</body>
+</html>`;
+  }
+}
+
+// ============================================================================
+// HTML helpers
+// ============================================================================
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#x27;");
+}
+
+interface PaginatedData {
+  count?: number;
+  next?: string | null;
+  previous?: string | null;
+  results?: unknown[];
+  cursor?: string;
+}
+
+function isPaginatedResponse(data: unknown): data is PaginatedData {
+  if (data === null || typeof data !== "object") return false;
+  const d = data as Record<string, unknown>;
+  return "results" in d && Array.isArray(d.results);
+}
+
+function buildBreadcrumb(urlPath: string): string {
+  const parts = urlPath.replace(/^\/|\/$/g, "").split("/").filter(Boolean);
+  if (parts.length === 0) return '<a href="/">/</a>';
+
+  let accumulated = "";
+  const links = parts.map((part) => {
+    accumulated += `/${part}`;
+    const href = accumulated + "/";
+    return `<a href="${escapeHtml(href)}">${escapeHtml(part)}</a>`;
+  });
+
+  return '<a href="/">/</a> ' + links.join(" / ");
+}
+
+function buildPaginationControls(data: PaginatedData): string {
+  const count = data.count ?? 0;
+  const hasPrev = Boolean(data.previous);
+  const hasNext = Boolean(data.next);
+  if (!hasPrev && !hasNext) return "";
+
+  const prevBtn = hasPrev
+    ? `<a class="btn btn-sm btn-outline" href="${
+      escapeHtml(data.previous!)
+    }">← Previous</a>`
+    : `<button class="btn btn-sm btn-outline" disabled>← Previous</button>`;
+
+  const nextBtn = hasNext
+    ? `<a class="btn btn-sm btn-outline" href="${
+      escapeHtml(data.next!)
+    }">Next →</a>`
+    : `<button class="btn btn-sm btn-outline" disabled>Next →</button>`;
+
+  return `<div class="pagination-bar">
+    <span class="pagination-count">${count} result${
+    count !== 1 ? "s" : ""
+  }</span>
+    <div class="pagination-btns">${prevBtn}${nextBtn}</div>
+  </div>`;
+}
+
+/**
+ * Build form panels for writable HTTP methods
+ */
+function buildRequestForms(
+  _urlPath: string,
+  allowedMethods: string[],
+  _responseData: unknown,
+): string {
+  const writableMethods = allowedMethods.filter((m) =>
+    ["POST", "PUT", "PATCH"].includes(m)
+  );
+
+  if (writableMethods.length === 0) return "";
+
+  const forms = writableMethods.map((m, i) => buildRawForm(m, i === 0)).join(
+    "\n",
+  );
+
+  return `<div class="panel">
+    <div class="panel-header">
+      <h3>Request</h3>
+    </div>
+    <div class="form-tabs" id="form-tabs">
+      ${
+    writableMethods
+      .map(
+        (m, i) =>
+          `<button class="form-tab${
+            i === 0 ? " active" : ""
+          }" onclick="switchTab(this,'${m}-form')">${m}</button>`,
+      )
+      .join("")
+  }
+    </div>
+    ${forms}
+  </div>`;
+}
+
+function buildRawForm(method: string, isFirst: boolean): string {
+  const display = isFirst ? "" : " style='display:none'";
+  return `<div class="tab-panel" id="${method}-form"${display}>
+    <form class="api-form" onsubmit="submitRequest(event,'${method}')">
+      <div class="form-group">
+        <label for="raw-body-${method}">Content (JSON)</label>
+        <textarea id="raw-body-${method}" class="form-input code-input" rows="8" placeholder='{\n  "field": "value"\n}'></textarea>
+      </div>
+      <div class="form-actions">
+        <button type="submit" class="btn btn-primary">${
+    escapeHtml(method)
+  }</button>
+      </div>
+      <div class="form-error" id="error-${method}"></div>
+      <div class="form-success" id="success-${method}"></div>
+    </form>
+  </div>`;
+}
+
+// ============================================================================
+// Syntax highlighter
+// ============================================================================
+
+/**
+ * Server-side syntax highlight of JSON string using HTML spans
+ */
+function syntaxHighlight(json: string): string {
+  return json.replace(
+    /("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+\.?\d*(?:[eE][+-]?\d+)?)/g,
+    (match) => {
+      let cls = "json-number";
+      if (/^"/.test(match)) {
+        if (/:$/.test(match)) {
+          cls = "json-key";
+        } else {
+          cls = "json-string";
+        }
+      } else if (/true|false/.test(match)) {
+        cls = "json-boolean";
+      } else if (/null/.test(match)) {
+        cls = "json-null";
+      }
+      return `<span class="${cls}">${escapeHtml(match)}</span>`;
+    },
+  );
+}
+
+// ============================================================================
+// Inline CSS
+// ============================================================================
+
+const CSS = `
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  :root {
+    --bg: #f8f9fa;
+    --surface: #ffffff;
+    --border: #e1e4e8;
+    --text: #24292e;
+    --text-muted: #6a737d;
+    --primary: #0366d6;
+    --primary-dark: #0256c0;
+    --danger: #d73a49;
+    --success: #22863a;
+    --radius: 6px;
+    --shadow: 0 1px 3px rgba(0,0,0,.1);
+  }
+
+  body { background: var(--bg); color: var(--text); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.5; }
+
+  a { color: var(--primary); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+
+  /* Header */
+  .site-header { background: #24292e; color: #fff; padding: 0 1rem; position: sticky; top: 0; z-index: 100; box-shadow: 0 1px 4px rgba(0,0,0,.3); }
+  .header-inner { max-width: 1200px; margin: 0 auto; display: flex; align-items: center; justify-content: space-between; height: 48px; }
+  .site-title { font-weight: 600; font-size: 16px; color: #fff; }
+  .auth-controls { display: flex; align-items: center; gap: .5rem; }
+  .user-info { color: #ccc; font-size: 13px; }
+
+  /* Container */
+  .container { max-width: 1200px; margin: 0 auto; padding: 1.5rem 1rem; }
+
+  /* Endpoint header */
+  .endpoint-header { margin-bottom: 1rem; }
+  .breadcrumb { color: var(--text-muted); font-size: 13px; margin-bottom: .5rem; }
+  .breadcrumb a { color: var(--text-muted); }
+  .method-url { display: flex; align-items: center; gap: .75rem; flex-wrap: wrap; }
+  .url-path { font-family: monospace; font-size: 16px; font-weight: 500; }
+
+  /* Badges */
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 12px; font-weight: 700; letter-spacing: .05em; text-transform: uppercase; }
+  .badge-get { background: #0075ca; color: #fff; }
+  .badge-post { background: #28a745; color: #fff; }
+  .badge-put { background: #6f42c1; color: #fff; }
+  .badge-patch { background: #fd7e14; color: #fff; }
+  .badge-delete { background: #dc3545; color: #fff; }
+  .badge-options, .badge-head { background: #6c757d; color: #fff; }
+  .status-code { font-family: monospace; font-weight: 700; }
+  .status-2xx { color: var(--success); }
+  .status-3xx { color: #6f42c1; }
+  .status-4xx { color: #e36209; }
+  .status-5xx { color: var(--danger); }
+
+  /* Panel */
+  .panel { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); box-shadow: var(--shadow); margin-bottom: 1rem; overflow: hidden; }
+  .panel-header { display: flex; align-items: center; justify-content: space-between; padding: .6rem 1rem; border-bottom: 1px solid var(--border); background: #f6f8fa; }
+  .panel-header h3 { font-size: 14px; font-weight: 600; }
+
+  /* JSON display */
+  .json-display { padding: 1rem; overflow: auto; font-size: 13px; line-height: 1.6; background: #1e1e1e; color: #d4d4d4; max-height: 60vh; }
+  .json-key { color: #9cdcfe; }
+  .json-string { color: #ce9178; }
+  .json-number { color: #b5cea8; }
+  .json-boolean { color: #569cd6; }
+  .json-null { color: #569cd6; }
+
+  /* Pagination */
+  .pagination-bar { display: flex; align-items: center; justify-content: space-between; background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: .5rem 1rem; margin-bottom: 1rem; box-shadow: var(--shadow); }
+  .pagination-count { color: var(--text-muted); font-size: 13px; }
+  .pagination-btns { display: flex; gap: .5rem; }
+
+  /* Forms */
+  .form-tabs { display: flex; gap: 0; border-bottom: 1px solid var(--border); padding: 0 1rem; background: #f6f8fa; }
+  .form-tab { background: none; border: none; border-bottom: 2px solid transparent; padding: .6rem .75rem; font-size: 13px; font-weight: 600; cursor: pointer; color: var(--text-muted); margin-bottom: -1px; }
+  .form-tab.active { color: var(--primary); border-bottom-color: var(--primary); }
+  .tab-panel { padding: 1rem; }
+  .api-form { display: flex; flex-direction: column; gap: .75rem; padding: 1rem; }
+  .form-group { display: flex; flex-direction: column; gap: .25rem; }
+  .form-group label { font-size: 13px; font-weight: 600; }
+  .form-input { padding: .5rem .75rem; border: 1px solid var(--border); border-radius: var(--radius); font-size: 13px; font-family: inherit; background: var(--surface); color: var(--text); }
+  .form-input:focus { outline: none; border-color: var(--primary); box-shadow: 0 0 0 3px rgba(3,102,214,.15); }
+  .code-input { font-family: monospace; resize: vertical; }
+  .form-actions { display: flex; gap: .5rem; }
+  .form-error { color: var(--danger); font-size: 13px; min-height: 1.2em; }
+  .form-success { color: var(--success); font-size: 13px; min-height: 1.2em; }
+
+  /* Buttons */
+  .btn { display: inline-flex; align-items: center; justify-content: center; padding: .375rem .75rem; border: 1px solid transparent; border-radius: var(--radius); font-size: 14px; font-weight: 500; cursor: pointer; transition: background .15s, border-color .15s; }
+  .btn-sm { padding: .25rem .5rem; font-size: 12px; }
+  .btn-primary { background: var(--primary); color: #fff; border-color: var(--primary); }
+  .btn-primary:hover { background: var(--primary-dark); border-color: var(--primary-dark); }
+  .btn-outline { background: transparent; color: var(--text); border-color: var(--border); }
+  .btn-outline:hover { background: var(--bg); }
+  .btn-danger { background: var(--danger); color: #fff; border-color: var(--danger); }
+  .btn-danger:hover { background: #cb2431; }
+  .btn-copy { background: transparent; color: var(--text-muted); border-color: var(--border); font-size: 12px; }
+  .btn-copy:hover { background: var(--bg); }
+  button:disabled { opacity: .5; cursor: not-allowed; }
+
+  @media (max-width: 640px) {
+    .method-url { flex-direction: column; align-items: flex-start; }
+    .header-inner { flex-wrap: wrap; height: auto; padding: .5rem 0; gap: .5rem; }
+  }
+`;
+
+// ============================================================================
+// Inline JavaScript
+// ============================================================================
+
+const JAVASCRIPT = `
+  // ---- Auth ----
+  function getTokens() {
+    try { return JSON.parse(localStorage.getItem(TOKEN_KEY) || "null"); } catch { return null; }
+  }
+  function setTokens(tokens) {
+    localStorage.setItem(TOKEN_KEY, JSON.stringify(tokens));
+  }
+  function clearTokens() {
+    localStorage.removeItem(TOKEN_KEY);
+  }
+  function getAccessToken() {
+    const t = getTokens();
+    return t && t.accessToken ? t.accessToken : null;
+  }
+
+  // ---- UI updates ----
+  function updateAuthUI(user) {
+    const info = document.getElementById("user-info");
+    const loginBtn = document.getElementById("login-btn");
+    const logoutBtn = document.getElementById("logout-btn");
+    if (user) {
+      info.textContent = user.email || ("User #" + (user.id || ""));
+      loginBtn.style.display = "none";
+      logoutBtn.style.display = "";
+    } else {
+      info.textContent = "";
+      loginBtn.style.display = "";
+      logoutBtn.style.display = "none";
+    }
+  }
+
+  async function fetchCurrentUser() {
+    const token = getAccessToken();
+    if (!token) { updateAuthUI(null); return; }
+    try {
+      const res = await fetch(ME_URL, { headers: { Authorization: "Bearer " + token } });
+      if (res.ok) { updateAuthUI(await res.json()); }
+      else { updateAuthUI(null); }
+    } catch { updateAuthUI(null); }
+  }
+
+  // ---- Login / Logout ----
+  function showLoginForm() {
+    document.getElementById("login-panel").style.display = "";
+    document.getElementById("login-btn").style.display = "none";
+  }
+  function hideLoginForm() {
+    document.getElementById("login-panel").style.display = "none";
+    const token = getAccessToken();
+    document.getElementById("login-btn").style.display = token ? "none" : "";
+  }
+
+  async function doLogin(e) {
+    e.preventDefault();
+    const email = document.getElementById("login-email").value;
+    const password = document.getElementById("login-password").value;
+    const errorEl = document.getElementById("login-error");
+    errorEl.textContent = "";
+    try {
+      const res = await fetch(LOGIN_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setTokens(data);
+        hideLoginForm();
+        fetchCurrentUser();
+      } else {
+        errorEl.textContent = data.detail || data.error || "Login failed";
+      }
+    } catch (err) {
+      errorEl.textContent = "Network error: " + err.message;
+    }
+  }
+
+  async function doLogout() {
+    const token = getAccessToken();
+    if (token) {
+      try {
+        await fetch(LOGOUT_URL, {
+          method: "POST",
+          headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
+        });
+      } catch {}
+    }
+    clearTokens();
+    updateAuthUI(null);
+  }
+
+  // ---- Form tabs ----
+  function switchTab(btn, panelId) {
+    document.querySelectorAll(".form-tab").forEach(t => t.classList.remove("active"));
+    document.querySelectorAll(".tab-panel").forEach(p => p.style.display = "none");
+    btn.classList.add("active");
+    const panel = document.getElementById(panelId);
+    if (panel) panel.style.display = "";
+  }
+
+  // ---- Submit request ----
+  async function submitRequest(e, method) {
+    e.preventDefault();
+    const bodyEl = document.getElementById("raw-body-" + method);
+    const errorEl = document.getElementById("error-" + method);
+    const successEl = document.getElementById("success-" + method);
+    errorEl.textContent = "";
+    successEl.textContent = "";
+
+    let body;
+    try {
+      body = bodyEl.value.trim() ? JSON.parse(bodyEl.value) : undefined;
+    } catch {
+      errorEl.textContent = "Invalid JSON";
+      return;
+    }
+
+    const headers = { "Content-Type": "application/json" };
+    const token = getAccessToken();
+    if (token) headers["Authorization"] = "Bearer " + token;
+
+    try {
+      const res = await fetch(window.location.href.split("?")[0], {
+        method,
+        headers,
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+      });
+      const data = await res.json();
+      if (res.ok) {
+        successEl.textContent = method + " " + res.status + " OK";
+        // Refresh page to show updated data
+        setTimeout(() => window.location.reload(), 800);
+      } else {
+        errorEl.textContent = res.status + ": " + (data.detail || data.error || JSON.stringify(data));
+      }
+    } catch (err) {
+      errorEl.textContent = "Network error: " + err.message;
+    }
+  }
+
+  // ---- Copy JSON ----
+  function copyJson() {
+    const code = document.getElementById("json-code");
+    const text = code ? code.textContent : "";
+    navigator.clipboard.writeText(text).then(() => {
+      const btn = document.querySelector(".btn-copy");
+      if (btn) { btn.textContent = "Copied!"; setTimeout(() => btn.textContent = "Copy", 1500); }
+    }).catch(() => {});
+  }
+
+  // ---- Init ----
+  fetchCurrentUser();
+`;

--- a/src/restframework/renderers/browsable_api_test.ts
+++ b/src/restframework/renderers/browsable_api_test.ts
@@ -1,0 +1,404 @@
+/**
+ * Tests for BrowsableAPIRenderer
+ *
+ * @module @alexi/restframework/renderers/browsable_api_test
+ */
+
+import { assertEquals, assertStringIncludes } from "jsr:@std/assert@1";
+import { BrowsableAPIRenderer } from "./browsable_api.ts";
+import { JSONRenderer, type RenderContext } from "./renderers.ts";
+import { ViewSet, type ViewSetContext } from "../viewsets/viewset.ts";
+
+// ============================================================================
+// BrowsableAPIRenderer unit tests
+// ============================================================================
+
+Deno.test("BrowsableAPIRenderer: mediaType is text/html", () => {
+  const renderer = new BrowsableAPIRenderer();
+  assertEquals(renderer.mediaType, "text/html");
+});
+
+Deno.test("BrowsableAPIRenderer: format is api", () => {
+  const renderer = new BrowsableAPIRenderer();
+  assertEquals(renderer.format, "api");
+});
+
+Deno.test("BrowsableAPIRenderer: renders valid HTML document", () => {
+  const renderer = new BrowsableAPIRenderer();
+  const html = renderer.render({ id: 1, name: "Test" });
+  assertStringIncludes(html, "<!DOCTYPE html>");
+  assertStringIncludes(html, "<html");
+  assertStringIncludes(html, "</html>");
+});
+
+Deno.test("BrowsableAPIRenderer: includes default title", () => {
+  const renderer = new BrowsableAPIRenderer();
+  const html = renderer.render({});
+  assertStringIncludes(html, "Alexi REST Framework");
+});
+
+Deno.test("BrowsableAPIRenderer: custom title option", () => {
+  const renderer = new BrowsableAPIRenderer({ title: "My API" });
+  const html = renderer.render({});
+  assertStringIncludes(html, "My API");
+});
+
+Deno.test("BrowsableAPIRenderer: custom token storage key", () => {
+  const renderer = new BrowsableAPIRenderer({
+    tokenStorageKey: "my_api_tokens",
+  });
+  const html = renderer.render({});
+  assertStringIncludes(html, "my_api_tokens");
+});
+
+Deno.test("BrowsableAPIRenderer: custom login URL", () => {
+  const renderer = new BrowsableAPIRenderer({ loginUrl: "/v2/auth/login/" });
+  const html = renderer.render({});
+  assertStringIncludes(html, "/v2/auth/login/");
+});
+
+Deno.test("BrowsableAPIRenderer: renders JSON data with syntax highlighting", () => {
+  const renderer = new BrowsableAPIRenderer();
+  const html = renderer.render({ id: 1, name: "Alice" });
+  // Key should be highlighted
+  assertStringIncludes(html, "json-key");
+  // String value highlighted
+  assertStringIncludes(html, "json-string");
+  // Number value highlighted
+  assertStringIncludes(html, "json-number");
+});
+
+Deno.test("BrowsableAPIRenderer: renders boolean and null highlighting", () => {
+  const renderer = new BrowsableAPIRenderer();
+  const html = renderer.render({ active: true, deleted: false, note: null });
+  assertStringIncludes(html, "json-boolean");
+  assertStringIncludes(html, "json-null");
+});
+
+Deno.test("BrowsableAPIRenderer: shows URL path from context", () => {
+  const renderer = new BrowsableAPIRenderer();
+  const context: RenderContext = {
+    request: new Request("http://localhost/api/users/"),
+    method: "GET",
+    allowedMethods: ["GET"],
+    statusCode: 200,
+  };
+  const html = renderer.render({ results: [] }, context);
+  assertStringIncludes(html, "/api/users/");
+});
+
+Deno.test("BrowsableAPIRenderer: shows HTTP method badge", () => {
+  const renderer = new BrowsableAPIRenderer();
+  const context: RenderContext = {
+    request: new Request("http://localhost/api/users/"),
+    method: "POST",
+    allowedMethods: ["GET", "POST"],
+    statusCode: 201,
+  };
+  const html = renderer.render({ id: 5 }, context);
+  assertStringIncludes(html, "badge-post");
+  assertStringIncludes(html, ">POST<");
+});
+
+Deno.test("BrowsableAPIRenderer: shows status code", () => {
+  const renderer = new BrowsableAPIRenderer();
+  const context: RenderContext = {
+    request: new Request("http://localhost/api/items/"),
+    method: "GET",
+    statusCode: 200,
+  };
+  const html = renderer.render({ count: 0 }, context);
+  assertStringIncludes(html, ">200<");
+});
+
+Deno.test("BrowsableAPIRenderer: shows 2xx status class", () => {
+  const renderer = new BrowsableAPIRenderer();
+  const context: RenderContext = {
+    request: new Request("http://localhost/api/items/"),
+    method: "GET",
+    statusCode: 200,
+  };
+  const html = renderer.render({}, context);
+  assertStringIncludes(html, "status-2xx");
+});
+
+Deno.test("BrowsableAPIRenderer: shows 4xx status class", () => {
+  const renderer = new BrowsableAPIRenderer();
+  const context: RenderContext = {
+    request: new Request("http://localhost/api/items/"),
+    method: "GET",
+    statusCode: 404,
+  };
+  const html = renderer.render({ error: "Not found" }, context);
+  assertStringIncludes(html, "status-4xx");
+});
+
+Deno.test("BrowsableAPIRenderer: shows breadcrumb navigation", () => {
+  const renderer = new BrowsableAPIRenderer();
+  const context: RenderContext = {
+    request: new Request("http://localhost/api/v1/users/"),
+    method: "GET",
+    allowedMethods: ["GET"],
+    statusCode: 200,
+  };
+  const html = renderer.render([], context);
+  assertStringIncludes(html, "breadcrumb");
+  assertStringIncludes(html, "api");
+  assertStringIncludes(html, "users");
+});
+
+Deno.test("BrowsableAPIRenderer: shows request form for POST", () => {
+  const renderer = new BrowsableAPIRenderer();
+  const context: RenderContext = {
+    request: new Request("http://localhost/api/items/"),
+    method: "GET",
+    allowedMethods: ["GET", "POST"],
+    statusCode: 200,
+  };
+  const html = renderer.render([], context);
+  assertStringIncludes(html, "raw-body-POST");
+  assertStringIncludes(html, "submitRequest");
+});
+
+Deno.test("BrowsableAPIRenderer: shows request form for PUT and PATCH", () => {
+  const renderer = new BrowsableAPIRenderer();
+  const context: RenderContext = {
+    request: new Request("http://localhost/api/items/1/"),
+    method: "GET",
+    allowedMethods: ["GET", "PUT", "PATCH", "DELETE"],
+    statusCode: 200,
+  };
+  const html = renderer.render({ id: 1 }, context);
+  assertStringIncludes(html, "raw-body-PUT");
+  assertStringIncludes(html, "raw-body-PATCH");
+});
+
+Deno.test("BrowsableAPIRenderer: no request form for read-only endpoint", () => {
+  const renderer = new BrowsableAPIRenderer();
+  const context: RenderContext = {
+    request: new Request("http://localhost/api/health/"),
+    method: "GET",
+    allowedMethods: ["GET"],
+    statusCode: 200,
+  };
+  const html = renderer.render({ status: "ok" }, context);
+  // No form panel should be rendered (the "Request" panel heading is not shown)
+  assertEquals(html.includes("<h3>Request</h3>"), false);
+});
+
+Deno.test("BrowsableAPIRenderer: shows pagination controls for paginated response", () => {
+  const renderer = new BrowsableAPIRenderer();
+  const context: RenderContext = {
+    request: new Request("http://localhost/api/items/"),
+    method: "GET",
+    allowedMethods: ["GET"],
+    statusCode: 200,
+  };
+  const html = renderer.render(
+    {
+      count: 100,
+      next: "http://localhost/api/items/?page=2",
+      previous: null,
+      results: [{ id: 1 }],
+    },
+    context,
+  );
+  assertStringIncludes(html, "pagination-bar");
+  assertStringIncludes(html, "100 results");
+  assertStringIncludes(html, "Next →");
+});
+
+Deno.test("BrowsableAPIRenderer: pagination previous link is disabled when null", () => {
+  const renderer = new BrowsableAPIRenderer();
+  const context: RenderContext = {
+    request: new Request("http://localhost/api/items/"),
+    method: "GET",
+    allowedMethods: ["GET"],
+    statusCode: 200,
+  };
+  const html = renderer.render(
+    {
+      count: 50,
+      next: null,
+      previous: "http://localhost/api/items/?page=1",
+      results: [],
+    },
+    context,
+  );
+  assertStringIncludes(html, "← Previous");
+  assertStringIncludes(html, "disabled");
+});
+
+Deno.test("BrowsableAPIRenderer: no pagination for non-paginated response", () => {
+  const renderer = new BrowsableAPIRenderer();
+  const html = renderer.render({ id: 1, name: "Alice" });
+  // The pagination-btns div is only rendered when pagination controls are shown
+  assertEquals(html.includes('class="pagination-btns"'), false);
+});
+
+Deno.test("BrowsableAPIRenderer: includes login form", () => {
+  const renderer = new BrowsableAPIRenderer();
+  const html = renderer.render({});
+  assertStringIncludes(html, "login-panel");
+  assertStringIncludes(html, "login-email");
+  assertStringIncludes(html, "login-password");
+  assertStringIncludes(html, "doLogin");
+});
+
+Deno.test("BrowsableAPIRenderer: includes logout button", () => {
+  const renderer = new BrowsableAPIRenderer();
+  const html = renderer.render({});
+  assertStringIncludes(html, "doLogout");
+});
+
+Deno.test("BrowsableAPIRenderer: includes copy JSON button", () => {
+  const renderer = new BrowsableAPIRenderer();
+  const html = renderer.render({});
+  assertStringIncludes(html, "copyJson");
+  assertStringIncludes(html, "Copy");
+});
+
+Deno.test("BrowsableAPIRenderer: includes inline CSS", () => {
+  const renderer = new BrowsableAPIRenderer();
+  const html = renderer.render({});
+  assertStringIncludes(html, "<style>");
+  assertStringIncludes(html, ".json-display");
+});
+
+Deno.test("BrowsableAPIRenderer: includes inline JavaScript", () => {
+  const renderer = new BrowsableAPIRenderer();
+  const html = renderer.render({});
+  assertStringIncludes(html, "<script>");
+  assertStringIncludes(html, "fetchCurrentUser");
+});
+
+Deno.test("BrowsableAPIRenderer: escapes HTML special characters in data", () => {
+  const renderer = new BrowsableAPIRenderer();
+  const html = renderer.render({ message: '<script>alert("xss")</script>' });
+  // The HTML-escaped version should appear, not the raw script tag
+  assertStringIncludes(html, "&lt;script&gt;");
+  assertEquals(
+    html.includes('<script>alert("xss")</script>'),
+    false,
+  );
+});
+
+Deno.test("BrowsableAPIRenderer: escapes HTML in URL path", () => {
+  const renderer = new BrowsableAPIRenderer();
+  const context: RenderContext = {
+    // Angle brackets are percent-encoded by the URL constructor
+    request: new Request(
+      "http://localhost/api/%3Cbad%3E&path/",
+    ),
+    method: "GET",
+    allowedMethods: ["GET"],
+    statusCode: 200,
+  };
+  const html = renderer.render({}, context);
+  // The & in the path should be escaped to &amp; in HTML output
+  assertStringIncludes(html, "&amp;path");
+});
+
+Deno.test("BrowsableAPIRenderer: renders array response", () => {
+  const renderer = new BrowsableAPIRenderer();
+  const html = renderer.render([{ id: 1 }, { id: 2 }]);
+  assertStringIncludes(html, "json-display");
+  assertStringIncludes(html, "json-number");
+});
+
+Deno.test("BrowsableAPIRenderer: singular count label", () => {
+  const renderer = new BrowsableAPIRenderer();
+  const context: RenderContext = {
+    request: new Request("http://localhost/api/items/"),
+    method: "GET",
+    allowedMethods: ["GET"],
+    statusCode: 200,
+  };
+  const html = renderer.render(
+    {
+      count: 1,
+      next: "http://localhost/api/items/?page=2",
+      previous: null,
+      results: [{ id: 1 }],
+    },
+    context,
+  );
+  assertStringIncludes(html, "1 result");
+  assertEquals(html.includes("1 results"), false);
+});
+
+// ============================================================================
+// ViewSet integration tests
+// ============================================================================
+
+Deno.test("ViewSet.asView: returns HTML for Accept: text/html", async () => {
+  class HtmlViewSet extends ViewSet {
+    override renderer_classes = [JSONRenderer, BrowsableAPIRenderer];
+
+    override async list(_context: ViewSetContext): Promise<Response> {
+      return Response.json([{ id: 1 }]);
+    }
+  }
+
+  const view = HtmlViewSet.asView(
+    { GET: "list" } as Record<string, string>,
+  );
+  const request = new Request("http://localhost/api/items/", {
+    headers: { Accept: "text/html" },
+  });
+  const response = await view(request, {});
+
+  assertEquals(response.status, 200);
+  const ct = response.headers.get("Content-Type") ?? "";
+  assertStringIncludes(ct, "text/html");
+  const html = await response.text();
+  assertStringIncludes(html, "<!DOCTYPE html>");
+});
+
+Deno.test("ViewSet.asView: returns JSON when Accept is application/json", async () => {
+  class MixedViewSet extends ViewSet {
+    override renderer_classes = [JSONRenderer, BrowsableAPIRenderer];
+
+    override async list(_context: ViewSetContext): Promise<Response> {
+      return Response.json([{ id: 1 }]);
+    }
+  }
+
+  const view = MixedViewSet.asView(
+    { GET: "list" } as Record<string, string>,
+  );
+  const request = new Request("http://localhost/api/items/", {
+    headers: { Accept: "application/json" },
+  });
+  const response = await view(request, {});
+
+  assertEquals(response.status, 200);
+  const ct = response.headers.get("Content-Type") ?? "";
+  assertStringIncludes(ct, "application/json");
+});
+
+Deno.test("ViewSet.asView: passes allowed methods to browsable renderer", async () => {
+  class AllowedViewSet extends ViewSet {
+    override renderer_classes = [JSONRenderer, BrowsableAPIRenderer];
+
+    override async list(_context: ViewSetContext): Promise<Response> {
+      return Response.json([]);
+    }
+
+    override async create(_context: ViewSetContext): Promise<Response> {
+      return Response.json({}, { status: 201 });
+    }
+  }
+
+  const view = AllowedViewSet.asView(
+    { GET: "list", POST: "create" } as Record<string, string>,
+  );
+  const request = new Request("http://localhost/api/items/", {
+    headers: { Accept: "text/html" },
+  });
+  const response = await view(request, {});
+
+  const html = await response.text();
+  // Both methods should be in the page (POST form shown)
+  assertStringIncludes(html, "raw-body-POST");
+});

--- a/src/restframework/renderers/mod.ts
+++ b/src/restframework/renderers/mod.ts
@@ -17,5 +17,10 @@ export {
 export type {
   ContentNegotiationOptions,
   NegotiationResult,
+  RenderContext,
   RendererClass,
 } from "./renderers.ts";
+
+export { BrowsableAPIRenderer } from "./browsable_api.ts";
+
+export type { BrowsableAPIRendererOptions } from "./browsable_api.ts";

--- a/src/restframework/viewsets/viewset.ts
+++ b/src/restframework/viewsets/viewset.ts
@@ -11,6 +11,7 @@ import type { BasePermission, PermissionClass } from "../permissions/mod.ts";
 import {
   type BaseRenderer,
   JSONRenderer,
+  type RenderContext,
   type RendererClass,
   renderResponse,
   selectRenderer,
@@ -423,8 +424,21 @@ export class ViewSet {
       // Call the action
       try {
         const actionResponse = await actionMethod.call(viewset, context);
+        // Build render context for context-aware renderers (e.g. BrowsableAPIRenderer)
+        const renderContext: RenderContext = {
+          request,
+          method: request.method.toUpperCase(),
+          allowedMethods: Object.keys(actions),
+          statusCode: actionResponse.status,
+          action: actionName,
+          params,
+        };
         // Re-render the response using the negotiated renderer
-        return await renderResponse(actionResponse, negotiated.renderer);
+        return await renderResponse(
+          actionResponse,
+          negotiated.renderer,
+          renderContext,
+        );
       } catch (error) {
         // Re-throw permission errors to return proper status codes
         if (


### PR DESCRIPTION
## Summary

- Adds `BrowsableAPIRenderer` that renders interactive HTML pages for API endpoints when accessed from a browser (`Accept: text/html`)
- Adds `RenderContext` type and threads it through `renderResponse()` and `BaseRenderer.render()` so renderers have access to request metadata
- Updates `ViewSet.asView()` to build and pass a `RenderContext` (request, method, allowedMethods, statusCode, action, params) to renderers

## Features

- Syntax-highlighted JSON response display
- Auto-generated JSON request forms for POST/PUT/PATCH
- Breadcrumb navigation and HTTP method badge with status code
- Pagination controls (next/previous links)
- Login/logout with JWT token management
- Copy-to-clipboard for response data
- Mobile-responsive design
- Fully customizable via subclassing or constructor options (`title`, `tokenStorageKey`, `loginUrl`, `logoutUrl`, `meUrl`)

## Tests

33 tests added in `browsable_api_test.ts`, all passing.

Closes #72