### PR TITLE
feat(restframework): add authentication_classes and JWTAuthentication (#102)

### DIFF
--- a/src/create/tests/e2e_utils.ts
+++ b/src/create/tests/e2e_utils.ts
@@ -163,6 +163,8 @@ async function patchProjectForLocalAlexi(projectPath: string): Promise<void> {
     "@alexi/webui/bindings": `${alexiRoot}src/webui/bindings.ts`,
     "@alexi/staticfiles": `${alexiRoot}src/staticfiles/mod.ts`,
     "@alexi/restframework": `${alexiRoot}src/restframework/mod.ts`,
+    "@alexi/restframework/authentication":
+      `${alexiRoot}src/restframework/authentication/mod.ts`,
     "@alexi/auth": `${alexiRoot}src/auth/mod.ts`,
     "@alexi/admin": `${alexiRoot}src/admin/mod.ts`,
     "@alexi/capacitor": `${alexiRoot}src/capacitor/mod.ts`,

--- a/src/restframework/authentication/authentication.ts
+++ b/src/restframework/authentication/authentication.ts
@@ -1,0 +1,269 @@
+/**
+ * Authentication classes for Alexi REST Framework
+ *
+ * Provides DRF-style authentication classes for ViewSet-level user identification.
+ * Authentication runs before permission checks and populates context.user.
+ *
+ * @module @alexi/restframework/authentication/authentication
+ */
+
+import type { ViewSetContext } from "../viewsets/viewset.ts";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * The authenticated user shape populated by authentication classes
+ */
+export type AuthenticatedUser = NonNullable<ViewSetContext["user"]>;
+
+/**
+ * Authentication class constructor type
+ */
+export interface AuthenticationClass {
+  new (): BaseAuthentication;
+}
+
+// ============================================================================
+// Base Authentication
+// ============================================================================
+
+/**
+ * Base authentication class
+ *
+ * All authentication classes should extend this class and implement
+ * the authenticate method. Return a user object on success, or null
+ * to indicate that this authenticator does not apply to the request
+ * (allowing the next authenticator in the list to try).
+ *
+ * Authentication classes are tried in order. The first one that returns
+ * a non-null user wins. If all return null, context.user remains undefined.
+ *
+ * @example
+ * ```ts
+ * class ApiKeyAuthentication extends BaseAuthentication {
+ *   async authenticate(context: ViewSetContext): Promise<AuthenticatedUser | null> {
+ *     const apiKey = context.request.headers.get("X-API-Key");
+ *     if (!apiKey) return null;
+ *
+ *     const user = await UserModel.objects.filter({ apiKey }).first();
+ *     if (!user) return null;
+ *
+ *     return {
+ *       id: user.id.get(),
+ *       email: user.email.get(),
+ *       isAdmin: user.isAdmin.get(),
+ *     };
+ *   }
+ * }
+ * ```
+ */
+export abstract class BaseAuthentication {
+  /**
+   * Authenticate the request and return a user object, or null.
+   *
+   * Return null to indicate this authenticator does not apply — the
+   * next authenticator in authentication_classes will be tried.
+   *
+   * Return a user object to indicate successful authentication.
+   * The returned object will be set as context.user.
+   *
+   * @param context - The ViewSet context with request and params
+   * @returns Authenticated user or null
+   */
+  abstract authenticate(
+    context: ViewSetContext,
+  ): Promise<AuthenticatedUser | null> | AuthenticatedUser | null;
+}
+
+// ============================================================================
+// Built-in Authentication Classes
+// ============================================================================
+
+/**
+ * JWT Bearer token authentication
+ *
+ * Reads a JWT from the `Authorization: Bearer <token>` header and
+ * verifies it using the SECRET_KEY environment variable.
+ *
+ * The token payload must contain `userId` (or `sub`), and optionally
+ * `email` and `isAdmin`.
+ *
+ * @example
+ * ```ts
+ * class ArticleViewSet extends ModelViewSet {
+ *   authentication_classes = [JWTAuthentication];
+ *   permission_classes = [IsAuthenticated];
+ * }
+ * ```
+ *
+ * @example With custom secret key
+ * ```ts
+ * class MyAuth extends JWTAuthentication {
+ *   override secretKey = Deno.env.get("MY_SECRET_KEY") ?? "fallback";
+ * }
+ * ```
+ */
+export class JWTAuthentication extends BaseAuthentication {
+  /**
+   * Secret key used to verify JWT signatures.
+   * Defaults to the SECRET_KEY environment variable.
+   */
+  secretKey: string = Deno.env.get("SECRET_KEY") ?? "";
+
+  async authenticate(
+    context: ViewSetContext,
+  ): Promise<AuthenticatedUser | null> {
+    const authHeader = context.request.headers.get("Authorization");
+    if (!authHeader) return null;
+
+    const [scheme, token] = authHeader.split(" ");
+    if (scheme?.toLowerCase() !== "bearer" || !token) return null;
+
+    try {
+      const payload = await verifyJWT(token, this.secretKey);
+      if (!payload) return null;
+
+      const userId = payload.userId ?? payload.sub;
+      if (userId == null) return null;
+
+      return {
+        id: typeof userId === "number" ? userId : Number(userId) || userId,
+        email: typeof payload.email === "string" ? payload.email : undefined,
+        isAdmin: payload.isAdmin === true,
+        ...payload,
+      } as AuthenticatedUser;
+    } catch {
+      return null;
+    }
+  }
+}
+
+// ============================================================================
+// JWT Utilities
+// ============================================================================
+
+/**
+ * Verify a JWT token and return its payload.
+ *
+ * Supports both HS256-signed JWTs (using Web Crypto API) and
+ * unsigned/development tokens encoded as base64url JSON.
+ *
+ * @param token - The JWT string to verify
+ * @param secretKey - The HMAC-SHA256 secret key
+ * @returns Decoded payload, or null if invalid/expired
+ */
+async function verifyJWT(
+  token: string,
+  secretKey: string,
+): Promise<Record<string, unknown> | null> {
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+
+  const [headerB64, payloadB64, signatureB64] = parts;
+
+  // Decode header to check algorithm
+  let header: Record<string, unknown>;
+  try {
+    header = JSON.parse(base64UrlDecode(headerB64));
+  } catch {
+    return null;
+  }
+
+  // Decode payload
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(base64UrlDecode(payloadB64));
+  } catch {
+    return null;
+  }
+
+  // Check expiry
+  if (typeof payload.exp === "number" && payload.exp < Date.now() / 1000) {
+    return null;
+  }
+
+  const alg = header.alg as string | undefined;
+
+  // Verify signature for HS256
+  if (alg === "HS256") {
+    if (!secretKey) {
+      // No secret key configured — cannot verify
+      return null;
+    }
+
+    const valid = await verifyHmacSha256(
+      `${headerB64}.${payloadB64}`,
+      signatureB64,
+      secretKey,
+    );
+
+    if (!valid) return null;
+  } else if (alg === "none" || !alg) {
+    // Unsigned token — only allowed in development (no secret key set)
+    if (secretKey) {
+      // If secret key is set, refuse unsigned tokens for security
+      return null;
+    }
+  } else {
+    // Unsupported algorithm
+    return null;
+  }
+
+  return payload;
+}
+
+/**
+ * Verify an HMAC-SHA256 signature using the Web Crypto API
+ */
+async function verifyHmacSha256(
+  data: string,
+  signatureB64: string,
+  secretKey: string,
+): Promise<boolean> {
+  try {
+    const encoder = new TextEncoder();
+    const keyMaterial = await crypto.subtle.importKey(
+      "raw",
+      encoder.encode(secretKey),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["verify"],
+    );
+
+    const signatureBytes = base64UrlToBytes(signatureB64);
+    return await crypto.subtle.verify(
+      "HMAC",
+      keyMaterial,
+      signatureBytes.buffer as ArrayBuffer,
+      encoder.encode(data),
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Decode a base64url string to a UTF-8 string
+ */
+function base64UrlDecode(input: string): string {
+  // Convert base64url to base64
+  const base64 = input
+    .replace(/-/g, "+")
+    .replace(/_/g, "/")
+    .padEnd(input.length + (4 - (input.length % 4)) % 4, "=");
+  return atob(base64);
+}
+
+/**
+ * Decode a base64url string to a Uint8Array
+ */
+function base64UrlToBytes(input: string): Uint8Array {
+  const binary = base64UrlDecode(input);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}

--- a/src/restframework/authentication/authentication_test.ts
+++ b/src/restframework/authentication/authentication_test.ts
@@ -1,0 +1,590 @@
+/**
+ * Tests for authentication classes
+ *
+ * @module @alexi/restframework/authentication/authentication_test
+ */
+
+import { assertEquals, assertNotEquals } from "jsr:@std/assert@1";
+import { BaseAuthentication, JWTAuthentication } from "./authentication.ts";
+import type { AuthenticatedUser } from "./authentication.ts";
+import type { ViewSetContext } from "../viewsets/viewset.ts";
+import { ViewSet } from "../viewsets/viewset.ts";
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+/**
+ * Create a mock ViewSetContext with optional Authorization header
+ */
+function createContext(options: {
+  authorizationHeader?: string;
+  method?: string;
+}): ViewSetContext {
+  const headers: Record<string, string> = {};
+  if (options.authorizationHeader) {
+    headers["Authorization"] = options.authorizationHeader;
+  }
+  const request = new Request("http://localhost/test", {
+    method: options.method ?? "GET",
+    headers,
+  });
+
+  return {
+    request,
+    params: {},
+    action: "list",
+  };
+}
+
+/**
+ * Create a minimal unsigned JWT (alg: none) for testing without a secret key.
+ * NOT for production use.
+ */
+function createUnsignedJWT(payload: Record<string, unknown>): string {
+  const header = btoa(JSON.stringify({ alg: "none", typ: "JWT" }))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  const body = btoa(JSON.stringify(payload))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  return `${header}.${body}.`;
+}
+
+/**
+ * Create an HS256-signed JWT for testing
+ */
+async function createSignedJWT(
+  payload: Record<string, unknown>,
+  secretKey: string,
+): Promise<string> {
+  const header = { alg: "HS256", typ: "JWT" };
+  const toB64Url = (obj: unknown) =>
+    btoa(JSON.stringify(obj))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+
+  const headerB64 = toB64Url(header);
+  const payloadB64 = toB64Url(payload);
+  const signingInput = `${headerB64}.${payloadB64}`;
+
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secretKey),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+
+  const signatureBuffer = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode(signingInput),
+  );
+
+  const signatureB64 = btoa(
+    String.fromCharCode(...new Uint8Array(signatureBuffer)),
+  )
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+
+  return `${headerB64}.${payloadB64}.${signatureB64}`;
+}
+
+// ============================================================================
+// BaseAuthentication Tests
+// ============================================================================
+
+Deno.test({
+  name: "BaseAuthentication: can be extended",
+  async fn() {
+    class AlwaysAuthAuthentication extends BaseAuthentication {
+      authenticate(_context: ViewSetContext): AuthenticatedUser {
+        return { id: 42, email: "test@test.com", isAdmin: false };
+      }
+    }
+
+    const auth = new AlwaysAuthAuthentication();
+    const context = createContext({});
+    const user = await auth.authenticate(context);
+
+    assertEquals(user?.id, 42);
+    assertEquals(user?.email, "test@test.com");
+  },
+});
+
+Deno.test({
+  name: "BaseAuthentication: can return null for anonymous",
+  async fn() {
+    class NeverAuthAuthentication extends BaseAuthentication {
+      authenticate(_context: ViewSetContext): null {
+        return null;
+      }
+    }
+
+    const auth = new NeverAuthAuthentication();
+    const context = createContext({});
+    const user = await auth.authenticate(context);
+
+    assertEquals(user, null);
+  },
+});
+
+// ============================================================================
+// JWTAuthentication: No header
+// ============================================================================
+
+Deno.test({
+  name: "JWTAuthentication: returns null when no Authorization header",
+  async fn() {
+    const auth = new JWTAuthentication();
+    auth.secretKey = ""; // No secret, allow unsigned
+    const context = createContext({});
+    const user = await auth.authenticate(context);
+
+    assertEquals(user, null);
+  },
+});
+
+Deno.test({
+  name: "JWTAuthentication: returns null for non-Bearer scheme",
+  async fn() {
+    const token = createUnsignedJWT({ userId: 1, email: "test@test.com" });
+    const auth = new JWTAuthentication();
+    auth.secretKey = "";
+    const context = createContext({ authorizationHeader: `Basic ${token}` });
+    const user = await auth.authenticate(context);
+
+    assertEquals(user, null);
+  },
+});
+
+Deno.test({
+  name: "JWTAuthentication: returns null for malformed token",
+  async fn() {
+    const auth = new JWTAuthentication();
+    auth.secretKey = "";
+    const context = createContext({
+      authorizationHeader: "Bearer not.a.valid.jwt.at.all",
+    });
+    const user = await auth.authenticate(context);
+
+    assertEquals(user, null);
+  },
+});
+
+// ============================================================================
+// JWTAuthentication: Unsigned tokens (no secretKey)
+// ============================================================================
+
+Deno.test({
+  name: "JWTAuthentication: authenticates valid unsigned JWT when no secret",
+  async fn() {
+    const token = createUnsignedJWT({
+      userId: 7,
+      email: "user@test.com",
+      isAdmin: false,
+    });
+
+    const auth = new JWTAuthentication();
+    auth.secretKey = ""; // Explicitly no secret
+    const context = createContext({ authorizationHeader: `Bearer ${token}` });
+    const user = await auth.authenticate(context);
+
+    assertNotEquals(user, null);
+    assertEquals(user?.id, 7);
+    assertEquals(user?.email, "user@test.com");
+    assertEquals(user?.isAdmin, false);
+  },
+});
+
+Deno.test({
+  name: "JWTAuthentication: rejects unsigned JWT when secret key is set",
+  async fn() {
+    const token = createUnsignedJWT({ userId: 1 });
+
+    const auth = new JWTAuthentication();
+    auth.secretKey = "my-secret";
+    const context = createContext({ authorizationHeader: `Bearer ${token}` });
+    const user = await auth.authenticate(context);
+
+    assertEquals(user, null);
+  },
+});
+
+Deno.test({
+  name: "JWTAuthentication: returns null for expired unsigned token",
+  async fn() {
+    const pastTimestamp = Math.floor(Date.now() / 1000) - 3600; // 1 hour ago
+    const token = createUnsignedJWT({
+      userId: 1,
+      exp: pastTimestamp,
+    });
+
+    const auth = new JWTAuthentication();
+    auth.secretKey = "";
+    const context = createContext({ authorizationHeader: `Bearer ${token}` });
+    const user = await auth.authenticate(context);
+
+    assertEquals(user, null);
+  },
+});
+
+Deno.test({
+  name: "JWTAuthentication: returns null for token without userId",
+  async fn() {
+    const token = createUnsignedJWT({ email: "user@test.com" });
+
+    const auth = new JWTAuthentication();
+    auth.secretKey = "";
+    const context = createContext({ authorizationHeader: `Bearer ${token}` });
+    const user = await auth.authenticate(context);
+
+    assertEquals(user, null);
+  },
+});
+
+Deno.test({
+  name: "JWTAuthentication: supports sub claim as userId fallback",
+  async fn() {
+    const token = createUnsignedJWT({ sub: "123", email: "user@test.com" });
+
+    const auth = new JWTAuthentication();
+    auth.secretKey = "";
+    const context = createContext({ authorizationHeader: `Bearer ${token}` });
+    const user = await auth.authenticate(context);
+
+    assertNotEquals(user, null);
+    assertEquals(user?.id, 123);
+  },
+});
+
+Deno.test({
+  name: "JWTAuthentication: sets isAdmin correctly",
+  async fn() {
+    const adminToken = createUnsignedJWT({
+      userId: 1,
+      email: "admin@test.com",
+      isAdmin: true,
+    });
+    const userToken = createUnsignedJWT({
+      userId: 2,
+      email: "user@test.com",
+      isAdmin: false,
+    });
+    const noAdminToken = createUnsignedJWT({
+      userId: 3,
+      email: "nofield@test.com",
+    });
+
+    const auth = new JWTAuthentication();
+    auth.secretKey = "";
+
+    const adminContext = createContext({
+      authorizationHeader: `Bearer ${adminToken}`,
+    });
+    const userContext = createContext({
+      authorizationHeader: `Bearer ${userToken}`,
+    });
+    const noAdminContext = createContext({
+      authorizationHeader: `Bearer ${noAdminToken}`,
+    });
+
+    const adminUser = await auth.authenticate(adminContext);
+    const regularUser = await auth.authenticate(userContext);
+    const noAdminUser = await auth.authenticate(noAdminContext);
+
+    assertEquals(adminUser?.isAdmin, true);
+    assertEquals(regularUser?.isAdmin, false);
+    assertEquals(noAdminUser?.isAdmin, false);
+  },
+});
+
+// ============================================================================
+// JWTAuthentication: HS256 signed tokens
+// ============================================================================
+
+Deno.test({
+  name: "JWTAuthentication: authenticates valid HS256 JWT",
+  async fn() {
+    const secret = "test-secret-key";
+    const token = await createSignedJWT(
+      { userId: 5, email: "signed@test.com", isAdmin: true },
+      secret,
+    );
+
+    const auth = new JWTAuthentication();
+    auth.secretKey = secret;
+    const context = createContext({ authorizationHeader: `Bearer ${token}` });
+    const user = await auth.authenticate(context);
+
+    assertNotEquals(user, null);
+    assertEquals(user?.id, 5);
+    assertEquals(user?.email, "signed@test.com");
+    assertEquals(user?.isAdmin, true);
+  },
+});
+
+Deno.test({
+  name: "JWTAuthentication: rejects HS256 JWT with wrong secret",
+  async fn() {
+    const token = await createSignedJWT(
+      { userId: 5, email: "signed@test.com" },
+      "correct-secret",
+    );
+
+    const auth = new JWTAuthentication();
+    auth.secretKey = "wrong-secret";
+    const context = createContext({ authorizationHeader: `Bearer ${token}` });
+    const user = await auth.authenticate(context);
+
+    assertEquals(user, null);
+  },
+});
+
+Deno.test({
+  name: "JWTAuthentication: rejects HS256 JWT with no secret configured",
+  async fn() {
+    const token = await createSignedJWT(
+      { userId: 5 },
+      "some-secret",
+    );
+
+    const auth = new JWTAuthentication();
+    auth.secretKey = ""; // No secret
+    const context = createContext({ authorizationHeader: `Bearer ${token}` });
+    const user = await auth.authenticate(context);
+
+    // HS256 requires a secret key for verification
+    assertEquals(user, null);
+  },
+});
+
+// ============================================================================
+// ViewSet.performAuthentication() Integration Tests
+// ============================================================================
+
+Deno.test({
+  name: "ViewSet.performAuthentication: populates context.user on success",
+  async fn() {
+    const token = createUnsignedJWT({
+      userId: 99,
+      email: "viewset@test.com",
+      isAdmin: false,
+    });
+
+    class TestAuth extends JWTAuthentication {
+      override secretKey = "";
+    }
+
+    class TestViewSet extends ViewSet {
+      override authentication_classes = [TestAuth];
+    }
+
+    const viewset = new TestViewSet();
+    const context = createContext({ authorizationHeader: `Bearer ${token}` });
+    await viewset.performAuthentication(context);
+
+    assertNotEquals(context.user, undefined);
+    assertEquals(context.user?.id, 99);
+    assertEquals(context.user?.email, "viewset@test.com");
+  },
+});
+
+Deno.test({
+  name:
+    "ViewSet.performAuthentication: context.user remains undefined without credentials",
+  async fn() {
+    class TestAuth extends JWTAuthentication {
+      override secretKey = "";
+    }
+
+    class TestViewSet extends ViewSet {
+      override authentication_classes = [TestAuth];
+    }
+
+    const viewset = new TestViewSet();
+    const context = createContext({});
+    await viewset.performAuthentication(context);
+
+    assertEquals(context.user, undefined);
+  },
+});
+
+Deno.test({
+  name:
+    "ViewSet.performAuthentication: no authentication_classes leaves user undefined",
+  async fn() {
+    class TestViewSet extends ViewSet {}
+
+    const viewset = new TestViewSet();
+    const context = createContext({});
+    await viewset.performAuthentication(context);
+
+    assertEquals(context.user, undefined);
+  },
+});
+
+Deno.test({
+  name: "ViewSet.performAuthentication: first successful authenticator wins",
+  async fn() {
+    let firstCalled = false;
+    let secondCalled = false;
+
+    class FirstAuth extends BaseAuthentication {
+      authenticate(_context: ViewSetContext): AuthenticatedUser {
+        firstCalled = true;
+        return { id: 1, email: "first@test.com" };
+      }
+    }
+
+    class SecondAuth extends BaseAuthentication {
+      authenticate(_context: ViewSetContext): AuthenticatedUser {
+        secondCalled = true;
+        return { id: 2, email: "second@test.com" };
+      }
+    }
+
+    class TestViewSet extends ViewSet {
+      override authentication_classes = [FirstAuth, SecondAuth];
+    }
+
+    const viewset = new TestViewSet();
+    const context = createContext({});
+    await viewset.performAuthentication(context);
+
+    assertEquals(firstCalled, true);
+    assertEquals(secondCalled, false); // Should not be called since FirstAuth succeeded
+    assertEquals(context.user?.id, 1);
+  },
+});
+
+Deno.test({
+  name: "ViewSet.performAuthentication: falls through to second authenticator",
+  async fn() {
+    class FailingAuth extends BaseAuthentication {
+      authenticate(_context: ViewSetContext): null {
+        return null;
+      }
+    }
+
+    class SucceedingAuth extends BaseAuthentication {
+      authenticate(_context: ViewSetContext): AuthenticatedUser {
+        return { id: 42, email: "fallback@test.com" };
+      }
+    }
+
+    class TestViewSet extends ViewSet {
+      override authentication_classes = [FailingAuth, SucceedingAuth];
+    }
+
+    const viewset = new TestViewSet();
+    const context = createContext({});
+    await viewset.performAuthentication(context);
+
+    assertEquals(context.user?.id, 42);
+  },
+});
+
+// ============================================================================
+// End-to-end: asView() with authentication + permission
+// ============================================================================
+
+Deno.test({
+  name: "asView: returns 401 when authentication_classes set but no token",
+  async fn() {
+    class TestAuth extends JWTAuthentication {
+      override secretKey = "";
+    }
+
+    const { IsAuthenticated } = await import("../permissions/permission.ts");
+
+    class ProtectedViewSet extends ViewSet {
+      override authentication_classes = [TestAuth];
+      override permission_classes = [IsAuthenticated];
+
+      override async list(_context: ViewSetContext): Promise<Response> {
+        return Response.json({ data: "secret" });
+      }
+    }
+
+    const view = ProtectedViewSet.asView(
+      { GET: "list" } as Record<string, string>,
+    );
+    const request = new Request("http://localhost/test");
+    const response = await view(request, {});
+
+    assertEquals(response.status, 401);
+  },
+});
+
+Deno.test({
+  name: "asView: returns 200 when valid JWT provided with IsAuthenticated",
+  async fn() {
+    const token = createUnsignedJWT({ userId: 1, email: "test@test.com" });
+
+    class TestAuth extends JWTAuthentication {
+      override secretKey = "";
+    }
+
+    const { IsAuthenticated } = await import("../permissions/permission.ts");
+
+    class ProtectedViewSet extends ViewSet {
+      override authentication_classes = [TestAuth];
+      override permission_classes = [IsAuthenticated];
+
+      override async list(_context: ViewSetContext): Promise<Response> {
+        return Response.json({ data: "secret" });
+      }
+    }
+
+    const view = ProtectedViewSet.asView(
+      { GET: "list" } as Record<string, string>,
+    );
+    const request = new Request("http://localhost/test", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const response = await view(request, {});
+
+    assertEquals(response.status, 200);
+  },
+});
+
+Deno.test({
+  name: "asView: context.user available in action after authentication",
+  async fn() {
+    const token = createUnsignedJWT({
+      userId: 42,
+      email: "me@test.com",
+      isAdmin: false,
+    });
+
+    class TestAuth extends JWTAuthentication {
+      override secretKey = "";
+    }
+
+    let capturedUserId: unknown = undefined;
+
+    class MyViewSet extends ViewSet {
+      override authentication_classes = [TestAuth];
+
+      override async list(context: ViewSetContext): Promise<Response> {
+        capturedUserId = context.user?.id;
+        return Response.json({ ok: true });
+      }
+    }
+
+    const view = MyViewSet.asView({ GET: "list" } as Record<string, string>);
+    const request = new Request("http://localhost/test", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    await view(request, {});
+
+    assertEquals(capturedUserId, 42);
+  },
+});

--- a/src/restframework/authentication/mod.ts
+++ b/src/restframework/authentication/mod.ts
@@ -1,0 +1,42 @@
+/**
+ * Authentication module for Alexi REST Framework
+ *
+ * Provides DRF-style authentication classes that populate context.user
+ * before permission checks are applied.
+ *
+ * @module @alexi/restframework/authentication
+ *
+ * @example JWT authentication with permission check
+ * ```ts
+ * import { ModelViewSet } from "@alexi/restframework";
+ * import { JWTAuthentication, IsAuthenticated } from "@alexi/restframework";
+ *
+ * class ArticleViewSet extends ModelViewSet {
+ *   authentication_classes = [JWTAuthentication];
+ *   permission_classes = [IsAuthenticated];
+ * }
+ * ```
+ *
+ * @example Custom authenticator
+ * ```ts
+ * import { BaseAuthentication } from "@alexi/restframework";
+ * import type { ViewSetContext } from "@alexi/restframework";
+ *
+ * class ApiKeyAuthentication extends BaseAuthentication {
+ *   async authenticate(context: ViewSetContext) {
+ *     const key = context.request.headers.get("X-API-Key");
+ *     if (!key) return null;
+ *     const user = await UserModel.objects.filter({ apiKey: key }).first();
+ *     if (!user) return null;
+ *     return { id: user.id.get(), email: user.email.get(), isAdmin: false };
+ *   }
+ * }
+ * ```
+ */
+
+export { BaseAuthentication, JWTAuthentication } from "./authentication.ts";
+
+export type {
+  AuthenticatedUser,
+  AuthenticationClass,
+} from "./authentication.ts";

--- a/src/restframework/deno.jsonc
+++ b/src/restframework/deno.jsonc
@@ -4,6 +4,7 @@
   "license": "MIT",
   "exports": {
     ".": "./mod.ts",
+    "./authentication": "./authentication/mod.ts",
     "./serializers": "./serializers/mod.ts",
     "./viewsets": "./viewsets/mod.ts",
     "./routers": "./routers/mod.ts"

--- a/src/restframework/mod.ts
+++ b/src/restframework/mod.ts
@@ -229,3 +229,14 @@ export {
 } from "./versioning/mod.ts";
 
 export type { VersioningClass, VersioningConfig } from "./versioning/mod.ts";
+
+// ============================================================================
+// Authentication
+// ============================================================================
+
+export { BaseAuthentication, JWTAuthentication } from "./authentication/mod.ts";
+
+export type {
+  AuthenticatedUser,
+  AuthenticationClass,
+} from "./authentication/mod.ts";


### PR DESCRIPTION
## Summary

- Implements DRF-style `authentication_classes` on `ViewSet` so that `context.user` is auto-populated before `permission_classes` are checked — fixing the root issue where `IsAuthenticated` never worked in practice
- Adds `BaseAuthentication` abstract class and built-in `JWTAuthentication` (supports HS256 via Web Crypto API and unsigned tokens)
- Exports `@alexi/restframework/authentication` as a proper subpath

## Changes

- **`src/restframework/authentication/`** (new) — `BaseAuthentication`, `JWTAuthentication`, JWT verification helpers, barrel exports
- **`src/restframework/viewsets/viewset.ts`** — `authentication_classes`, `getAuthenticators()`, `performAuthentication()`, called in `asView()` before `checkPermissions()`
- **`src/restframework/mod.ts`** — re-exports authentication classes
- **`src/restframework/deno.jsonc`** — adds `./authentication` subpath export
- **`src/create/tests/e2e_utils.ts`** — maps new subpath to local file for E2E tests
- **`AGENTS.md`** — documents the new authentication system

## Tests

22 new tests added (`authentication_test.ts`), all 932 tests pass.

Closes #102