### PR TITLE
feat(admin): dashboard view with JWT auth guard

### DIFF
--- a/src/admin/tests/dashboard_test.ts
+++ b/src/admin/tests/dashboard_test.ts
@@ -1,0 +1,386 @@
+/**
+ * Tests for the Admin Dashboard view (#127)
+ *
+ * These tests cover:
+ *  - Auth guard: unauthenticated requests redirect to /admin/login/
+ *  - Authenticated requests return 200 with dashboard HTML
+ *  - Dashboard HTML contains expected elements (nav, model list, breadcrumbs)
+ *  - Sidebar nav contains registered models
+ */
+
+import { assertEquals, assertStringIncludes } from "jsr:@std/assert@1";
+import { AdminSite } from "../site.ts";
+import { ModelAdmin } from "../model_admin.ts";
+import { renderDashboard } from "../views/dashboard_views.ts";
+import { verifyAdminToken } from "../views/auth_guard.ts";
+import { AutoField, CharField, Manager, Model } from "@alexi/db";
+
+// =============================================================================
+// Test models
+// =============================================================================
+
+class ArticleModel extends Model {
+  id = new AutoField({ primaryKey: true });
+  title = new CharField({ maxLength: 200 });
+  static objects = new Manager(ArticleModel);
+  static override meta = {
+    dbTable: "articles",
+    verboseName: "Article",
+    verboseNamePlural: "Articles",
+  };
+}
+
+class UserModel extends Model {
+  id = new AutoField({ primaryKey: true });
+  email = new CharField({ maxLength: 200 });
+  static objects = new Manager(UserModel);
+  static override meta = {
+    dbTable: "users",
+    verboseName: "User",
+    verboseNamePlural: "Users",
+  };
+}
+
+// =============================================================================
+// Helper: create an unsigned dev JWT (alg: none)
+// =============================================================================
+
+function makeDevToken(payload: Record<string, unknown>): string {
+  const encode = (obj: Record<string, unknown>) => {
+    const json = JSON.stringify(obj);
+    return btoa(json).replace(/\+/g, "-").replace(/\//g, "_").replace(
+      /=+$/,
+      "",
+    );
+  };
+  const header = encode({ alg: "none", typ: "JWT" });
+  const body = encode(payload);
+  return `${header}.${body}.`;
+}
+
+function makeValidToken(): string {
+  const now = Math.floor(Date.now() / 1000);
+  return makeDevToken({
+    userId: 1,
+    email: "admin@example.com",
+    isAdmin: true,
+    iat: now,
+    exp: now + 900,
+  });
+}
+
+function makeExpiredToken(): string {
+  const past = Math.floor(Date.now() / 1000) - 1000;
+  return makeDevToken({
+    userId: 1,
+    email: "admin@example.com",
+    isAdmin: true,
+    iat: past - 900,
+    exp: past,
+  });
+}
+
+function makeRequest(
+  path = "/admin/",
+  token?: string,
+): Request {
+  const headers: Record<string, string> = {};
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+  return new Request(`http://localhost${path}`, { headers });
+}
+
+// =============================================================================
+// verifyAdminToken tests
+// =============================================================================
+
+Deno.test({
+  name:
+    "verifyAdminToken: returns authenticated=false when no Authorization header",
+  async fn() {
+    const req = new Request("http://localhost/admin/");
+    const result = await verifyAdminToken(req);
+    assertEquals(result.authenticated, false);
+  },
+});
+
+Deno.test({
+  name: "verifyAdminToken: returns authenticated=false for malformed header",
+  async fn() {
+    const req = new Request("http://localhost/admin/", {
+      headers: { Authorization: "Basic abc123" },
+    });
+    const result = await verifyAdminToken(req);
+    assertEquals(result.authenticated, false);
+  },
+});
+
+Deno.test({
+  name: "verifyAdminToken: returns authenticated=false for expired token",
+  async fn() {
+    const req = makeRequest("/admin/", makeExpiredToken());
+    const result = await verifyAdminToken(req);
+    assertEquals(result.authenticated, false);
+  },
+});
+
+Deno.test({
+  name:
+    "verifyAdminToken: returns authenticated=true for valid unsigned dev token (no SECRET_KEY)",
+  async fn() {
+    // Remove SECRET_KEY from env if set (dev mode)
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    try {
+      const req = makeRequest("/admin/", makeValidToken());
+      const result = await verifyAdminToken(req);
+      assertEquals(result.authenticated, true);
+      assertEquals(result.email, "admin@example.com");
+      assertEquals(result.isAdmin, true);
+    } finally {
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+Deno.test({
+  name: "verifyAdminToken: rejects unsigned token when SECRET_KEY is set",
+  async fn() {
+    const original = Deno.env.get("SECRET_KEY");
+    Deno.env.set("SECRET_KEY", "supersecret");
+
+    try {
+      const req = makeRequest("/admin/", makeValidToken());
+      const result = await verifyAdminToken(req);
+      assertEquals(result.authenticated, false);
+    } finally {
+      if (original !== undefined) {
+        Deno.env.set("SECRET_KEY", original);
+      } else {
+        Deno.env.delete("SECRET_KEY");
+      }
+    }
+  },
+});
+
+// =============================================================================
+// renderDashboard tests
+// =============================================================================
+
+function makeSite(): AdminSite {
+  return new AdminSite({ title: "Test Admin", urlPrefix: "/admin" });
+}
+
+Deno.test({
+  name: "renderDashboard: redirects to login when no Authorization header",
+  async fn() {
+    const site = makeSite();
+    const req = new Request("http://localhost/admin/");
+    const res = await renderDashboard({
+      request: req,
+      params: {},
+      adminSite: site,
+    });
+    assertEquals(res.status, 302);
+    assertEquals(res.headers.get("Location"), "/admin/login/");
+  },
+});
+
+Deno.test({
+  name:
+    "renderDashboard: redirects to login with HX-Redirect for HTMX requests",
+  async fn() {
+    const site = makeSite();
+    const req = new Request("http://localhost/admin/");
+    const res = await renderDashboard({
+      request: req,
+      params: {},
+      adminSite: site,
+    });
+    assertEquals(res.headers.get("HX-Redirect"), "/admin/login/");
+  },
+});
+
+Deno.test({
+  name: "renderDashboard: returns 200 HTML for authenticated request",
+  async fn() {
+    const original = Deno.env.get("SECRET_KEY");
+    if (original) Deno.env.delete("SECRET_KEY");
+
+    try {
+      const site = makeSite();
+      const req = makeRequest("/admin/", makeValidToken());
+      const res = await renderDashboard({
+        request: req,
+        params: {},
+        adminSite: site,
+      });
+      assertEquals(res.status, 200);
+      assertEquals(
+        res.headers.get("Content-Type"),
+        "text/html; charset=utf-8",
+      );
+    } finally {
+      if (original) Deno.env.set("SECRET_KEY", original);
+    }
+  },
+});
+
+Deno.test({
+  name: "renderDashboard: HTML contains site title",
+  async fn() {
+    const original = Deno.env.get("SECRET_KEY");
+    if (original) Deno.env.delete("SECRET_KEY");
+
+    try {
+      const site = makeSite();
+      const req = makeRequest("/admin/", makeValidToken());
+      const res = await renderDashboard({
+        request: req,
+        params: {},
+        adminSite: site,
+      });
+      const html = await res.text();
+      assertStringIncludes(html, "Test Admin");
+    } finally {
+      if (original) Deno.env.set("SECRET_KEY", original);
+    }
+  },
+});
+
+Deno.test({
+  name: "renderDashboard: HTML contains 'Site administration' heading",
+  async fn() {
+    const original = Deno.env.get("SECRET_KEY");
+    if (original) Deno.env.delete("SECRET_KEY");
+
+    try {
+      const site = makeSite();
+      const req = makeRequest("/admin/", makeValidToken());
+      const res = await renderDashboard({
+        request: req,
+        params: {},
+        adminSite: site,
+      });
+      const html = await res.text();
+      assertStringIncludes(html, "Site administration");
+    } finally {
+      if (original) Deno.env.set("SECRET_KEY", original);
+    }
+  },
+});
+
+Deno.test({
+  name: "renderDashboard: HTML contains user email in header",
+  async fn() {
+    const original = Deno.env.get("SECRET_KEY");
+    if (original) Deno.env.delete("SECRET_KEY");
+
+    try {
+      const site = makeSite();
+      const req = makeRequest("/admin/", makeValidToken());
+      const res = await renderDashboard({
+        request: req,
+        params: {},
+        adminSite: site,
+      });
+      const html = await res.text();
+      assertStringIncludes(html, "admin@example.com");
+    } finally {
+      if (original) Deno.env.set("SECRET_KEY", original);
+    }
+  },
+});
+
+Deno.test({
+  name: "renderDashboard: HTML contains registered model links",
+  async fn() {
+    const original = Deno.env.get("SECRET_KEY");
+    if (original) Deno.env.delete("SECRET_KEY");
+
+    try {
+      const site = makeSite();
+      site.register(ArticleModel, ModelAdmin);
+      site.register(UserModel, ModelAdmin);
+
+      const req = makeRequest("/admin/", makeValidToken());
+      const res = await renderDashboard({
+        request: req,
+        params: {},
+        adminSite: site,
+      });
+      const html = await res.text();
+      assertStringIncludes(html, "/admin/articlemodel/");
+      assertStringIncludes(html, "/admin/usermodel/");
+    } finally {
+      if (original) Deno.env.set("SECRET_KEY", original);
+    }
+  },
+});
+
+Deno.test({
+  name: "renderDashboard: HTML contains logout link",
+  async fn() {
+    const original = Deno.env.get("SECRET_KEY");
+    if (original) Deno.env.delete("SECRET_KEY");
+
+    try {
+      const site = makeSite();
+      const req = makeRequest("/admin/", makeValidToken());
+      const res = await renderDashboard({
+        request: req,
+        params: {},
+        adminSite: site,
+      });
+      const html = await res.text();
+      assertStringIncludes(html, "/admin/logout/");
+    } finally {
+      if (original) Deno.env.set("SECRET_KEY", original);
+    }
+  },
+});
+
+Deno.test({
+  name: "renderDashboard: HTML includes HTMX script tag",
+  async fn() {
+    const original = Deno.env.get("SECRET_KEY");
+    if (original) Deno.env.delete("SECRET_KEY");
+
+    try {
+      const site = makeSite();
+      const req = makeRequest("/admin/", makeValidToken());
+      const res = await renderDashboard({
+        request: req,
+        params: {},
+        adminSite: site,
+      });
+      const html = await res.text();
+      assertStringIncludes(html, "htmx.org");
+      assertStringIncludes(html, "admin.js");
+    } finally {
+      if (original) Deno.env.set("SECRET_KEY", original);
+    }
+  },
+});
+
+Deno.test({
+  name: "renderDashboard: shows 'No models registered' when site is empty",
+  async fn() {
+    const original = Deno.env.get("SECRET_KEY");
+    if (original) Deno.env.delete("SECRET_KEY");
+
+    try {
+      const site = makeSite();
+      const req = makeRequest("/admin/", makeValidToken());
+      const res = await renderDashboard({
+        request: req,
+        params: {},
+        adminSite: site,
+      });
+      const html = await res.text();
+      assertStringIncludes(html, "No models registered");
+    } finally {
+      if (original) Deno.env.set("SECRET_KEY", original);
+    }
+  },
+});

--- a/src/admin/urls.ts
+++ b/src/admin/urls.ts
@@ -8,11 +8,8 @@
 
 import type { DatabaseBackend } from "@alexi/db";
 import type { AdminSite } from "./site.ts";
-import {
-  renderDashboard,
-  renderModelDetail,
-  renderModelList,
-} from "./views/admin_views.ts";
+import { renderModelDetail, renderModelList } from "./views/admin_views.ts";
+import { renderDashboard } from "./views/dashboard_views.ts";
 import {
   handleLoginPost,
   handleLogout,
@@ -248,18 +245,11 @@ export function getAdminUrls(
         "admin:index",
         "index",
         (request, params) => {
-          const result = renderDashboard({
+          return renderDashboard({
             request,
             params,
             adminSite: site,
-            backend: backend,
-          });
-          return new Response(result.html, {
-            status: result.status ?? 200,
-            headers: {
-              "Content-Type": "text/html; charset=utf-8",
-              ...result.headers,
-            },
+            settings,
           });
         },
       ),

--- a/src/admin/views/auth_guard.ts
+++ b/src/admin/views/auth_guard.ts
@@ -1,0 +1,170 @@
+/**
+ * Alexi Admin Auth Guard
+ *
+ * Provides a thin JWT verification helper for admin views.
+ * Reads the Authorization: Bearer <token> header and verifies it
+ * using the same logic as JWTAuthentication in @alexi/restframework.
+ *
+ * @module
+ */
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface AuthGuardResult {
+  /** Whether the request carries a valid, non-expired JWT */
+  authenticated: boolean;
+  /** User ID from the token payload (if authenticated) */
+  userId?: number;
+  /** Email from the token payload (if authenticated) */
+  email?: string;
+  /** isAdmin flag from the token payload (if authenticated) */
+  isAdmin?: boolean;
+}
+
+// =============================================================================
+// Base64url Helpers
+// =============================================================================
+
+function base64UrlDecode(str: string): string {
+  // Restore standard base64 padding
+  const padded = str.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = padded.length % 4;
+  const b64 = pad === 0 ? padded : padded + "=".repeat(4 - pad);
+  return atob(b64);
+}
+
+// =============================================================================
+// HMAC-SHA256 Verification
+// =============================================================================
+
+async function verifyHmacSha256(
+  signingInput: string,
+  signatureB64: string,
+  secretKey: string,
+): Promise<boolean> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secretKey),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["verify"],
+  );
+
+  // Decode the base64url signature to bytes
+  const b64 = signatureB64.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = b64.length % 4;
+  const paddedB64 = pad === 0 ? b64 : b64 + "=".repeat(4 - pad);
+  const binary = atob(paddedB64);
+  const sigBytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    sigBytes[i] = binary.charCodeAt(i);
+  }
+
+  return crypto.subtle.verify(
+    "HMAC",
+    key,
+    sigBytes,
+    encoder.encode(signingInput),
+  );
+}
+
+// =============================================================================
+// verifyAdminToken
+// =============================================================================
+
+/**
+ * Verify the JWT in the request's Authorization header.
+ *
+ * Returns an AuthGuardResult with `authenticated: true` if the token is
+ * present, valid, and not expired.  Returns `authenticated: false` otherwise.
+ *
+ * @param request - The incoming HTTP request
+ * @param settings - Optional settings object (reads SECRET_KEY if provided)
+ */
+export async function verifyAdminToken(
+  request: Request,
+  settings?: Record<string, unknown>,
+): Promise<AuthGuardResult> {
+  const authHeader = request.headers.get("Authorization") ??
+    request.headers.get("authorization");
+  if (!authHeader) return { authenticated: false };
+
+  const parts = authHeader.split(" ");
+  if (parts.length !== 2 || parts[0].toLowerCase() !== "bearer") {
+    return { authenticated: false };
+  }
+
+  const token = parts[1];
+  if (!token) return { authenticated: false };
+
+  // Split JWT
+  const segments = token.split(".");
+  if (segments.length !== 3) return { authenticated: false };
+
+  const [headerB64, payloadB64, signatureB64] = segments;
+
+  // Decode header
+  let header: Record<string, unknown>;
+  try {
+    header = JSON.parse(base64UrlDecode(headerB64));
+  } catch {
+    return { authenticated: false };
+  }
+
+  // Decode payload
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(base64UrlDecode(payloadB64));
+  } catch {
+    return { authenticated: false };
+  }
+
+  // Check expiry
+  if (typeof payload.exp === "number" && payload.exp < Date.now() / 1000) {
+    return { authenticated: false };
+  }
+
+  const alg = header.alg as string | undefined;
+
+  if (alg === "HS256") {
+    const secretKey = (settings?.SECRET_KEY as string | undefined) ??
+      Deno.env.get("SECRET_KEY") ??
+      "";
+    if (!secretKey) return { authenticated: false };
+
+    const valid = await verifyHmacSha256(
+      `${headerB64}.${payloadB64}`,
+      signatureB64,
+      secretKey,
+    );
+    if (!valid) return { authenticated: false };
+  } else if (alg === "none") {
+    // Unsigned dev token — accept only when no SECRET_KEY is set
+    const secretKey = (settings?.SECRET_KEY as string | undefined) ??
+      Deno.env.get("SECRET_KEY") ??
+      "";
+    if (secretKey) {
+      // Secret configured but unsigned token presented — reject
+      return { authenticated: false };
+    }
+  } else {
+    // Unknown algorithm
+    return { authenticated: false };
+  }
+
+  const userId = payload.userId ?? payload.sub;
+  const email = typeof payload.email === "string" ? payload.email : undefined;
+  const isAdmin = payload.isAdmin === true;
+
+  return {
+    authenticated: true,
+    userId: userId != null
+      ? (typeof userId === "number" ? userId : Number(userId))
+      : undefined,
+    email,
+    isAdmin,
+  };
+}

--- a/src/admin/views/dashboard_views.ts
+++ b/src/admin/views/dashboard_views.ts
@@ -1,0 +1,176 @@
+/**
+ * Alexi Admin Dashboard View
+ *
+ * Renders the admin index / dashboard page (GET /admin/).
+ * Uses the MPA base template and requires a valid JWT in the
+ * Authorization header (injected by admin.js on every HTMX request).
+ *
+ * If no valid token is present the response redirects to /admin/login/.
+ *
+ * @module
+ */
+
+import type { AdminSite } from "../site.ts";
+import type { ModelClass } from "../options.ts";
+import { baseTemplate } from "../templates/mpa/base.ts";
+import { verifyAdminToken } from "./auth_guard.ts";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface DashboardViewContext {
+  request: Request;
+  params: Record<string, string>;
+  adminSite: AdminSite;
+  /** Optional settings — used for SECRET_KEY when verifying JWT */
+  settings?: Record<string, unknown>;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#x27;");
+}
+
+/**
+ * Build the sidebar nav items from the registered models.
+ */
+function buildNavItems(
+  site: AdminSite,
+  currentPath: string,
+): Array<{ name: string; url: string; active: boolean }> {
+  const items: Array<{ name: string; url: string; active: boolean }> = [
+    {
+      name: "Dashboard",
+      url: `${site.urlPrefix}/`,
+      active: currentPath === `${site.urlPrefix}/`,
+    },
+  ];
+
+  for (const model of site.getRegisteredModels()) {
+    const admin = site.getModelAdmin(model);
+    const url = admin.getListUrl();
+    items.push({
+      name: admin.getVerboseNamePlural(),
+      url,
+      active: currentPath.startsWith(url),
+    });
+  }
+
+  return items;
+}
+
+/**
+ * Render one "app group" section (Django Admin style).
+ * Currently all models are grouped under a single "Models" section.
+ */
+function renderAppGroup(
+  site: AdminSite,
+  models: ModelClass[],
+): string {
+  if (models.length === 0) {
+    return `<p class="admin-dashboard-empty">No models registered.</p>`;
+  }
+
+  const rows = models
+    .map((model) => {
+      const admin = site.getModelAdmin(model);
+      const listUrl = admin.getListUrl();
+      const addUrl = admin.getAddUrl();
+      const name = admin.getVerboseNamePlural();
+
+      return `
+      <tr>
+        <th scope="row">
+          <a href="${escapeHtml(listUrl)}">${escapeHtml(name)}</a>
+        </th>
+        <td>
+          <a href="${escapeHtml(addUrl)}" class="admin-addlink">Add</a>
+        </td>
+        <td>
+          <a href="${escapeHtml(listUrl)}" class="admin-changelink">Change</a>
+        </td>
+      </tr>`;
+    })
+    .join("\n");
+
+  return `
+  <div class="admin-app-listing">
+    <div class="admin-app-listing-header">
+      <h2>Models</h2>
+    </div>
+    <table class="admin-model-table">
+      <tbody>
+        ${rows}
+      </tbody>
+    </table>
+  </div>`;
+}
+
+// =============================================================================
+// Dashboard View
+// =============================================================================
+
+/**
+ * Render the admin dashboard (GET /admin/).
+ *
+ * Verifies the JWT from the Authorization header. If missing or invalid,
+ * returns a redirect response to /admin/login/.
+ */
+export async function renderDashboard(
+  context: DashboardViewContext,
+): Promise<Response> {
+  const { request, adminSite, settings } = context;
+  const urlPrefix = adminSite.urlPrefix.replace(/\/$/, "");
+
+  // --- Auth guard ---
+  const authResult = await verifyAdminToken(request, settings);
+  if (!authResult.authenticated) {
+    const loginUrl = `${urlPrefix}/login/`;
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: loginUrl,
+        "HX-Redirect": loginUrl,
+      },
+    });
+  }
+
+  const userEmail = authResult.email;
+  const url = new URL(request.url);
+  const models = adminSite.getRegisteredModels();
+  const navItems = buildNavItems(adminSite, url.pathname);
+
+  const appGroupHtml = renderAppGroup(adminSite, models);
+
+  const content = `
+    <div class="admin-dashboard">
+      <div class="admin-breadcrumbs">
+        <a href="${escapeHtml(urlPrefix)}/">Home</a>
+      </div>
+      <h1 class="admin-page-title">Site administration</h1>
+      ${appGroupHtml}
+    </div>`;
+
+  const html = baseTemplate({
+    title: "Site administration",
+    siteTitle: adminSite.title,
+    urlPrefix,
+    userEmail,
+    navItems,
+    content,
+  });
+
+  return new Response(html, {
+    status: 200,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}


### PR DESCRIPTION
## Summary

- Adds `views/auth_guard.ts`: shared JWT verification helper (`verifyAdminToken`) used by all protected views
- Adds `views/dashboard_views.ts`: new `renderDashboard` using `baseTemplate` from MPA templates, with:
  - JWT auth guard (unauthenticated → 302 redirect + HX-Redirect to /admin/login/)
  - Sidebar nav with all registered models
  - Django Admin-style app group table (model name, Add link, Change link)
  - User email displayed in header
- Updates `urls.ts`: dashboard route now calls the new `renderDashboard` (returns `Promise<Response>` directly)
- Adds `tests/dashboard_test.ts` with 15 tests (all passing)

Closes #127