### PR TITLE
feat(admin): login/logout views + JWT authentication

### DIFF
--- a/src/admin/tests/login_test.ts
+++ b/src/admin/tests/login_test.ts
@@ -1,0 +1,210 @@
+/**
+ * Login/Logout view tests for Alexi Admin
+ *
+ * Tests for GET /admin/login/, POST /admin/login/, and GET /admin/logout/.
+ * Uses an in-memory mock backend so no real database is needed.
+ *
+ * @module
+ */
+
+import { assertEquals, assertStringIncludes } from "jsr:@std/assert@1";
+import { AdminSite } from "../mod.ts";
+import {
+  handleLoginPost,
+  handleLogout,
+  renderLoginPage,
+} from "../views/login_views.ts";
+import type { LoginViewContext } from "../views/login_views.ts";
+import type { DatabaseBackend } from "@alexi/db";
+
+// =============================================================================
+// Minimal mock backend (we only need it for type satisfaction in the context)
+// =============================================================================
+
+const mockBackend = {} as DatabaseBackend;
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function makeSite(): AdminSite {
+  return new AdminSite({ urlPrefix: "/admin", title: "Test Admin" });
+}
+
+// =============================================================================
+// GET /admin/login/ — renderLoginPage
+// =============================================================================
+
+Deno.test("renderLoginPage: returns 200 HTML", () => {
+  const site = makeSite();
+  const response = renderLoginPage(site);
+
+  assertEquals(response.status, 200);
+  assertEquals(
+    response.headers.get("content-type"),
+    "text/html; charset=utf-8",
+  );
+});
+
+Deno.test("renderLoginPage: contains form action", async () => {
+  const site = makeSite();
+  const response = renderLoginPage(site);
+  const html = await response.text();
+
+  assertStringIncludes(html, "/admin/login/");
+  assertStringIncludes(html, 'type="email"');
+  assertStringIncludes(html, 'type="password"');
+});
+
+Deno.test("renderLoginPage: shows error message when provided", async () => {
+  const site = makeSite();
+  const response = renderLoginPage(site, { error: "Invalid credentials" });
+  const html = await response.text();
+
+  assertStringIncludes(html, "Invalid credentials");
+});
+
+Deno.test("renderLoginPage: includes next hidden field when provided", async () => {
+  const site = makeSite();
+  const response = renderLoginPage(site, { next: "/admin/users/" });
+  const html = await response.text();
+
+  assertStringIncludes(html, "/admin/users/");
+});
+
+// =============================================================================
+// POST /admin/login/ — handleLoginPost
+// =============================================================================
+
+Deno.test("handleLoginPost: returns error when AUTH_USER_MODEL not configured", async () => {
+  const site = makeSite();
+  const request = new Request("http://localhost/admin/login/", {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: "email=admin%40example.com&password=secret",
+  });
+
+  const ctx: LoginViewContext = {
+    request,
+    params: {},
+    adminSite: site,
+    backend: mockBackend,
+    settings: {}, // No AUTH_USER_MODEL
+  };
+
+  const response = await handleLoginPost(ctx);
+  const html = await response.text();
+
+  assertEquals(response.status, 200);
+  assertStringIncludes(html, "Authentication is not configured");
+});
+
+Deno.test("handleLoginPost: returns error when fields are missing", async () => {
+  const site = makeSite();
+  const request = new Request("http://localhost/admin/login/", {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: "email=admin%40example.com", // missing password
+  });
+
+  const ctx: LoginViewContext = {
+    request,
+    params: {},
+    adminSite: site,
+    backend: mockBackend,
+    settings: { AUTH_USER_MODEL: "./nonexistent.ts" },
+  };
+
+  const response = await handleLoginPost(ctx);
+  const html = await response.text();
+
+  assertEquals(response.status, 200);
+  assertStringIncludes(html, "Please enter both email and password");
+});
+
+Deno.test("handleLoginPost: returns config error when user model cannot be loaded", async () => {
+  const site = makeSite();
+
+  const request = new Request("http://localhost/admin/login/", {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: "email=nobody%40example.com&password=wrong",
+  });
+
+  const ctx: LoginViewContext = {
+    request,
+    params: {},
+    adminSite: site,
+    backend: mockBackend,
+    // Point to a module that doesn't exist — loadUserModel returns null
+    settings: { AUTH_USER_MODEL: "/nonexistent/path/user.ts" },
+  };
+
+  const response = await handleLoginPost(ctx);
+  const html = await response.text();
+
+  assertEquals(response.status, 200);
+  // Can't load module → config error is shown
+  assertStringIncludes(html, "Authentication configuration error");
+});
+
+// =============================================================================
+// GET /admin/logout/ — handleLogout
+// =============================================================================
+
+Deno.test("handleLogout: returns 200 HTML", () => {
+  const site = makeSite();
+  const response = handleLogout(site);
+
+  assertEquals(response.status, 200);
+  assertEquals(
+    response.headers.get("content-type"),
+    "text/html; charset=utf-8",
+  );
+});
+
+Deno.test("handleLogout: clears adminToken from localStorage", async () => {
+  const site = makeSite();
+  const response = handleLogout(site);
+  const html = await response.text();
+
+  assertStringIncludes(html, "removeItem");
+  assertStringIncludes(html, "adminToken");
+});
+
+Deno.test("handleLogout: sets HX-Redirect to login page", () => {
+  const site = makeSite();
+  const response = handleLogout(site);
+
+  assertEquals(response.headers.get("HX-Redirect"), "/admin/login/");
+});
+
+Deno.test("handleLogout: redirects to login page", async () => {
+  const site = makeSite();
+  const response = handleLogout(site);
+  const html = await response.text();
+
+  assertStringIncludes(html, "/admin/login/");
+});
+
+// =============================================================================
+// URL routing — login/logout routes present in getAdminUrls
+// =============================================================================
+
+Deno.test("getAdminUrls: includes login URL in placeholder mode", async () => {
+  const { getAdminUrls } = await import("../urls.ts");
+  const site = makeSite();
+  const urls = getAdminUrls(site);
+
+  const loginUrl = urls.find((u) => u.name === "admin:login");
+  assertEquals(loginUrl?.pattern, "/admin/login/");
+});
+
+Deno.test("getAdminUrls: includes logout URL in placeholder mode", async () => {
+  const { getAdminUrls } = await import("../urls.ts");
+  const site = makeSite();
+  const urls = getAdminUrls(site);
+
+  const logoutUrl = urls.find((u) => u.name === "admin:logout");
+  assertEquals(logoutUrl?.pattern, "/admin/logout/");
+});

