### PR TITLE
feat(admin): MPA infrastructure - static files, base template, static serving

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -3,6 +3,7 @@
   "specifiers": {
     "jsr:@luca/esbuild-deno-loader@~0.11.1": "0.11.1",
     "jsr:@std/assert@*": "1.0.19",
+    "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/bytes@^1.0.2": "1.0.6",
     "jsr:@std/encoding@^1.0.5": "1.0.10",
     "jsr:@std/fs@^1.0.19": "1.0.23",
@@ -14,7 +15,8 @@
     "jsr:@zip-js/zip-js@^2.8.7": "2.8.21",
     "npm:esbuild@0.24": "0.24.2",
     "npm:fake-indexeddb@6": "6.2.5",
-    "npm:pg@8": "8.19.0"
+    "npm:pg@8": "8.19.0",
+    "npm:playwright@^1.48.0": "1.58.2"
   },
   "jsr": {
     "@luca/esbuild-deno-loader@0.11.1": {
@@ -226,6 +228,11 @@
     "fake-indexeddb@6.2.5": {
       "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w=="
     },
+    "fsevents@2.3.2": {
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "os": ["darwin"],
+      "scripts": true
+    },
     "pg-cloudflare@1.3.0": {
       "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ=="
     },
@@ -273,6 +280,20 @@
         "split2"
       ]
     },
+    "playwright-core@1.58.2": {
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "bin": true
+    },
+    "playwright@1.58.2": {
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dependencies": [
+        "playwright-core"
+      ],
+      "optionalDependencies": [
+        "fsevents"
+      ],
+      "bin": true
+    },
     "postgres-array@2.0.0": {
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
     },
