### PR TITLE
fix(db): normalize type comparison in 'in' lookup to fix selectRelated() on IndexedDB

### DIFF
--- a/src/db/backends/backend.ts
+++ b/src/db/backends/backend.ts
@@ -711,7 +711,10 @@ export abstract class DatabaseBackend {
         );
 
       case "in":
-        return Array.isArray(compareValue) && compareValue.includes(fieldValue);
+        return (
+          Array.isArray(compareValue) &&
+          compareValue.some((v) => String(v) === String(fieldValue))
+        );
 
       case "gt":
         return (fieldValue as number) > (compareValue as number);


### PR DESCRIPTION
## Summary

- Fixes `selectRelated()` silently failing on IndexedDB backend
- Replaces strict `Array.includes()` with `some((v) => String(v) === String(fieldValue))` in `evaluateLookup()` for the `in` lookup
- IndexedDB stores IDs as strings; `selectRelated()` collects FK IDs as numbers — the type mismatch caused all batch queries to return empty results
- Fix applies to the base `DatabaseBackend` class, so all backends using `evaluateLookup()` (IndexedDB, DenoKV) benefit consistently

Closes #118