--- a/src/admin/views/admin_views.ts
+++ b/src/admin/views/admin_views.ts
@@ -754,8 +754,9 @@ function formatValue(value: unknown): string {
 export function createAdminUrls(
   adminSite: AdminSite,
   backend: DatabaseBackend,
+  settings?: Record<string, unknown>,
 ) {
-  return getAdminUrls(adminSite, backend);
+  return getAdminUrls(adminSite, backend, settings);
 }
 
 /**
@@ -767,8 +768,9 @@ export function createAdminUrls(
 export function createAdminHandler(
   adminSite: AdminSite,
   backend: DatabaseBackend,
+  settings?: Record<string, unknown>,
 ): (request: Request) => Promise<Response | null> {
-  const patterns = getAdminUrls(adminSite, backend);
+  const patterns = getAdminUrls(adminSite, backend, settings);
 
   return async (request: Request): Promise<Response | null> => {
     const url = new URL(request.url);

--- a/src/admin/views/login_views.ts
+++ b/src/admin/views/login_views.ts
@@ -1,0 +1,421 @@
+/**
+ * Alexi Admin Login Views
+ *
+ * Handles GET /admin/login/, POST /admin/login/, and GET|POST /admin/logout/.
+ * Authentication is JWT-based: on success the browser stores the token in
+ * localStorage (via admin.js) and subsequent HTMX requests inject it as
+ * Authorization: Bearer <token>.
+ *
+ * @module
+ */
+
+import type { AdminSite } from "../site.ts";
+import type { DatabaseBackend } from "@alexi/db";
+import { loginTemplate } from "../templates/mpa/base.ts";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface LoginViewContext {
+  request: Request;
+  params: Record<string, string>;
+  adminSite: AdminSite;
+  backend: DatabaseBackend;
+  /** Settings object, used to load AUTH_USER_MODEL and SECRET_KEY */
+  settings?: Record<string, unknown>;
+}
+
+// =============================================================================
+// JWT Helpers (inline — avoids dependency on @alexi/auth internals)
+// =============================================================================
+
+/**
+ * Base64url-encode a Uint8Array.
+ */
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(
+    /=+$/,
+    "",
+  );
+}
+
+/**
+ * Create an HS256-signed JWT.
+ * Falls back to unsigned (alg: none) when no secret is set — dev only.
+ */
+async function createJWT(
+  payload: Record<string, unknown>,
+  secretKey: string,
+): Promise<string> {
+  const encoder = new TextEncoder();
+
+  if (secretKey) {
+    const header = base64UrlEncode(
+      encoder.encode(JSON.stringify({ alg: "HS256", typ: "JWT" })),
+    );
+    const body = base64UrlEncode(encoder.encode(JSON.stringify(payload)));
+    const signingInput = `${header}.${body}`;
+
+    const keyMaterial = await crypto.subtle.importKey(
+      "raw",
+      encoder.encode(secretKey),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"],
+    );
+
+    const signatureBuffer = await crypto.subtle.sign(
+      "HMAC",
+      keyMaterial,
+      encoder.encode(signingInput),
+    );
+
+    const sig = base64UrlEncode(new Uint8Array(signatureBuffer));
+    return `${signingInput}.${sig}`;
+  } else {
+    // No secret — unsigned token (development only)
+    const header = base64UrlEncode(
+      encoder.encode(JSON.stringify({ alg: "none", typ: "JWT" })),
+    );
+    const body = base64UrlEncode(encoder.encode(JSON.stringify(payload)));
+    return `${header}.${body}.`;
+  }
+}
+
+/**
+ * Create an access token for the given user.
+ * Expires in 15 minutes.
+ */
+async function createAccessToken(
+  userId: unknown,
+  email: string,
+  isAdmin: boolean,
+  secretKey: string,
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  return createJWT(
+    {
+      userId,
+      email,
+      isAdmin,
+      iat: now,
+      exp: now + 15 * 60, // 15 minutes
+    },
+    secretKey,
+  );
+}
+
+// =============================================================================
+// User Model Helpers
+// =============================================================================
+
+interface UserRecord {
+  id: unknown;
+  email: string;
+  passwordHash: string;
+  isAdmin: boolean;
+  isActive: boolean;
+}
+
+type UserModelLike = {
+  objects: {
+    using(b: DatabaseBackend): {
+      filter(q: Record<string, unknown>): {
+        first(): Promise<unknown>;
+      };
+    };
+  };
+};
+
+/**
+ * Dynamically load UserModel and verifyPassword from AUTH_USER_MODEL setting.
+ */
+async function loadUserModel(
+  authUserModelPath: string,
+): Promise<{
+  UserModel: UserModelLike | null;
+  verifyPassword: ((plain: string, hash: string) => Promise<boolean>) | null;
+}> {
+  try {
+    // Resolve file path to URL
+    let url = authUserModelPath;
+    if (!url.startsWith("file://") && !url.startsWith("http")) {
+      const normalized = url.replace(/\\/g, "/");
+      if (/^[A-Za-z]:\//.test(normalized)) {
+        url = `file:///${normalized}`;
+      } else if (normalized.startsWith("/")) {
+        url = `file://${normalized}`;
+      } else {
+        const cwd = Deno.cwd().replace(/\\/g, "/");
+        const abs = `${cwd}/${normalized}`;
+        url = /^[A-Za-z]:\//.test(abs) ? `file:///${abs}` : `file://${abs}`;
+      }
+    }
+
+    const mod = await import(url);
+    const UserModel = (mod.UserModel as UserModelLike | undefined) ?? null;
+    const verifyPassword = (mod.verifyPassword as
+      | ((plain: string, hash: string) => Promise<boolean>)
+      | undefined) ?? null;
+
+    return { UserModel, verifyPassword };
+  } catch {
+    return { UserModel: null, verifyPassword: null };
+  }
+}
+
+/**
+ * Extract a plain value from a model field (supports .get() accessor or raw value).
+ */
+function fieldValue(model: unknown, key: string): unknown {
+  const obj = model as Record<string, unknown>;
+  const field = obj[key];
+  if (field && typeof field === "object" && "get" in field) {
+    return (field as { get(): unknown }).get();
+  }
+  return field;
+}
+
+// =============================================================================
+// GET /admin/login/
+// =============================================================================
+
+/**
+ * Render the login page (GET).
+ */
+export function renderLoginPage(
+  adminSite: AdminSite,
+  options: { error?: string; next?: string } = {},
+): Response {
+  const html = loginTemplate({
+    siteTitle: adminSite.title,
+    urlPrefix: adminSite.urlPrefix.replace(/\/$/, ""),
+    error: options.error,
+    next: options.next,
+  });
+
+  return new Response(html, {
+    status: 200,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}
+
+// =============================================================================
+// POST /admin/login/
+// =============================================================================
+
+/**
+ * Handle login form submission (POST).
+ *
+ * On success:
+ *   - Returns HTML with an inline <script> that stores the token in localStorage
+ *   - Sets HX-Redirect: /admin/ header so HTMX (or admin.js) redirects the page
+ *
+ * On failure:
+ *   - Re-renders the login page with an error message
+ */
+export async function handleLoginPost(
+  context: LoginViewContext,
+): Promise<Response> {
+  const { request, adminSite, backend, settings } = context;
+  const urlPrefix = adminSite.urlPrefix.replace(/\/$/, "");
+
+  // Parse form body
+  let email = "";
+  let password = "";
+  let next = "";
+
+  try {
+    const contentType = request.headers.get("content-type") ?? "";
+    if (contentType.includes("application/x-www-form-urlencoded")) {
+      const text = await request.text();
+      const params = new URLSearchParams(text);
+      email = params.get("email") ?? "";
+      password = params.get("password") ?? "";
+      next = params.get("next") ?? "";
+    } else if (contentType.includes("multipart/form-data")) {
+      const formData = await request.formData();
+      email = (formData.get("email") as string) ?? "";
+      password = (formData.get("password") as string) ?? "";
+      next = (formData.get("next") as string) ?? "";
+    }
+  } catch {
+    return renderLoginPage(adminSite, { error: "Invalid form submission." });
+  }
+
+  if (!email || !password) {
+    return renderLoginPage(adminSite, {
+      error: "Please enter both email and password.",
+      next,
+    });
+  }
+
+  // Load AUTH_USER_MODEL
+  const authUserModelPath = settings?.AUTH_USER_MODEL as string | undefined;
+  if (!authUserModelPath) {
+    return renderLoginPage(adminSite, {
+      error: "Authentication is not configured (AUTH_USER_MODEL missing).",
+      next,
+    });
+  }
+
+  const { UserModel, verifyPassword } = await loadUserModel(authUserModelPath);
+
+  if (!UserModel || !verifyPassword) {
+    return renderLoginPage(adminSite, {
+      error:
+        "Authentication configuration error. Check AUTH_USER_MODEL exports.",
+      next,
+    });
+  }
+
+  // Look up the user
+  let user: unknown = null;
+  try {
+    user = await UserModel.objects.using(backend).filter({ email }).first();
+  } catch {
+    return renderLoginPage(adminSite, {
+      error: "An error occurred during authentication.",
+      next,
+    });
+  }
+
+  if (!user) {
+    return renderLoginPage(adminSite, {
+      error: "Invalid email or password.",
+      next,
+    });
+  }
+
+  // Verify password
+  const storedHash = fieldValue(user, "passwordHash") as string;
+  let passwordValid = false;
+  try {
+    passwordValid = await verifyPassword(password, storedHash);
+  } catch {
+    return renderLoginPage(adminSite, {
+      error: "An error occurred during authentication.",
+      next,
+    });
+  }
+
+  if (!passwordValid) {
+    return renderLoginPage(adminSite, {
+      error: "Invalid email or password.",
+      next,
+    });
+  }
+
+  // Check isActive
+  const isActive = fieldValue(user, "isActive") as boolean;
+  if (!isActive) {
+    return renderLoginPage(adminSite, {
+      error: "This account is inactive.",
+      next,
+    });
+  }
+
+  // Check isAdmin (admin panel requires admin access)
+  const isAdmin = fieldValue(user, "isAdmin") as boolean;
+  if (!isAdmin) {
+    return renderLoginPage(adminSite, {
+      error: "You do not have permission to access the admin panel.",
+      next,
+    });
+  }
+
+  // Create JWT token
+  const userId = fieldValue(user, "id");
+  const userEmail = fieldValue(user, "email") as string;
+  const secretKey = (settings?.SECRET_KEY as string | undefined) ??
+    Deno.env.get("SECRET_KEY") ??
+    "";
+
+  let token: string;
+  try {
+    token = await createAccessToken(userId, userEmail, isAdmin, secretKey);
+  } catch {
+    return renderLoginPage(adminSite, {
+      error: "Failed to create session token.",
+      next,
+    });
+  }
+
+  // Determine redirect target
+  const redirectTo = next && next.startsWith("/") ? next : `${urlPrefix}/`;
+
+  // Return HTML page that stores the token and redirects.
+  // admin.js listens for HX-Redirect but we also handle the plain redirect case.
+  const html = `<!DOCTYPE html>
+<html>
+<head><meta charset="UTF-8"></head>
+<body>
+<script>
+  (function() {
+    try {
+      localStorage.setItem('adminToken', ${JSON.stringify(token)});
+    } catch(e) {}
+    window.location.href = ${JSON.stringify(redirectTo)};
+  })();
+</script>
+<noscript>
+  <p>Login successful. <a href="${redirectTo}">Click here to continue</a>.</p>
+</noscript>
+</body>
+</html>`;
+
+  return new Response(html, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      // HTMX will follow this header for hx-post requests
+      "HX-Redirect": redirectTo,
+    },
+  });
+}
+
+// =============================================================================
+// GET|POST /admin/logout/
+// =============================================================================
+
+/**
+ * Handle logout.
+ *
+ * Returns HTML that clears localStorage and redirects to the login page.
+ * Also sets HX-Redirect for HTMX clients.
+ */
+export function handleLogout(adminSite: AdminSite): Response {
+  const urlPrefix = adminSite.urlPrefix.replace(/\/$/, "");
+  const loginUrl = `${urlPrefix}/login/`;
+
+  const html = `<!DOCTYPE html>
+<html>
+<head><meta charset="UTF-8"></head>
+<body>
+<script>
+  (function() {
+    try {
+      localStorage.removeItem('adminToken');
+    } catch(e) {}
+    window.location.href = ${JSON.stringify(loginUrl)};
+  })();
+</script>
+<noscript>
+  <p>You have been logged out. <a href="${loginUrl}">Log in again</a>.</p>
+</noscript>
+</body>
+</html>`;
+
+  return new Response(html, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      "HX-Redirect": loginUrl,
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- Adds `views/login_views.ts` with full GET/POST login and logout handlers
- Login POST validates credentials via `AUTH_USER_MODEL` setting, issues HS256-signed JWT stored in `localStorage`
- Logout clears `adminToken` from `localStorage` and redirects via `HX-Redirect`
- Updates `urls.ts`: login/logout routes added to both real and placeholder branches; `getAdminUrls` and `AdminRouter` accept optional `settings` param
- Updates `views/admin_views.ts`: `createAdminHandler` and `createAdminUrls` accept optional `settings` param
- Adds `tests/login_test.ts` with 13 tests (all passing)

Closes #126