### PR TITLE
feat(db): enable fully reversible data migrations

### DIFF
--- a/src/create/templates/skills/alexi_db_skill_md.ts
+++ b/src/create/templates/skills/alexi_db_skill_md.ts
@@ -290,6 +290,9 @@ await schema.addField(UserModel, "bio", new TextField({ blank: true }));
 // Deprecate a field (safe removal with rollback support)
 await schema.deprecateField(UserModel, "legacyField");
 
+// Drop a field (permanent deletion - use with caution)
+await schema.dropField(UserModel, "temporaryField");
+
 // Alter a field
 await schema.alterField(UserModel, "name", new CharField({ maxLength: 200 }));
 
@@ -318,6 +321,27 @@ await schema.deprecateField(UserModel, "phoneNumber");
 
 // Clean up deprecated items older than 30 days
 // deno task manage migrate --cleanup
+\`\`\`
+
+### Non-Reversible Migrations
+
+Migrations without a \`backwards()\` method cannot be rolled back:
+
+\`\`\`typescript
+import { DataMigration, MigrationSchemaEditor } from "@alexi/db/migrations";
+
+export default class Migration0003 extends DataMigration {
+  name = "0003_normalize_emails";
+  dependencies = ["0002_add_email"];
+
+  async forwards(_schema: MigrationSchemaEditor): Promise<void> {
+    // Transform data in-place
+  }
+
+  // No backwards() = migration cannot be reversed
+  // - Warning shown when applying
+  // - Rollback blocked with error
+}
 \`\`\`
 
 ## Database Setup

--- a/src/db/commands/sqlmigrate.ts
+++ b/src/db/commands/sqlmigrate.ts
@@ -136,10 +136,9 @@ export class SqlmigrateCommand extends BaseCommand {
 
       // Check if backward is possible
       if (backwards && !migration.migration.canReverse()) {
-        this.warn(
-          `Migration '${migration.migration.name}' is marked as irreversible.`,
+        return failure(
+          `Migration '${migration.migration.name}' cannot be reversed (no backwards() method).`,
         );
-        this.warn("The backwards SQL may be incomplete or incorrect.\n");
       }
 
       // Create schema editor in dry-run mode
@@ -164,6 +163,11 @@ export class SqlmigrateCommand extends BaseCommand {
 
       // Execute the migration in dry-run mode
       if (backwards) {
+        if (!migration.migration.backwards) {
+          return failure(
+            `Migration ${migration.migration.getFullName()} cannot be reversed (no backwards() method)`,
+          );
+        }
         await migration.migration.backwards(migrationSchemaEditor);
       } else {
         await migration.migration.forwards(migrationSchemaEditor);

--- a/src/db/migrations/schema_editor.ts
+++ b/src/db/migrations/schema_editor.ts
@@ -308,6 +308,26 @@ export class MigrationSchemaEditor {
   }
 
   /**
+   * Drop a field from a model
+   *
+   * **Warning:** This permanently deletes the column and its data.
+   * Use `deprecateField()` instead if you want to preserve data.
+   *
+   * This is primarily useful in `backwards()` methods to drop fields
+   * that were added in `forwards()`.
+   *
+   * @param model - Model class
+   * @param fieldName - Field name to drop
+   */
+  async dropField(model: typeof Model, fieldName: string): Promise<void> {
+    const tableName = this._getTableName(model);
+
+    this._log(`Dropping field ${fieldName} from ${model.name}...`);
+    await this._backendEditor.dropColumn(tableName, fieldName);
+    this._logVerbose(`  Dropped column: ${fieldName}`);
+  }
+
+  /**
    * Deprecate a field (rename column to _deprecated_*)
    *
    * This preserves the data but frees the column name for reuse.

--- a/src/db/tests/migrations_test.ts
+++ b/src/db/tests/migrations_test.ts
@@ -109,11 +109,7 @@ class IrreversibleMigration extends DataMigration {
   override dependencies = ["0002_add_user_email"];
 
   override async forwards(_schema: MigrationSchemaEditor): Promise<void> {
-    // Data migration logic
-  }
-
-  override async backwards(_schema: MigrationSchemaEditor): Promise<void> {
-    throw new Error("This migration cannot be reversed");
+    // Data migration logic - no backwards() method means it cannot be reversed
   }
 }
 
@@ -131,15 +127,13 @@ Deno.test("Migration - dependencies property", () => {
   assertEquals(migration.dependencies, ["0001_initial"]);
 });
 
-Deno.test("Migration - reversible property defaults to true", () => {
+Deno.test("Migration - canReverse() returns true when backwards() is implemented", () => {
   const migration = new Migration0001();
-  assertEquals(migration.reversible, true);
   assertEquals(migration.canReverse(), true);
 });
 
-Deno.test("DataMigration - reversible defaults to false", () => {
+Deno.test("DataMigration - canReverse() returns false when backwards() is not implemented", () => {
   const migration = new IrreversibleMigration();
-  assertEquals(migration.reversible, false);
   assertEquals(migration.canReverse(), false);
 });
 


### PR DESCRIPTION
## Summary

Closes #97

- Add `dropField()` method to `MigrationSchemaEditor` for permanent field deletion
- Make `backwards()` optional in `Migration` base class (no longer abstract)
- Remove `reversible` property - reversibility is now detected from `backwards()` implementation
- Block rollback with error for migrations without `backwards()`
- Warn when applying non-reversible migrations
- Skip non-reversible migrations during `--test` mode with warning

## Changes

### Core Changes
- `MigrationSchemaEditor.dropField()` - permanently deletes a column (for cleanup in reversible migrations)
- `Migration.backwards?()` - now optional, omit for non-reversible migrations
- `Migration.canReverse()` - returns `true` if `backwards()` is implemented

### Behavior Changes
| Scenario | Before | After |
|----------|--------|-------|
| Apply migration without `backwards()` | No warning | Warning shown |
| Rollback migration without `backwards()` | Warning only | **Error and blocked** |
| Test mode on migration without `backwards()` | Warning | Warning and skip |

### Documentation
- Updated `docs/db/migrations.md` with new patterns
- Updated `@alexi/create` skill template