@@ -294,6 +315,75 @@
     "xtend@4.0.2": {
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     }
+  },
+  "remote": {
+    "https://deno.land/std@0.208.0/assert/_constants.ts": "8a9da298c26750b28b326b297316cdde860bc237533b07e1337c021379e6b2a9",
+    "https://deno.land/std@0.208.0/assert/_diff.ts": "58e1461cc61d8eb1eacbf2a010932bf6a05b79344b02ca38095f9b805795dc48",
+    "https://deno.land/std@0.208.0/assert/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
+    "https://deno.land/std@0.208.0/assert/assert.ts": "9a97dad6d98c238938e7540736b826440ad8c1c1e54430ca4c4e623e585607ee",
+    "https://deno.land/std@0.208.0/assert/assert_almost_equals.ts": "e15ca1f34d0d5e0afae63b3f5d975cbd18335a132e42b0c747d282f62ad2cd6c",
+    "https://deno.land/std@0.208.0/assert/assert_array_includes.ts": "6856d7f2c3544bc6e62fb4646dfefa3d1df5ff14744d1bca19f0cbaf3b0d66c9",
+    "https://deno.land/std@0.208.0/assert/assert_equals.ts": "d8ec8a22447fbaf2fc9d7c3ed2e66790fdb74beae3e482855d75782218d68227",
+    "https://deno.land/std@0.208.0/assert/assert_exists.ts": "407cb6b9fb23a835cd8d5ad804e2e2edbbbf3870e322d53f79e1c7a512e2efd7",
+    "https://deno.land/std@0.208.0/assert/assert_false.ts": "0ccbcaae910f52c857192ff16ea08bda40fdc79de80846c206bfc061e8c851c6",
+    "https://deno.land/std@0.208.0/assert/assert_greater.ts": "ae2158a2d19313bf675bf7251d31c6dc52973edb12ac64ac8fc7064152af3e63",
+    "https://deno.land/std@0.208.0/assert/assert_greater_or_equal.ts": "1439da5ebbe20855446cac50097ac78b9742abe8e9a43e7de1ce1426d556e89c",
+    "https://deno.land/std@0.208.0/assert/assert_instance_of.ts": "3aedb3d8186e120812d2b3a5dea66a6e42bf8c57a8bd927645770bd21eea554c",
+    "https://deno.land/std@0.208.0/assert/assert_is_error.ts": "c21113094a51a296ffaf036767d616a78a2ae5f9f7bbd464cd0197476498b94b",
+    "https://deno.land/std@0.208.0/assert/assert_less.ts": "aec695db57db42ec3e2b62e97e1e93db0063f5a6ec133326cc290ff4b71b47e4",
+    "https://deno.land/std@0.208.0/assert/assert_less_or_equal.ts": "5fa8b6a3ffa20fd0a05032fe7257bf985d207b85685fdbcd23651b70f928c848",
+    "https://deno.land/std@0.208.0/assert/assert_match.ts": "c4083f80600bc190309903c95e397a7c9257ff8b5ae5c7ef91e834704e672e9b",
+    "https://deno.land/std@0.208.0/assert/assert_not_equals.ts": "9f1acab95bd1f5fc9a1b17b8027d894509a745d91bac1718fdab51dc76831754",
+    "https://deno.land/std@0.208.0/assert/assert_not_instance_of.ts": "0c14d3dfd9ab7a5276ed8ed0b18c703d79a3d106102077ec437bfe7ed912bd22",
+    "https://deno.land/std@0.208.0/assert/assert_not_match.ts": "3796a5b0c57a1ce6c1c57883dd4286be13a26f715ea662318ab43a8491a13ab0",
+    "https://deno.land/std@0.208.0/assert/assert_not_strict_equals.ts": "4cdef83df17488df555c8aac1f7f5ec2b84ad161b6d0645ccdbcc17654e80c99",
+    "https://deno.land/std@0.208.0/assert/assert_object_match.ts": "d8fc2867cfd92eeacf9cea621e10336b666de1874a6767b5ec48988838370b54",
+    "https://deno.land/std@0.208.0/assert/assert_rejects.ts": "45c59724de2701e3b1f67c391d6c71c392363635aad3f68a1b3408f9efca0057",
+    "https://deno.land/std@0.208.0/assert/assert_strict_equals.ts": "b1f538a7ea5f8348aeca261d4f9ca603127c665e0f2bbfeb91fa272787c87265",
+    "https://deno.land/std@0.208.0/assert/assert_string_includes.ts": "b821d39ebf5cb0200a348863c86d8c4c4b398e02012ce74ad15666fc4b631b0c",
+    "https://deno.land/std@0.208.0/assert/assert_throws.ts": "63784e951475cb7bdfd59878cd25a0931e18f6dc32a6077c454b2cd94f4f4bcd",
+    "https://deno.land/std@0.208.0/assert/assertion_error.ts": "4d0bde9b374dfbcbe8ac23f54f567b77024fb67dbb1906a852d67fe050d42f56",
+    "https://deno.land/std@0.208.0/assert/equal.ts": "9f1a46d5993966d2596c44e5858eec821859b45f783a5ee2f7a695dfc12d8ece",
+    "https://deno.land/std@0.208.0/assert/fail.ts": "c36353d7ae6e1f7933d45f8ea51e358c8c4b67d7e7502028598fe1fea062e278",
+    "https://deno.land/std@0.208.0/assert/mod.ts": "37c49a26aae2b254bbe25723434dc28cd7532e444cf0b481a97c045d110ec085",
+    "https://deno.land/std@0.208.0/assert/unimplemented.ts": "d56fbeecb1f108331a380f72e3e010a1f161baa6956fd0f7cf3e095ae1a4c75a",
+    "https://deno.land/std@0.208.0/assert/unreachable.ts": "4600dc0baf7d9c15a7f7d234f00c23bca8f3eba8b140286aaca7aa998cf9a536",
+    "https://deno.land/std@0.208.0/fmt/colors.ts": "34b3f77432925eb72cf0bfb351616949746768620b8e5ead66da532f93d10ba2",
+    "https://deno.land/std@0.208.0/testing/_test_suite.ts": "30f018feeb3835f12ab198d8a518f9089b1bcb2e8c838a8b615ab10d5005465c",
+    "https://deno.land/std@0.208.0/testing/bdd.ts": "c41f019786c4a9112aadb7e5a7bbcc711f58429ac5904b3855fa248ba5fa0ba6",
+    "https://deno.land/std@0.224.0/assert/_constants.ts": "a271e8ef5a573f1df8e822a6eb9d09df064ad66a4390f21b3e31f820a38e0975",
+    "https://deno.land/std@0.224.0/assert/assert.ts": "09d30564c09de846855b7b071e62b5974b001bb72a4b797958fe0660e7849834",
+    "https://deno.land/std@0.224.0/assert/assert_almost_equals.ts": "9e416114322012c9a21fa68e187637ce2d7df25bcbdbfd957cd639e65d3cf293",
+    "https://deno.land/std@0.224.0/assert/assert_array_includes.ts": "14c5094471bc8e4a7895fc6aa5a184300d8a1879606574cb1cd715ef36a4a3c7",
+    "https://deno.land/std@0.224.0/assert/assert_equals.ts": "3bbca947d85b9d374a108687b1a8ba3785a7850436b5a8930d81f34a32cb8c74",
+    "https://deno.land/std@0.224.0/assert/assert_exists.ts": "43420cf7f956748ae6ed1230646567b3593cb7a36c5a5327269279c870c5ddfd",
+    "https://deno.land/std@0.224.0/assert/assert_false.ts": "3e9be8e33275db00d952e9acb0cd29481a44fa0a4af6d37239ff58d79e8edeff",
+    "https://deno.land/std@0.224.0/assert/assert_greater.ts": "5e57b201fd51b64ced36c828e3dfd773412c1a6120c1a5a99066c9b261974e46",
+    "https://deno.land/std@0.224.0/assert/assert_greater_or_equal.ts": "9870030f997a08361b6f63400273c2fb1856f5db86c0c3852aab2a002e425c5b",
+    "https://deno.land/std@0.224.0/assert/assert_instance_of.ts": "e22343c1fdcacfaea8f37784ad782683ec1cf599ae9b1b618954e9c22f376f2c",
+    "https://deno.land/std@0.224.0/assert/assert_is_error.ts": "f856b3bc978a7aa6a601f3fec6603491ab6255118afa6baa84b04426dd3cc491",
+    "https://deno.land/std@0.224.0/assert/assert_less.ts": "60b61e13a1982865a72726a5fa86c24fad7eb27c3c08b13883fb68882b307f68",
+    "https://deno.land/std@0.224.0/assert/assert_less_or_equal.ts": "d2c84e17faba4afe085e6c9123a63395accf4f9e00150db899c46e67420e0ec3",
+    "https://deno.land/std@0.224.0/assert/assert_match.ts": "ace1710dd3b2811c391946954234b5da910c5665aed817943d086d4d4871a8b7",
+    "https://deno.land/std@0.224.0/assert/assert_not_equals.ts": "78d45dd46133d76ce624b2c6c09392f6110f0df9b73f911d20208a68dee2ef29",
+    "https://deno.land/std@0.224.0/assert/assert_not_instance_of.ts": "3434a669b4d20cdcc5359779301a0588f941ffdc2ad68803c31eabdb4890cf7a",
+    "https://deno.land/std@0.224.0/assert/assert_not_match.ts": "df30417240aa2d35b1ea44df7e541991348a063d9ee823430e0b58079a72242a",
+    "https://deno.land/std@0.224.0/assert/assert_not_strict_equals.ts": "37f73880bd672709373d6dc2c5f148691119bed161f3020fff3548a0496f71b8",
+    "https://deno.land/std@0.224.0/assert/assert_object_match.ts": "411450fd194fdaabc0089ae68f916b545a49d7b7e6d0026e84a54c9e7eed2693",
+    "https://deno.land/std@0.224.0/assert/assert_rejects.ts": "4bee1d6d565a5b623146a14668da8f9eb1f026a4f338bbf92b37e43e0aa53c31",
+    "https://deno.land/std@0.224.0/assert/assert_strict_equals.ts": "b4f45f0fd2e54d9029171876bd0b42dd9ed0efd8f853ab92a3f50127acfa54f5",
+    "https://deno.land/std@0.224.0/assert/assert_string_includes.ts": "496b9ecad84deab72c8718735373feb6cdaa071eb91a98206f6f3cb4285e71b8",
+    "https://deno.land/std@0.224.0/assert/assert_throws.ts": "c6508b2879d465898dab2798009299867e67c570d7d34c90a2d235e4553906eb",
+    "https://deno.land/std@0.224.0/assert/assertion_error.ts": "ba8752bd27ebc51f723702fac2f54d3e94447598f54264a6653d6413738a8917",
+    "https://deno.land/std@0.224.0/assert/equal.ts": "bddf07bb5fc718e10bb72d5dc2c36c1ce5a8bdd3b647069b6319e07af181ac47",
+    "https://deno.land/std@0.224.0/assert/fail.ts": "0eba674ffb47dff083f02ced76d5130460bff1a9a68c6514ebe0cdea4abadb68",
+    "https://deno.land/std@0.224.0/assert/mod.ts": "48b8cb8a619ea0b7958ad7ee9376500fe902284bb36f0e32c598c3dc34cbd6f3",
+    "https://deno.land/std@0.224.0/assert/unimplemented.ts": "8c55a5793e9147b4f1ef68cd66496b7d5ba7a9e7ca30c6da070c1a58da723d73",
+    "https://deno.land/std@0.224.0/assert/unreachable.ts": "5ae3dbf63ef988615b93eb08d395dda771c96546565f9e521ed86f6510c29e19",
+    "https://deno.land/std@0.224.0/fmt/colors.ts": "508563c0659dd7198ba4bbf87e97f654af3c34eb56ba790260f252ad8012e1c5",
+    "https://deno.land/std@0.224.0/internal/diff.ts": "6234a4b493ebe65dc67a18a0eb97ef683626a1166a1906232ce186ae9f65f4e6",
+    "https://deno.land/std@0.224.0/internal/format.ts": "0a98ee226fd3d43450245b1844b47003419d34d210fa989900861c79820d21c2",
+    "https://deno.land/std@0.224.0/internal/mod.ts": "534125398c8e7426183e12dc255bb635d94e06d0f93c60a297723abe69d3b22e"
   },
   "workspace": {
     "dependencies": [

--- a/src/admin/deno.jsonc
+++ b/src/admin/deno.jsonc
@@ -10,7 +10,8 @@
     "./options": "./options.ts",
     "./components": "./components/mod.ts",
     "./views": "./views/admin_views.ts",
-    "./app": "./app/app.ts"
+    "./app": "./app/app.ts",
+    "./templates/mpa": "./templates/mpa/base.ts"
   },
   "imports": {
     "@alexi/db": "jsr:@alexi/db@0.24.6",

--- a/src/admin/static/css/admin.css
+++ b/src/admin/static/css/admin.css
@@ -1,0 +1,2070 @@
+/**
+ * Alexi Admin CSS
+ *
+ * Django Admin-inspired stylesheet for the Alexi Admin MPA.
+ * Consolidated from: variables.css, base.css, layout.css, forms.css, tables.css, responsive.css
+ */
+
+/* =========================================================================
+ * CSS Variables (Django Admin Inspired)
+ * ========================================================================= */
+
+:root {
+  /* Primary colors */
+  --admin-primary: #417690;
+  --admin-primary-dark: #205067;
+  --admin-primary-light: #79aec8;
+  --admin-secondary: #79aec8;
+  --admin-accent: #609ab6;
+
+  /* Background colors */
+  --admin-bg: #ffffff;
+  --admin-bg-alt: #f8f8f8;
+  --admin-bg-dark: #417690;
+  --admin-bg-darker: #205067;
+  --admin-bg-hover: #f0f0f0;
+  --admin-bg-selected: #e8f4f8;
+
+  /* Text colors */
+  --admin-text: #333333;
+  --admin-text-light: #666666;
+  --admin-text-muted: #999999;
+  --admin-text-inverse: #ffffff;
+  --admin-text-link: #417690;
+  --admin-text-link-hover: #205067;
+
+  /* Border colors */
+  --admin-border: #cccccc;
+  --admin-border-light: #eeeeee;
+  --admin-border-dark: #999999;
+  --admin-border-focus: #417690;
+
+  /* Status colors */
+  --admin-success: #44aa00;
+  --admin-success-bg: #e6f4e1;
+  --admin-error: #ba2121;
+  --admin-error-bg: #fde8e8;
+  --admin-warning: #cc9900;
+  --admin-warning-bg: #fff8e1;
+  --admin-info: #417690;
+  --admin-info-bg: #e8f4f8;
+
+  /* Typography */
+  --admin-font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
+    Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  --admin-font-mono:
+    ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas,
+    "DejaVu Sans Mono", monospace;
+
+  --admin-font-size-xs: 11px;
+  --admin-font-size-sm: 12px;
+  --admin-font-size-base: 14px;
+  --admin-font-size-md: 16px;
+  --admin-font-size-lg: 18px;
+  --admin-font-size-xl: 20px;
+  --admin-font-size-2xl: 24px;
+  --admin-font-size-3xl: 30px;
+
+  --admin-font-weight-normal: 400;
+  --admin-font-weight-medium: 500;
+  --admin-font-weight-semibold: 600;
+  --admin-font-weight-bold: 700;
+
+  --admin-line-height-tight: 1.25;
+  --admin-line-height-normal: 1.5;
+  --admin-line-height-relaxed: 1.75;
+
+  /* Spacing */
+  --admin-spacing-xs: 4px;
+  --admin-spacing-sm: 8px;
+  --admin-spacing-md: 12px;
+  --admin-spacing-base: 16px;
+  --admin-spacing-lg: 20px;
+  --admin-spacing-xl: 24px;
+  --admin-spacing-2xl: 32px;
+  --admin-spacing-3xl: 48px;
+
+  /* Layout */
+  --admin-header-height: 48px;
+  --admin-sidebar-width: 220px;
+  --admin-sidebar-collapsed-width: 60px;
+  --admin-content-max-width: 1200px;
+  --admin-form-max-width: 800px;
+
+  /* Borders & Shadows */
+  --admin-radius-sm: 2px;
+  --admin-radius: 4px;
+  --admin-radius-md: 6px;
+  --admin-radius-lg: 8px;
+  --admin-radius-full: 9999px;
+
+  --admin-shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  --admin-shadow:
+    0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
+  --admin-shadow-md:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+  --admin-shadow-lg:
+    0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+
+  /* Transitions */
+  --admin-transition-fast: 0.1s ease;
+  --admin-transition-base: 0.15s ease;
+  --admin-transition-slow: 0.3s ease;
+
+  /* Z-index layers */
+  --admin-z-dropdown: 100;
+  --admin-z-sticky: 200;
+  --admin-z-fixed: 300;
+  --admin-z-modal-backdrop: 400;
+  --admin-z-modal: 500;
+  --admin-z-popover: 600;
+  --admin-z-tooltip: 700;
+  --admin-z-toast: 800;
+}
+
+/* =========================================================================
+ * Reset & Base
+ * ========================================================================= */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: var(--admin-font-family);
+  font-size: var(--admin-font-size-base);
+  line-height: var(--admin-line-height-normal);
+  color: var(--admin-text);
+  background-color: var(--admin-bg-alt);
+}
+
+a {
+  color: var(--admin-text-link);
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--admin-text-link-hover);
+  text-decoration: underline;
+}
+
+/* =========================================================================
+ * Admin Container
+ * ========================================================================= */
+
+.admin-container {
+  font-family: var(--admin-font-family);
+  font-size: var(--admin-font-size-base);
+  line-height: var(--admin-line-height-normal);
+  color: var(--admin-text);
+  background-color: var(--admin-bg);
+  min-height: 100vh;
+}
+
+/* =========================================================================
+ * Typography
+ * ========================================================================= */
+
+.admin-h1,
+.admin-h2,
+.admin-h3,
+.admin-h4,
+.admin-h5,
+.admin-h6 {
+  margin: 0 0 var(--admin-spacing-md);
+  font-weight: var(--admin-font-weight-semibold);
+  line-height: var(--admin-line-height-tight);
+  color: var(--admin-text);
+}
+
+.admin-h1 {
+  font-size: var(--admin-font-size-2xl);
+}
+.admin-h2 {
+  font-size: var(--admin-font-size-xl);
+}
+.admin-h3 {
+  font-size: var(--admin-font-size-lg);
+}
+.admin-h4 {
+  font-size: var(--admin-font-size-md);
+}
+
+.admin-text-muted {
+  color: var(--admin-text-muted);
+}
+.admin-text-light {
+  color: var(--admin-text-light);
+}
+.admin-text-small {
+  font-size: var(--admin-font-size-sm);
+}
+
+/* =========================================================================
+ * Links
+ * ========================================================================= */
+
+.admin-link {
+  color: var(--admin-text-link);
+  text-decoration: none;
+  cursor: pointer;
+  transition: color var(--admin-transition-fast);
+}
+
+.admin-link:hover {
+  color: var(--admin-text-link-hover);
+  text-decoration: underline;
+}
+
+.admin-link:focus {
+  outline: 2px solid var(--admin-primary);
+  outline-offset: 2px;
+}
+
+/* =========================================================================
+ * Buttons
+ * ========================================================================= */
+
+.admin-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--admin-spacing-sm);
+  padding: var(--admin-spacing-sm) var(--admin-spacing-base);
+  border: none;
+  border-radius: var(--admin-radius);
+  font-family: var(--admin-font-family);
+  font-size: var(--admin-font-size-base);
+  font-weight: var(--admin-font-weight-medium);
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background-color var(--admin-transition-fast),
+    border-color var(--admin-transition-fast),
+    color var(--admin-transition-fast);
+  white-space: nowrap;
+  text-decoration: none;
+}
+
+.admin-btn:focus {
+  outline: 2px solid var(--admin-primary);
+  outline-offset: 2px;
+}
+
+.admin-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.admin-btn-primary {
+  background-color: var(--admin-primary);
+  color: var(--admin-text-inverse);
+}
+
+.admin-btn-primary:hover:not(:disabled) {
+  background-color: var(--admin-primary-dark);
+}
+
+.admin-btn-secondary {
+  background-color: var(--admin-bg-alt);
+  color: var(--admin-text);
+  border: 1px solid var(--admin-border);
+}
+
+.admin-btn-secondary:hover:not(:disabled) {
+  background-color: var(--admin-bg-hover);
+  border-color: var(--admin-border-dark);
+}
+
+.admin-btn-danger {
+  background-color: var(--admin-error);
+  color: var(--admin-text-inverse);
+}
+
+.admin-btn-danger:hover:not(:disabled) {
+  background-color: #a01c1c;
+}
+
+.admin-btn-success {
+  background-color: var(--admin-success);
+  color: var(--admin-text-inverse);
+}
+
+.admin-btn-success:hover:not(:disabled) {
+  background-color: #3a9000;
+}
+
+.admin-btn-link {
+  background: none;
+  color: var(--admin-text-link);
+  padding: var(--admin-spacing-xs) var(--admin-spacing-sm);
+}
+
+.admin-btn-link:hover:not(:disabled) {
+  color: var(--admin-text-link-hover);
+  text-decoration: underline;
+}
+
+.admin-btn-sm {
+  padding: var(--admin-spacing-xs) var(--admin-spacing-sm);
+  font-size: var(--admin-font-size-sm);
+}
+
+.admin-btn-lg {
+  padding: var(--admin-spacing-md) var(--admin-spacing-lg);
+  font-size: var(--admin-font-size-md);
+}
+
+.admin-btn-group {
+  display: inline-flex;
+  gap: var(--admin-spacing-sm);
+}
+
+/* =========================================================================
+ * Cards & Panels
+ * ========================================================================= */
+
+.admin-card {
+  background-color: var(--admin-bg);
+  border: 1px solid var(--admin-border-light);
+  border-radius: var(--admin-radius-md);
+  box-shadow: var(--admin-shadow-sm);
+}
+
+.admin-card-header {
+  padding: var(--admin-spacing-md) var(--admin-spacing-base);
+  border-bottom: 1px solid var(--admin-border-light);
+  font-weight: var(--admin-font-weight-semibold);
+  background-color: var(--admin-bg-alt);
+  border-radius: var(--admin-radius-md) var(--admin-radius-md) 0 0;
+}
+
+.admin-card-body {
+  padding: var(--admin-spacing-base);
+}
+
+.admin-card-footer {
+  padding: var(--admin-spacing-md) var(--admin-spacing-base);
+  border-top: 1px solid var(--admin-border-light);
+  background-color: var(--admin-bg-alt);
+  border-radius: 0 0 var(--admin-radius-md) var(--admin-radius-md);
+}
+
+/* =========================================================================
+ * Alerts & Messages
+ * ========================================================================= */
+
+.admin-alert {
+  padding: var(--admin-spacing-md) var(--admin-spacing-base);
+  border-radius: var(--admin-radius);
+  font-size: var(--admin-font-size-base);
+  margin-bottom: var(--admin-spacing-base);
+}
+
+.admin-alert-success {
+  background-color: var(--admin-success-bg);
+  color: var(--admin-success);
+  border: 1px solid var(--admin-success);
+}
+
+.admin-alert-error {
+  background-color: var(--admin-error-bg);
+  color: var(--admin-error);
+  border: 1px solid var(--admin-error);
+}
+
+.admin-alert-warning {
+  background-color: var(--admin-warning-bg);
+  color: var(--admin-warning);
+  border: 1px solid var(--admin-warning);
+}
+
+.admin-alert-info {
+  background-color: var(--admin-info-bg);
+  color: var(--admin-info);
+  border: 1px solid var(--admin-info);
+}
+
+/* =========================================================================
+ * Badges & Tags
+ * ========================================================================= */
+
+.admin-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  font-size: var(--admin-font-size-xs);
+  font-weight: var(--admin-font-weight-medium);
+  border-radius: var(--admin-radius-full);
+  white-space: nowrap;
+}
+
+.admin-badge-primary {
+  background-color: var(--admin-primary);
+  color: var(--admin-text-inverse);
+}
+
+.admin-badge-success {
+  background-color: var(--admin-success);
+  color: var(--admin-text-inverse);
+}
+
+.admin-badge-error {
+  background-color: var(--admin-error);
+  color: var(--admin-text-inverse);
+}
+
+.admin-badge-warning {
+  background-color: var(--admin-warning);
+  color: var(--admin-text-inverse);
+}
+
+.admin-badge-muted {
+  background-color: var(--admin-bg-alt);
+  color: var(--admin-text-light);
+  border: 1px solid var(--admin-border);
+}
+
+/* =========================================================================
+ * Empty State
+ * ========================================================================= */
+
+.admin-empty-state {
+  padding: var(--admin-spacing-3xl) var(--admin-spacing-base);
+  text-align: center;
+  color: var(--admin-text-muted);
+}
+
+.admin-empty-state-icon {
+  font-size: 48px;
+  margin-bottom: var(--admin-spacing-base);
+  opacity: 0.5;
+}
+
+.admin-empty-state-title {
+  font-size: var(--admin-font-size-lg);
+  font-weight: var(--admin-font-weight-medium);
+  margin-bottom: var(--admin-spacing-sm);
+  color: var(--admin-text-light);
+}
+
+.admin-empty-state-description {
+  font-size: var(--admin-font-size-base);
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+/* =========================================================================
+ * Loading Spinner
+ * ========================================================================= */
+
+.admin-spinner {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  border: 2px solid var(--admin-border);
+  border-top-color: var(--admin-primary);
+  border-radius: 50%;
+  animation: admin-spin 0.8s linear infinite;
+}
+
+.admin-spinner-lg {
+  width: 40px;
+  height: 40px;
+  border-width: 3px;
+}
+
+@keyframes admin-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* =========================================================================
+ * Utility Classes
+ * ========================================================================= */
+
+.admin-text-left {
+  text-align: left;
+}
+.admin-text-center {
+  text-align: center;
+}
+.admin-text-right {
+  text-align: right;
+}
+
+.admin-flex {
+  display: flex;
+}
+.admin-flex-col {
+  flex-direction: column;
+}
+.admin-flex-wrap {
+  flex-wrap: wrap;
+}
+.admin-items-center {
+  align-items: center;
+}
+.admin-items-start {
+  align-items: flex-start;
+}
+.admin-items-end {
+  align-items: flex-end;
+}
+.admin-justify-center {
+  justify-content: center;
+}
+.admin-justify-between {
+  justify-content: space-between;
+}
+.admin-justify-end {
+  justify-content: flex-end;
+}
+.admin-gap-sm {
+  gap: var(--admin-spacing-sm);
+}
+.admin-gap-md {
+  gap: var(--admin-spacing-md);
+}
+.admin-gap-lg {
+  gap: var(--admin-spacing-lg);
+}
+
+.admin-mt-0 {
+  margin-top: 0;
+}
+.admin-mb-0 {
+  margin-bottom: 0;
+}
+.admin-mt-sm {
+  margin-top: var(--admin-spacing-sm);
+}
+.admin-mb-sm {
+  margin-bottom: var(--admin-spacing-sm);
+}
+.admin-mt-md {
+  margin-top: var(--admin-spacing-md);
+}
+.admin-mb-md {
+  margin-bottom: var(--admin-spacing-md);
+}
+.admin-mt-lg {
+  margin-top: var(--admin-spacing-lg);
+}
+.admin-mb-lg {
+  margin-bottom: var(--admin-spacing-lg);
+}
+
+.admin-hidden {
+  display: none !important;
+}
+
+.admin-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.admin-truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* =========================================================================
+ * Main Layout
+ * ========================================================================= */
+
+.admin-layout {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background-color: var(--admin-bg-alt);
+}
+
+.admin-main {
+  display: flex;
+  flex: 1;
+}
+
+.admin-content-wrapper {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  margin-left: var(--admin-sidebar-width);
+  transition: margin-left var(--admin-transition-slow);
+}
+
+.admin-content-wrapper.sidebar-collapsed {
+  margin-left: var(--admin-sidebar-collapsed-width);
+}
+
+/* =========================================================================
+ * Header
+ * ========================================================================= */
+
+.admin-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--admin-header-height);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 var(--admin-spacing-base);
+  background-color: var(--admin-bg-dark);
+  color: var(--admin-text-inverse);
+  z-index: var(--admin-z-fixed);
+  box-shadow: var(--admin-shadow);
+}
+
+.admin-header-brand {
+  display: flex;
+  align-items: center;
+  gap: var(--admin-spacing-md);
+}
+
+.admin-header-logo {
+  height: 32px;
+  width: auto;
+}
+
+.admin-header-title {
+  font-size: var(--admin-font-size-lg);
+  font-weight: var(--admin-font-weight-semibold);
+  color: var(--admin-text-inverse);
+  text-decoration: none;
+}
+
+.admin-header-title:hover {
+  color: var(--admin-secondary);
+}
+
+.admin-header-nav {
+  display: flex;
+  align-items: center;
+  gap: var(--admin-spacing-base);
+}
+
+.admin-header-link {
+  color: var(--admin-text-inverse);
+  text-decoration: none;
+  font-size: var(--admin-font-size-sm);
+  padding: var(--admin-spacing-xs) var(--admin-spacing-sm);
+  border-radius: var(--admin-radius);
+  transition: background-color var(--admin-transition-fast);
+}
+
+.admin-header-link:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.admin-header-user {
+  display: flex;
+  align-items: center;
+  gap: var(--admin-spacing-sm);
+  padding: var(--admin-spacing-xs) var(--admin-spacing-sm);
+  border-radius: var(--admin-radius);
+  cursor: pointer;
+  transition: background-color var(--admin-transition-fast);
+}
+
+.admin-header-user:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.admin-header-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background-color: var(--admin-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--admin-font-size-sm);
+  font-weight: var(--admin-font-weight-semibold);
+}
+
+.admin-header-username {
+  font-size: var(--admin-font-size-sm);
+}
+
+/* =========================================================================
+ * Sidebar
+ * ========================================================================= */
+
+.admin-sidebar {
+  position: fixed;
+  top: var(--admin-header-height);
+  left: 0;
+  bottom: 0;
+  width: var(--admin-sidebar-width);
+  background-color: var(--admin-bg);
+  border-right: 1px solid var(--admin-border-light);
+  overflow-y: auto;
+  overflow-x: hidden;
+  z-index: var(--admin-z-sticky);
+  transition: width var(--admin-transition-slow);
+}
+
+.admin-sidebar.collapsed {
+  width: var(--admin-sidebar-collapsed-width);
+}
+
+.admin-sidebar-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: var(--admin-spacing-md);
+  border: none;
+  background: none;
+  color: var(--admin-text-muted);
+  cursor: pointer;
+  transition: background-color var(--admin-transition-fast);
+}
+
+.admin-sidebar-toggle:hover {
+  background-color: var(--admin-bg-hover);
+  color: var(--admin-text);
+}
+
+.admin-sidebar-nav {
+  padding: var(--admin-spacing-sm) 0;
+}
+
+.admin-sidebar-section {
+  margin-bottom: var(--admin-spacing-sm);
+}
+
+.admin-sidebar-section-title {
+  padding: var(--admin-spacing-sm) var(--admin-spacing-base);
+  font-size: var(--admin-font-size-xs);
+  font-weight: var(--admin-font-weight-semibold);
+  color: var(--admin-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.admin-sidebar.collapsed .admin-sidebar-section-title {
+  display: none;
+}
+
+.admin-sidebar-item {
+  display: flex;
+  align-items: center;
+  gap: var(--admin-spacing-md);
+  padding: var(--admin-spacing-md) var(--admin-spacing-base);
+  color: var(--admin-text);
+  text-decoration: none;
+  font-size: var(--admin-font-size-base);
+  transition:
+    background-color var(--admin-transition-fast),
+    color var(--admin-transition-fast);
+}
+
+.admin-sidebar-item:hover {
+  background-color: var(--admin-bg-hover);
+  color: var(--admin-primary);
+}
+
+.admin-sidebar-item.active {
+  background-color: var(--admin-bg-selected);
+  color: var(--admin-primary);
+  border-left: 3px solid var(--admin-primary);
+  padding-left: calc(var(--admin-spacing-base) - 3px);
+}
+
+.admin-sidebar-item-icon {
+  flex-shrink: 0;
+  width: 20px;
+  text-align: center;
+  color: var(--admin-text-muted);
+}
+
+.admin-sidebar-item:hover .admin-sidebar-item-icon,
+.admin-sidebar-item.active .admin-sidebar-item-icon {
+  color: var(--admin-primary);
+}
+
+.admin-sidebar-item-text {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.admin-sidebar.collapsed .admin-sidebar-item-text {
+  display: none;
+}
+
+.admin-sidebar-item-badge {
+  padding: 2px 6px;
+  font-size: var(--admin-font-size-xs);
+  font-weight: var(--admin-font-weight-medium);
+  background-color: var(--admin-primary);
+  color: var(--admin-text-inverse);
+  border-radius: var(--admin-radius-full);
+}
+
+.admin-sidebar.collapsed .admin-sidebar-item-badge {
+  display: none;
+}
+
+/* =========================================================================
+ * Content Area
+ * ========================================================================= */
+
+.admin-content {
+  flex: 1;
+  padding: var(--admin-spacing-lg);
+  padding-top: calc(var(--admin-header-height) + var(--admin-spacing-lg));
+  max-width: var(--admin-content-max-width);
+  width: 100%;
+  margin: 0 auto;
+}
+
+.admin-content-full {
+  max-width: none;
+}
+
+/* =========================================================================
+ * Page Header
+ * ========================================================================= */
+
+.admin-page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--admin-spacing-lg);
+  flex-wrap: wrap;
+  gap: var(--admin-spacing-base);
+}
+
+.admin-page-header-left {
+  display: flex;
+  flex-direction: column;
+  gap: var(--admin-spacing-xs);
+}
+
+.admin-page-title {
+  font-size: var(--admin-font-size-2xl);
+  font-weight: var(--admin-font-weight-semibold);
+  color: var(--admin-text);
+  margin: 0;
+}
+
+.admin-page-subtitle {
+  font-size: var(--admin-font-size-base);
+  color: var(--admin-text-muted);
+  margin: 0;
+}
+
+.admin-page-header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--admin-spacing-sm);
+}
+
+/* =========================================================================
+ * Breadcrumb
+ * ========================================================================= */
+
+.admin-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: var(--admin-spacing-sm);
+  padding: var(--admin-spacing-md) 0;
+  font-size: var(--admin-font-size-sm);
+  color: var(--admin-text-muted);
+}
+
+.admin-breadcrumb-item {
+  display: flex;
+  align-items: center;
+}
+
+.admin-breadcrumb-link {
+  color: var(--admin-text-link);
+  text-decoration: none;
+}
+
+.admin-breadcrumb-link:hover {
+  text-decoration: underline;
+}
+
+.admin-breadcrumb-separator {
+  margin: 0 var(--admin-spacing-xs);
+  color: var(--admin-text-muted);
+}
+
+.admin-breadcrumb-current {
+  color: var(--admin-text);
+  font-weight: var(--admin-font-weight-medium);
+}
+
+/* =========================================================================
+ * Toolbar
+ * ========================================================================= */
+
+.admin-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--admin-spacing-base);
+  padding: var(--admin-spacing-md) var(--admin-spacing-base);
+  background-color: var(--admin-bg);
+  border: 1px solid var(--admin-border-light);
+  border-radius: var(--admin-radius-md) var(--admin-radius-md) 0 0;
+  flex-wrap: wrap;
+}
+
+.admin-toolbar-left {
+  display: flex;
+  align-items: center;
+  gap: var(--admin-spacing-sm);
+}
+
+.admin-toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: var(--admin-spacing-sm);
+}
+
+.admin-toolbar-search {
+  min-width: 250px;
+}
+
+/* =========================================================================
+ * Filters Sidebar
+ * ========================================================================= */
+
+.admin-filters {
+  width: 250px;
+  flex-shrink: 0;
+  padding: var(--admin-spacing-base);
+  background-color: var(--admin-bg);
+  border: 1px solid var(--admin-border-light);
+  border-radius: var(--admin-radius-md);
+  align-self: flex-start;
+}
+
+.admin-filters-title {
+  font-size: var(--admin-font-size-md);
+  font-weight: var(--admin-font-weight-semibold);
+  margin-bottom: var(--admin-spacing-base);
+  padding-bottom: var(--admin-spacing-sm);
+  border-bottom: 1px solid var(--admin-border-light);
+}
+
+.admin-filter-group {
+  margin-bottom: var(--admin-spacing-base);
+}
+
+.admin-filter-group:last-child {
+  margin-bottom: 0;
+}
+
+.admin-filter-label {
+  font-size: var(--admin-font-size-sm);
+  font-weight: var(--admin-font-weight-medium);
+  color: var(--admin-text);
+  margin-bottom: var(--admin-spacing-xs);
+}
+
+.admin-filter-options {
+  display: flex;
+  flex-direction: column;
+  gap: var(--admin-spacing-xs);
+}
+
+.admin-filter-option {
+  display: flex;
+  align-items: center;
+  padding: var(--admin-spacing-xs) var(--admin-spacing-sm);
+  border-radius: var(--admin-radius);
+  cursor: pointer;
+  font-size: var(--admin-font-size-sm);
+  color: var(--admin-text);
+  transition: background-color var(--admin-transition-fast);
+}
+
+.admin-filter-option:hover {
+  background-color: var(--admin-bg-hover);
+}
+
+.admin-filter-option.active {
+  background-color: var(--admin-bg-selected);
+  color: var(--admin-primary);
+}
+
+.admin-filters-clear {
+  margin-top: var(--admin-spacing-base);
+  padding-top: var(--admin-spacing-base);
+  border-top: 1px solid var(--admin-border-light);
+}
+
+/* =========================================================================
+ * Two Column Layout (List with Filters)
+ * ========================================================================= */
+
+.admin-list-layout {
+  display: flex;
+  gap: var(--admin-spacing-lg);
+  align-items: flex-start;
+}
+
+.admin-list-main {
+  flex: 1;
+  min-width: 0;
+}
+
+/* =========================================================================
+ * Grid Layout
+ * ========================================================================= */
+
+.admin-grid {
+  display: grid;
+  gap: var(--admin-spacing-lg);
+}
+
+.admin-grid-2 {
+  grid-template-columns: repeat(2, 1fr);
+}
+.admin-grid-3 {
+  grid-template-columns: repeat(3, 1fr);
+}
+.admin-grid-4 {
+  grid-template-columns: repeat(4, 1fr);
+}
+
+@media (max-width: 992px) {
+  .admin-grid-3,
+  .admin-grid-4 {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 768px) {
+  .admin-grid-2,
+  .admin-grid-3,
+  .admin-grid-4 {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* =========================================================================
+ * Dashboard Stats Cards
+ * ========================================================================= */
+
+.admin-stat-card {
+  padding: var(--admin-spacing-lg);
+  background-color: var(--admin-bg);
+  border: 1px solid var(--admin-border-light);
+  border-radius: var(--admin-radius-md);
+}
+
+.admin-stat-label {
+  font-size: var(--admin-font-size-sm);
+  color: var(--admin-text-muted);
+  margin-bottom: var(--admin-spacing-xs);
+}
+
+.admin-stat-value {
+  font-size: var(--admin-font-size-3xl);
+  font-weight: var(--admin-font-weight-bold);
+  color: var(--admin-text);
+}
+
+.admin-stat-change {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--admin-spacing-xs);
+  font-size: var(--admin-font-size-sm);
+  margin-top: var(--admin-spacing-xs);
+}
+
+.admin-stat-change-up {
+  color: var(--admin-success);
+}
+.admin-stat-change-down {
+  color: var(--admin-error);
+}
+
+/* =========================================================================
+ * Form Layout
+ * ========================================================================= */
+
+.admin-form {
+  max-width: var(--admin-form-max-width);
+}
+
+.admin-form-row {
+  margin-bottom: var(--admin-spacing-base);
+}
+
+.admin-form-row:last-child {
+  margin-bottom: 0;
+}
+
+.admin-form-inline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--admin-spacing-base);
+  align-items: flex-end;
+}
+
+.admin-form-actions {
+  display: flex;
+  gap: var(--admin-spacing-sm);
+  padding-top: var(--admin-spacing-base);
+  border-top: 1px solid var(--admin-border-light);
+  margin-top: var(--admin-spacing-lg);
+}
+
+.admin-form-actions-right {
+  justify-content: flex-end;
+}
+.admin-form-actions-between {
+  justify-content: space-between;
+}
+
+/* =========================================================================
+ * Field Container
+ * ========================================================================= */
+
+.admin-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--admin-spacing-xs);
+}
+
+.admin-field-inline {
+  flex-direction: row;
+  align-items: center;
+  gap: var(--admin-spacing-sm);
+}
+
+.admin-field-horizontal {
+  flex-direction: row;
+  align-items: flex-start;
+  gap: var(--admin-spacing-base);
+}
+
+.admin-field-horizontal .admin-label {
+  flex: 0 0 200px;
+  padding-top: var(--admin-spacing-sm);
+}
+
+.admin-field-horizontal .admin-field-content {
+  flex: 1;
+}
+
+/* =========================================================================
+ * Labels
+ * ========================================================================= */
+
+.admin-label {
+  display: block;
+  font-size: var(--admin-font-size-sm);
+  font-weight: var(--admin-font-weight-semibold);
+  color: var(--admin-text);
+  margin-bottom: var(--admin-spacing-xs);
+}
+
+.admin-label-required::after {
+  content: " *";
+  color: var(--admin-error);
+}
+
+.admin-label-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--admin-spacing-sm);
+  font-weight: var(--admin-font-weight-normal);
+  cursor: pointer;
+}
+
+/* =========================================================================
+ * Text Inputs
+ * ========================================================================= */
+
+.admin-input {
+  width: 100%;
+  padding: var(--admin-spacing-sm) var(--admin-spacing-md);
+  border: 1px solid var(--admin-border);
+  border-radius: var(--admin-radius);
+  font-family: var(--admin-font-family);
+  font-size: var(--admin-font-size-base);
+  line-height: var(--admin-line-height-normal);
+  color: var(--admin-text);
+  background-color: var(--admin-bg);
+  transition:
+    border-color var(--admin-transition-fast),
+    box-shadow var(--admin-transition-fast);
+}
+
+.admin-input::placeholder {
+  color: var(--admin-text-muted);
+}
+
+.admin-input:hover:not(:disabled):not(:focus) {
+  border-color: var(--admin-border-dark);
+}
+
+.admin-input:focus {
+  outline: none;
+  border-color: var(--admin-primary);
+  box-shadow: 0 0 0 2px rgba(65, 118, 144, 0.2);
+}
+
+.admin-input:disabled {
+  background-color: var(--admin-bg-alt);
+  color: var(--admin-text-muted);
+  cursor: not-allowed;
+}
+
+.admin-input:read-only {
+  background-color: var(--admin-bg-alt);
+}
+
+.admin-input-error {
+  border-color: var(--admin-error);
+}
+
+.admin-input-error:focus {
+  border-color: var(--admin-error);
+  box-shadow: 0 0 0 2px rgba(186, 33, 33, 0.2);
+}
+
+.admin-input-sm {
+  padding: var(--admin-spacing-xs) var(--admin-spacing-sm);
+  font-size: var(--admin-font-size-sm);
+}
+
+.admin-input-lg {
+  padding: var(--admin-spacing-md) var(--admin-spacing-base);
+  font-size: var(--admin-font-size-md);
+}
+
+/* =========================================================================
+ * Textarea
+ * ========================================================================= */
+
+.admin-textarea {
+  width: 100%;
+  min-height: 120px;
+  padding: var(--admin-spacing-sm) var(--admin-spacing-md);
+  border: 1px solid var(--admin-border);
+  border-radius: var(--admin-radius);
+  font-family: var(--admin-font-family);
+  font-size: var(--admin-font-size-base);
+  line-height: var(--admin-line-height-normal);
+  color: var(--admin-text);
+  background-color: var(--admin-bg);
+  resize: vertical;
+  transition:
+    border-color var(--admin-transition-fast),
+    box-shadow var(--admin-transition-fast);
+}
+
+.admin-textarea::placeholder {
+  color: var(--admin-text-muted);
+}
+
+.admin-textarea:hover:not(:disabled):not(:focus) {
+  border-color: var(--admin-border-dark);
+}
+
+.admin-textarea:focus {
+  outline: none;
+  border-color: var(--admin-primary);
+  box-shadow: 0 0 0 2px rgba(65, 118, 144, 0.2);
+}
+
+.admin-textarea:disabled {
+  background-color: var(--admin-bg-alt);
+  color: var(--admin-text-muted);
+  cursor: not-allowed;
+}
+
+.admin-textarea-error {
+  border-color: var(--admin-error);
+}
+
+/* =========================================================================
+ * Select
+ * ========================================================================= */
+
+.admin-select {
+  width: 100%;
+  padding: var(--admin-spacing-sm) var(--admin-spacing-md);
+  padding-right: var(--admin-spacing-2xl);
+  border: 1px solid var(--admin-border);
+  border-radius: var(--admin-radius);
+  font-family: var(--admin-font-family);
+  font-size: var(--admin-font-size-base);
+  line-height: var(--admin-line-height-normal);
+  color: var(--admin-text);
+  background-color: var(--admin-bg);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23666' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  appearance: none;
+  cursor: pointer;
+  transition:
+    border-color var(--admin-transition-fast),
+    box-shadow var(--admin-transition-fast);
+}
+
+.admin-select:hover:not(:disabled):not(:focus) {
+  border-color: var(--admin-border-dark);
+}
+
+.admin-select:focus {
+  outline: none;
+  border-color: var(--admin-primary);
+  box-shadow: 0 0 0 2px rgba(65, 118, 144, 0.2);
+}
+
+.admin-select:disabled {
+  background-color: var(--admin-bg-alt);
+  color: var(--admin-text-muted);
+  cursor: not-allowed;
+}
+
+.admin-select-error {
+  border-color: var(--admin-error);
+}
+
+.admin-select-sm {
+  padding: var(--admin-spacing-xs) var(--admin-spacing-sm);
+  padding-right: var(--admin-spacing-xl);
+  font-size: var(--admin-font-size-sm);
+}
+
+/* =========================================================================
+ * Checkbox & Radio
+ * ========================================================================= */
+
+.admin-checkbox,
+.admin-radio {
+  width: 18px;
+  height: 18px;
+  margin: 0;
+  cursor: pointer;
+  accent-color: var(--admin-primary);
+}
+
+.admin-checkbox:disabled,
+.admin-radio:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.admin-checkbox-wrapper,
+.admin-radio-wrapper {
+  display: flex;
+  align-items: center;
+  gap: var(--admin-spacing-sm);
+  cursor: pointer;
+}
+
+.admin-checkbox-wrapper:has(:disabled),
+.admin-radio-wrapper:has(:disabled) {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.admin-checkbox-label,
+.admin-radio-label {
+  font-size: var(--admin-font-size-base);
+  color: var(--admin-text);
+  user-select: none;
+}
+
+.admin-checkbox-group,
+.admin-radio-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--admin-spacing-sm);
+}
+
+.admin-checkbox-group-inline,
+.admin-radio-group-inline {
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: var(--admin-spacing-base);
+}
+
+/* =========================================================================
+ * Help Text & Errors
+ * ========================================================================= */
+
+.admin-help-text {
+  font-size: var(--admin-font-size-sm);
+  color: var(--admin-text-muted);
+  margin-top: var(--admin-spacing-xs);
+}
+
+.admin-error-text {
+  font-size: var(--admin-font-size-sm);
+  color: var(--admin-error);
+  margin-top: var(--admin-spacing-xs);
+}
+
+.admin-error-list {
+  margin: var(--admin-spacing-xs) 0 0 0;
+  padding-left: var(--admin-spacing-base);
+  font-size: var(--admin-font-size-sm);
+  color: var(--admin-error);
+}
+
+.admin-error-list li {
+  margin-bottom: 2px;
+}
+
+/* =========================================================================
+ * Fieldsets
+ * ========================================================================= */
+
+.admin-fieldset {
+  border: 1px solid var(--admin-border-light);
+  border-radius: var(--admin-radius-md);
+  padding: var(--admin-spacing-base);
+  margin-bottom: var(--admin-spacing-lg);
+  background-color: var(--admin-bg);
+}
+
+.admin-fieldset-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: var(--admin-font-size-md);
+  font-weight: var(--admin-font-weight-semibold);
+  color: var(--admin-text);
+  margin-bottom: var(--admin-spacing-base);
+  padding-bottom: var(--admin-spacing-sm);
+  border-bottom: 1px solid var(--admin-border-light);
+}
+
+.admin-fieldset-description {
+  font-size: var(--admin-font-size-sm);
+  color: var(--admin-text-muted);
+  margin-bottom: var(--admin-spacing-base);
+}
+
+/* =========================================================================
+ * Search Input
+ * ========================================================================= */
+
+.admin-search {
+  position: relative;
+}
+
+.admin-search-input {
+  padding-left: var(--admin-spacing-2xl);
+}
+
+.admin-search-icon {
+  position: absolute;
+  left: var(--admin-spacing-md);
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--admin-text-muted);
+  pointer-events: none;
+}
+
+/* =========================================================================
+ * Table Container
+ * ========================================================================= */
+
+.admin-table-container {
+  width: 100%;
+  overflow-x: auto;
+  background-color: var(--admin-bg);
+  border: 1px solid var(--admin-border-light);
+  border-radius: var(--admin-radius-md);
+}
+
+.admin-table-responsive {
+  min-width: 600px;
+}
+
+/* =========================================================================
+ * Base Table
+ * ========================================================================= */
+
+.admin-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--admin-font-size-base);
+}
+
+/* =========================================================================
+ * Table Header
+ * ========================================================================= */
+
+.admin-table thead {
+  background-color: var(--admin-bg-alt);
+}
+
+.admin-table th {
+  padding: var(--admin-spacing-md) var(--admin-spacing-base);
+  text-align: left;
+  font-weight: var(--admin-font-weight-semibold);
+  font-size: var(--admin-font-size-sm);
+  color: var(--admin-text);
+  border-bottom: 2px solid var(--admin-border);
+  white-space: nowrap;
+}
+
+.admin-table th:first-child {
+  padding-left: var(--admin-spacing-base);
+}
+.admin-table th:last-child {
+  padding-right: var(--admin-spacing-base);
+}
+
+.admin-sort-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--admin-spacing-xs);
+  padding: 0;
+  border: none;
+  background: none;
+  font-weight: var(--admin-font-weight-semibold);
+  font-size: var(--admin-font-size-sm);
+  color: var(--admin-text);
+  cursor: pointer;
+  transition: color var(--admin-transition-fast);
+}
+
+.admin-sort-btn:hover {
+  color: var(--admin-primary);
+}
+.admin-sort-btn::after {
+  content: "⇅";
+  font-size: var(--admin-font-size-xs);
+  color: var(--admin-text-muted);
+  opacity: 0.5;
+}
+.admin-sort-btn.sort-asc::after {
+  content: "↑";
+  opacity: 1;
+  color: var(--admin-primary);
+}
+.admin-sort-btn.sort-desc::after {
+  content: "↓";
+  opacity: 1;
+  color: var(--admin-primary);
+}
+
+/* =========================================================================
+ * Table Body
+ * ========================================================================= */
+
+.admin-table tbody tr {
+  border-bottom: 1px solid var(--admin-border-light);
+  transition: background-color var(--admin-transition-fast);
+}
+
+.admin-table tbody tr:hover {
+  background-color: var(--admin-bg-hover);
+}
+.admin-table tbody tr:last-child {
+  border-bottom: none;
+}
+
+.admin-table td {
+  padding: var(--admin-spacing-md) var(--admin-spacing-base);
+  color: var(--admin-text);
+  vertical-align: middle;
+}
+
+.admin-table td:first-child {
+  padding-left: var(--admin-spacing-base);
+}
+.admin-table td:last-child {
+  padding-right: var(--admin-spacing-base);
+}
+
+.admin-table tbody tr.admin-row-clickable {
+  cursor: pointer;
+}
+.admin-table tbody tr.admin-row-clickable:active {
+  background-color: var(--admin-bg-selected);
+}
+.admin-table tbody tr.admin-row-selected {
+  background-color: var(--admin-bg-selected);
+}
+.admin-table tbody tr.admin-row-selected:hover {
+  background-color: #d0e8f0;
+}
+
+/* =========================================================================
+ * Table Links & Columns
+ * ========================================================================= */
+
+.admin-table-link {
+  color: var(--admin-text-link);
+  text-decoration: none;
+  font-weight: var(--admin-font-weight-medium);
+}
+
+.admin-table-link:hover {
+  color: var(--admin-text-link-hover);
+  text-decoration: underline;
+}
+
+.admin-table th.admin-col-checkbox,
+.admin-table td.admin-col-checkbox {
+  width: 40px;
+  padding-left: var(--admin-spacing-base);
+  padding-right: var(--admin-spacing-sm);
+  text-align: center;
+}
+
+.admin-table-checkbox {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  accent-color: var(--admin-primary);
+}
+
+.admin-table th.admin-col-actions,
+.admin-table td.admin-col-actions {
+  width: auto;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.admin-row-actions {
+  display: inline-flex;
+  gap: var(--admin-spacing-sm);
+  align-items: center;
+}
+
+.admin-row-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--admin-spacing-xs);
+  border: none;
+  background: none;
+  color: var(--admin-text-muted);
+  cursor: pointer;
+  border-radius: var(--admin-radius);
+  transition:
+    color var(--admin-transition-fast),
+    background-color var(--admin-transition-fast);
+}
+
+.admin-row-action:hover {
+  color: var(--admin-primary);
+  background-color: var(--admin-bg-hover);
+}
+
+.admin-row-action-danger:hover {
+  color: var(--admin-error);
+}
+
+.admin-col-center {
+  text-align: center;
+}
+.admin-col-right {
+  text-align: right;
+}
+.admin-col-number {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.admin-col-date {
+  white-space: nowrap;
+  color: var(--admin-text-light);
+  font-size: var(--admin-font-size-sm);
+}
+.admin-col-boolean {
+  text-align: center;
+}
+.admin-bool-yes {
+  color: var(--admin-success);
+}
+.admin-bool-no {
+  color: var(--admin-error);
+}
+.admin-bool-icon {
+  font-size: var(--admin-font-size-lg);
+}
+.admin-col-status {
+  white-space: nowrap;
+}
+.admin-col-id {
+  font-family: var(--admin-font-mono);
+  font-size: var(--admin-font-size-sm);
+  color: var(--admin-text-muted);
+}
+
+/* =========================================================================
+ * Table Footer & Pagination
+ * ========================================================================= */
+
+.admin-table tfoot {
+  background-color: var(--admin-bg-alt);
+}
+.admin-table tfoot td {
+  padding: var(--admin-spacing-md) var(--admin-spacing-base);
+  font-size: var(--admin-font-size-sm);
+  color: var(--admin-text-light);
+  border-top: 1px solid var(--admin-border);
+}
+
+.admin-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--admin-spacing-md) var(--admin-spacing-base);
+  background-color: var(--admin-bg-alt);
+  border-top: 1px solid var(--admin-border-light);
+  font-size: var(--admin-font-size-sm);
+}
+
+.admin-pagination-info {
+  color: var(--admin-text-light);
+}
+
+.admin-pagination-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--admin-spacing-xs);
+}
+
+.admin-pagination-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  height: 32px;
+  padding: 0 var(--admin-spacing-sm);
+  border: 1px solid var(--admin-border);
+  border-radius: var(--admin-radius);
+  background-color: var(--admin-bg);
+  color: var(--admin-text);
+  font-size: var(--admin-font-size-sm);
+  cursor: pointer;
+  transition:
+    border-color var(--admin-transition-fast),
+    background-color var(--admin-transition-fast);
+}
+
+.admin-pagination-btn:hover:not(:disabled) {
+  border-color: var(--admin-primary);
+  background-color: var(--admin-bg-hover);
+}
+
+.admin-pagination-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.admin-pagination-btn.active {
+  background-color: var(--admin-primary);
+  border-color: var(--admin-primary);
+  color: var(--admin-text-inverse);
+}
+
+.admin-pagination-ellipsis {
+  padding: 0 var(--admin-spacing-sm);
+  color: var(--admin-text-muted);
+}
+
+/* =========================================================================
+ * Action Bar (Bulk Actions)
+ * ========================================================================= */
+
+.admin-action-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--admin-spacing-base);
+  padding: var(--admin-spacing-md) var(--admin-spacing-base);
+  background-color: var(--admin-bg-selected);
+  border-bottom: 1px solid var(--admin-border-light);
+}
+
+.admin-action-bar-hidden {
+  display: none;
+}
+
+.admin-action-bar-count {
+  font-size: var(--admin-font-size-sm);
+  font-weight: var(--admin-font-weight-medium);
+  color: var(--admin-text);
+}
+
+.admin-action-bar-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--admin-spacing-sm);
+}
+
+.admin-action-select {
+  padding: var(--admin-spacing-xs) var(--admin-spacing-sm);
+  font-size: var(--admin-font-size-sm);
+}
+
+/* =========================================================================
+ * Table Empty & Loading States
+ * ========================================================================= */
+
+.admin-table-empty {
+  padding: var(--admin-spacing-3xl) var(--admin-spacing-base);
+  text-align: center;
+  color: var(--admin-text-muted);
+}
+
+.admin-table-empty-icon {
+  font-size: 48px;
+  margin-bottom: var(--admin-spacing-base);
+  opacity: 0.5;
+}
+.admin-table-empty-message {
+  font-size: var(--admin-font-size-base);
+  margin-bottom: var(--admin-spacing-sm);
+}
+.admin-table-empty-hint {
+  font-size: var(--admin-font-size-sm);
+  color: var(--admin-text-muted);
+}
+
+.admin-table-striped tbody tr:nth-child(even) {
+  background-color: var(--admin-bg-alt);
+}
+.admin-table-striped tbody tr:nth-child(even):hover {
+  background-color: var(--admin-bg-hover);
+}
+
+.admin-table-compact th,
+.admin-table-compact td {
+  padding: var(--admin-spacing-sm) var(--admin-spacing-md);
+}
+
+.admin-table-bordered th,
+.admin-table-bordered td {
+  border: 1px solid var(--admin-border-light);
+}
+
+.admin-table-bordered th {
+  border-bottom-width: 2px;
+}
+
+/* =========================================================================
+ * Login Page
+ * ========================================================================= */
+
+.admin-login-wrapper {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--admin-bg-alt);
+  padding: var(--admin-spacing-base);
+}
+
+.admin-login-box {
+  background-color: var(--admin-bg);
+  border: 1px solid var(--admin-border-light);
+  border-radius: var(--admin-radius-lg);
+  box-shadow: var(--admin-shadow-md);
+  padding: var(--admin-spacing-2xl);
+  width: 100%;
+  max-width: 400px;
+}
+
+.admin-login-header {
+  text-align: center;
+  margin-bottom: var(--admin-spacing-xl);
+}
+
+.admin-login-title {
+  font-size: var(--admin-font-size-xl);
+  font-weight: var(--admin-font-weight-bold);
+  color: var(--admin-text);
+  margin-bottom: var(--admin-spacing-xs);
+}
+
+.admin-login-subtitle {
+  font-size: var(--admin-font-size-sm);
+  color: var(--admin-text-muted);
+}
+
+/* =========================================================================
+ * HTMX Loading Indicator
+ * ========================================================================= */
+
+.htmx-indicator {
+  display: none;
+}
+
+.htmx-request .htmx-indicator,
+.htmx-request.htmx-indicator {
+  display: inline-block;
+}
+
+/* =========================================================================
+ * Responsive Layout
+ * ========================================================================= */
+
+@media (max-width: 1024px) {
+  .admin-sidebar {
+    transform: translateX(-100%);
+    transition: transform var(--admin-transition-slow);
+  }
+
+  .admin-sidebar.open {
+    transform: translateX(0);
+  }
+
+  .admin-content-wrapper {
+    margin-left: 0;
+  }
+
+  .admin-list-layout {
+    flex-direction: column;
+  }
+
+  .admin-filters {
+    width: 100%;
+  }
+}
+
+@media (max-width: 768px) {
+  .admin-content {
+    padding: var(--admin-spacing-md);
+    padding-top: calc(var(--admin-header-height) + var(--admin-spacing-md));
+  }
+
+  .admin-page-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .admin-page-header-actions {
+    width: 100%;
+  }
+
+  .admin-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .admin-toolbar-search {
+    min-width: auto;
+    width: 100%;
+  }
+}
+
+@media screen and (max-width: 575px) {
+  .admin-table-container {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .admin-table {
+    min-width: 600px;
+  }
+
+  .admin-table th,
+  .admin-table td {
+    padding: 8px 10px;
+    font-size: 13px;
+  }
+
+  .admin-table .admin-col-hide-mobile {
+    display: none;
+  }
+
+  .admin-form-row {
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .admin-form-actions {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .admin-form-actions .admin-btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .admin-pagination {
+    flex-direction: column;
+    gap: 12px;
+    text-align: center;
+  }
+
+  .admin-pagination-info {
+    order: 1;
+  }
+  .admin-pagination-controls {
+    order: 0;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+}
+
+/* =========================================================================
+ * Print
+ * ========================================================================= */
+
+@media print {
+  .admin-sidebar,
+  .admin-header-nav,
+  .admin-action-bar,
+  .admin-pagination-controls,
+  .admin-form-actions,
+  .admin-table-checkbox,
+  .admin-col-checkbox {
+    display: none !important;
+  }
+
+  .admin-content-wrapper {
+    margin-left: 0 !important;
+  }
+
+  .admin-table {
+    font-size: 11px;
+  }
+
+  .admin-table th,
+  .admin-table td {
+    padding: 6px 8px;
+    border: 1px solid #cccccc;
+  }
+}
+
+/* =========================================================================
+ * Reduced Motion
+ * ========================================================================= */
+
+@media (prefers-reduced-motion: reduce) {
+  .admin-sidebar,
+  .admin-spinner {
+    transition: none !important;
+    animation: none !important;
+  }
+}

--- a/src/admin/static/js/admin.js
+++ b/src/admin/static/js/admin.js
@@ -1,0 +1,38 @@
+/**
+ * Alexi Admin JS
+ *
+ * Injects JWT Authorization header into every HTMX request.
+ * Token is stored in localStorage under "alexi_admin_token".
+ */
+(function () {
+  var TOKEN_KEY = "alexi_admin_token";
+
+  // Inject Authorization header on every HTMX request
+  document.body.addEventListener("htmx:configRequest", function (evt) {
+    var token = localStorage.getItem(TOKEN_KEY);
+    if (token) {
+      evt.detail.headers["Authorization"] = "Bearer " + token;
+    }
+  });
+
+  // Handle HX-Redirect response header (used after login)
+  document.body.addEventListener("htmx:afterRequest", function (evt) {
+    var redirect = evt.detail.xhr.getResponseHeader("HX-Redirect");
+    if (redirect) {
+      window.location.href = redirect;
+    }
+  });
+
+  // Expose helpers for login/logout
+  window.adminAuth = {
+    setToken: function (token) {
+      localStorage.setItem(TOKEN_KEY, token);
+    },
+    removeToken: function () {
+      localStorage.removeItem(TOKEN_KEY);
+    },
+    getToken: function () {
+      return localStorage.getItem(TOKEN_KEY);
+    },
+  };
+})();

--- a/src/admin/templates/mpa/base.ts
+++ b/src/admin/templates/mpa/base.ts
@@ -1,0 +1,237 @@
+/**
+ * Alexi Admin Base Template
+ *
+ * Base HTML template for the admin MPA.
+ * All other templates use this as their outer shell.
+ *
+ * @module
+ */
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface BaseTemplateContext {
+  /** Page title (e.g. "Dashboard") */
+  title: string;
+  /** Admin site title (e.g. "Alexi Administration") */
+  siteTitle: string;
+  /** URL prefix for the admin (e.g. "/admin") */
+  urlPrefix: string;
+  /** Currently logged-in user's email, if any */
+  userEmail?: string;
+  /** Flash messages to display */
+  messages?: Array<
+    { level: "success" | "error" | "warning" | "info"; text: string }
+  >;
+  /** Navigation items for the sidebar */
+  navItems?: Array<{ name: string; url: string; active?: boolean }>;
+  /** Inner HTML content for the <main> region */
+  content: string;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#x27;");
+}
+
+function renderMessages(
+  messages?: BaseTemplateContext["messages"],
+): string {
+  if (!messages || messages.length === 0) return "";
+  return messages
+    .map(
+      (m) =>
+        `<div class="admin-alert admin-alert-${
+          escapeHtml(m.level)
+        }" role="alert">${escapeHtml(m.text)}</div>`,
+    )
+    .join("\n");
+}
+
+function renderNavItems(
+  items: BaseTemplateContext["navItems"],
+  urlPrefix: string,
+): string {
+  if (!items || items.length === 0) return "";
+  return items
+    .map(
+      (item) =>
+        `<a href="${escapeHtml(item.url)}" class="admin-sidebar-item${
+          item.active ? " active" : ""
+        }">${escapeHtml(item.name)}</a>`,
+    )
+    .join("\n");
+}
+
+// =============================================================================
+// Base Template
+// =============================================================================
+
+/**
+ * Render the base admin page template.
+ */
+export function baseTemplate(ctx: BaseTemplateContext): string {
+  const {
+    title,
+    siteTitle,
+    urlPrefix,
+    userEmail,
+    messages,
+    navItems,
+    content,
+  } = ctx;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escapeHtml(title)} | ${escapeHtml(siteTitle)}</title>
+  <link rel="stylesheet" href="${escapeHtml(urlPrefix)}/static/css/admin.css">
+  <script src="https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js" defer></script>
+  <script src="${escapeHtml(urlPrefix)}/static/js/admin.js" defer></script>
+</head>
+<body hx-boost="true">
+  <div class="admin-layout">
+
+    <!-- Header -->
+    <header class="admin-header">
+      <div class="admin-header-brand">
+        <a href="${escapeHtml(urlPrefix)}/" class="admin-header-title">${
+    escapeHtml(siteTitle)
+  }</a>
+      </div>
+      <nav class="admin-header-nav">
+        ${
+    userEmail
+      ? `<span class="admin-header-link">${escapeHtml(userEmail)}</span>
+        <a href="${escapeHtml(urlPrefix)}/logout/" class="admin-header-link"
+           hx-boost="false"
+           onclick="window.adminAuth && window.adminAuth.removeToken(); return true;">Log out</a>`
+      : `<a href="${
+        escapeHtml(urlPrefix)
+      }/login/" class="admin-header-link">Log in</a>`
+  }
+      </nav>
+    </header>
+
+    <div class="admin-main">
+
+      <!-- Sidebar -->
+      <nav class="admin-sidebar" aria-label="Admin navigation">
+        <div class="admin-sidebar-nav">
+          ${
+    navItems && navItems.length > 0
+      ? `<div class="admin-sidebar-section">
+            <div class="admin-sidebar-section-title">Navigation</div>
+            ${renderNavItems(navItems, urlPrefix)}
+          </div>`
+      : ""
+  }
+        </div>
+      </nav>
+
+      <!-- Content -->
+      <div class="admin-content-wrapper">
+        <main class="admin-content" id="main-content">
+          ${renderMessages(messages)}
+          ${content}
+        </main>
+      </div>
+
+    </div><!-- /.admin-main -->
+  </div><!-- /.admin-layout -->
+</body>
+</html>`;
+}
+
+// =============================================================================
+// Login Template (no sidebar/header — standalone page)
+// =============================================================================
+
+export interface LoginTemplateContext {
+  siteTitle: string;
+  urlPrefix: string;
+  error?: string;
+  next?: string;
+}
+
+/**
+ * Render the login page (standalone, no sidebar).
+ */
+export function loginTemplate(ctx: LoginTemplateContext): string {
+  const { siteTitle, urlPrefix, error, next } = ctx;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Log in | ${escapeHtml(siteTitle)}</title>
+  <link rel="stylesheet" href="${escapeHtml(urlPrefix)}/static/css/admin.css">
+  <script src="https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js" defer></script>
+  <script src="${escapeHtml(urlPrefix)}/static/js/admin.js" defer></script>
+</head>
+<body>
+  <div class="admin-login-wrapper">
+    <div class="admin-login-box">
+      <div class="admin-login-header">
+        <h1 class="admin-login-title">${escapeHtml(siteTitle)}</h1>
+        <p class="admin-login-subtitle">Please log in to continue.</p>
+      </div>
+      ${
+    error
+      ? `<div class="admin-alert admin-alert-error">${escapeHtml(error)}</div>`
+      : ""
+  }
+      <form
+        method="POST"
+        action="${escapeHtml(urlPrefix)}/login/"
+        hx-post="${escapeHtml(urlPrefix)}/login/"
+        hx-target="body"
+        hx-swap="outerHTML"
+      >
+        ${
+    next ? `<input type="hidden" name="next" value="${escapeHtml(next)}">` : ""
+  }
+        <div class="admin-form-row">
+          <label class="admin-label admin-label-required" for="email">Email address</label>
+          <input
+            class="admin-input"
+            type="email"
+            id="email"
+            name="email"
+            autocomplete="email"
+            required
+            autofocus
+          >
+        </div>
+        <div class="admin-form-row">
+          <label class="admin-label admin-label-required" for="password">Password</label>
+          <input
+            class="admin-input"
+            type="password"
+            id="password"
+            name="password"
+            autocomplete="current-password"
+            required
+          >
+        </div>
+        <div class="admin-form-actions">
+          <button type="submit" class="admin-btn admin-btn-primary" style="width:100%;">Log in</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</body>
+</html>`;
+}


### PR DESCRIPTION
## Summary

- Add `src/admin/static/css/admin.css` — consolidated Django-style admin stylesheet (~1000 lines) with CSS variables, layout, forms, tables, responsive, login box, and HTMX indicator classes
- Add `src/admin/static/js/admin.js` — JWT interceptor for HTMX requests, `HX-Redirect` handler, and `window.adminAuth` helpers
- Add `src/admin/templates/mpa/base.ts` — `baseTemplate()` and `loginTemplate()` functions returning full HTML strings with HTMX CDN, CSS/JS links, header, sidebar nav, and main content
- Add static file route to `createAdminUrls()` in `admin_views.ts`: serves `admin.css` and `admin.js` from `/admin/static/*` using `import.meta.url`
- Add `./templates/mpa` export to `deno.jsonc`

Closes #124