### PR TITLE
feat(admin): change form view (add/edit) with validation (#129)

### DIFF
--- a/src/admin/tests/changeform_test.ts
+++ b/src/admin/tests/changeform_test.ts
@@ -1,0 +1,699 @@
+/**
+ * Tests for the Admin Change Form view (#129)
+ *
+ * Covers:
+ *  - Auth guard redirects unauthenticated requests
+ *  - 404 for unknown model
+ *  - 404 when editing a non-existent object
+ *  - GET add form: returns 200 with blank form
+ *  - GET change form: returns 200 pre-filled with instance data
+ *  - Form HTML contains correct field inputs and labels
+ *  - Save and add: breadcrumbs / heading
+ *  - POST add (valid data): creates object and redirects to changelist
+ *  - POST change (valid data): updates object and redirects
+ *  - POST validation errors: re-renders form with 422 and error messages
+ *  - POST with missing required field: re-renders with error
+ *  - Delete button present on change form
+ *  - No delete button on add form
+ */
+
+import { assertEquals, assertStringIncludes } from "jsr:@std/assert@1";
+import { reset, setup } from "@alexi/db";
+import { DenoKVBackend } from "@alexi/db/backends/denokv";
+import { AutoField, CharField, IntegerField, Manager, Model } from "@alexi/db";
+import { AdminSite } from "../site.ts";
+import { ModelAdmin } from "../model_admin.ts";
+import { renderChangeForm } from "../views/changeform_views.ts";
+
+// =============================================================================
+// Test model
+// =============================================================================
+
+class PostModel extends Model {
+  id = new AutoField({ primaryKey: true });
+  title = new CharField({ maxLength: 200 });
+  body = new CharField({ maxLength: 1000, blank: true, default: "" });
+  priority = new IntegerField({ default: 0 });
+
+  static objects = new Manager(PostModel);
+  static override meta = {
+    dbTable: "cf_posts",
+    verboseName: "Post",
+    verboseNamePlural: "Posts",
+  };
+}
+
+// =============================================================================
+// JWT helper (unsigned dev token)
+// =============================================================================
+
+function makeDevToken(payload: Record<string, unknown>): string {
+  const encode = (obj: Record<string, unknown>) => {
+    const json = JSON.stringify(obj);
+    return btoa(json).replace(/\+/g, "-").replace(/\//g, "_").replace(
+      /=+$/,
+      "",
+    );
+  };
+  const header = encode({ alg: "none", typ: "JWT" });
+  const body = encode(payload);
+  return `${header}.${body}.`;
+}
+
+function makeValidToken(): string {
+  const now = Math.floor(Date.now() / 1000);
+  return makeDevToken({
+    userId: 1,
+    email: "admin@example.com",
+    isAdmin: true,
+    iat: now,
+    exp: now + 900,
+  });
+}
+
+function makeGetRequest(path: string, token?: string): Request {
+  const headers: Record<string, string> = {};
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+  return new Request(`http://localhost${path}`, { method: "GET", headers });
+}
+
+function makePostRequest(
+  path: string,
+  data: Record<string, string>,
+  token?: string,
+): Request {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/x-www-form-urlencoded",
+  };
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+  const body = new URLSearchParams(data).toString();
+  return new Request(`http://localhost${path}`, {
+    method: "POST",
+    headers,
+    body,
+  });
+}
+
+// =============================================================================
+// Setup / teardown helpers
+// =============================================================================
+
+async function makeBackend() {
+  const backend = new DenoKVBackend({ name: "cf_test", path: ":memory:" });
+  await backend.connect();
+  await setup({ backend });
+  return backend;
+}
+
+async function teardownBackend(backend: DenoKVBackend) {
+  await reset();
+  await backend.disconnect();
+}
+
+function makeSite(): AdminSite {
+  return new AdminSite({ title: "Test Admin", urlPrefix: "/admin" });
+}
+
+// =============================================================================
+// Auth guard
+// =============================================================================
+
+Deno.test({
+  name: "renderChangeForm: redirects to login when no token (add)",
+  async fn() {
+    const backend = await makeBackend();
+    try {
+      const site = makeSite();
+      site.register(PostModel, ModelAdmin);
+      const req = makeGetRequest("/admin/postmodel/add/");
+      const res = await renderChangeForm(
+        { request: req, params: {}, adminSite: site, backend },
+        "postmodel",
+      );
+      assertEquals(res.status, 302);
+      assertEquals(res.headers.get("Location"), "/admin/login/");
+    } finally {
+      await teardownBackend(backend);
+    }
+  },
+});
+
+Deno.test({
+  name: "renderChangeForm: redirects to login when no token (change)",
+  async fn() {
+    const backend = await makeBackend();
+    try {
+      const site = makeSite();
+      site.register(PostModel, ModelAdmin);
+      const req = makeGetRequest("/admin/postmodel/1/");
+      const res = await renderChangeForm(
+        { request: req, params: {}, adminSite: site, backend },
+        "postmodel",
+        "1",
+      );
+      assertEquals(res.status, 302);
+      assertEquals(res.headers.get("Location"), "/admin/login/");
+    } finally {
+      await teardownBackend(backend);
+    }
+  },
+});
+
+// =============================================================================
+// 404 cases
+// =============================================================================
+
+Deno.test({
+  name: "renderChangeForm: returns 404 for unknown model",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const site = makeSite();
+      const req = makeGetRequest("/admin/nomodel/add/", makeValidToken());
+      const res = await renderChangeForm(
+        { request: req, params: {}, adminSite: site, backend },
+        "nomodel",
+      );
+      assertEquals(res.status, 404);
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+Deno.test({
+  name: "renderChangeForm: returns 404 when editing non-existent object",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const site = makeSite();
+      site.register(PostModel, ModelAdmin);
+      const req = makeGetRequest("/admin/postmodel/9999/", makeValidToken());
+      const res = await renderChangeForm(
+        { request: req, params: {}, adminSite: site, backend },
+        "postmodel",
+        "9999",
+      );
+      assertEquals(res.status, 404);
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+// =============================================================================
+// GET: Add form
+// =============================================================================
+
+Deno.test({
+  name: "renderChangeForm: GET add form returns 200 HTML",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const site = makeSite();
+      site.register(PostModel, ModelAdmin);
+      const req = makeGetRequest("/admin/postmodel/add/", makeValidToken());
+      const res = await renderChangeForm(
+        { request: req, params: {}, adminSite: site, backend },
+        "postmodel",
+      );
+      assertEquals(res.status, 200);
+      assertEquals(res.headers.get("Content-Type"), "text/html; charset=utf-8");
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+Deno.test({
+  name: "renderChangeForm: GET add form contains 'Add Post' heading",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const site = makeSite();
+      site.register(PostModel, ModelAdmin);
+      const req = makeGetRequest("/admin/postmodel/add/", makeValidToken());
+      const res = await renderChangeForm(
+        { request: req, params: {}, adminSite: site, backend },
+        "postmodel",
+      );
+      const html = await res.text();
+      assertStringIncludes(html, "Add Post");
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+Deno.test({
+  name: "renderChangeForm: GET add form contains field inputs",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const site = makeSite();
+      site.register(PostModel, ModelAdmin);
+      const req = makeGetRequest("/admin/postmodel/add/", makeValidToken());
+      const res = await renderChangeForm(
+        { request: req, params: {}, adminSite: site, backend },
+        "postmodel",
+      );
+      const html = await res.text();
+      assertStringIncludes(html, 'name="title"');
+      assertStringIncludes(html, 'name="body"');
+      assertStringIncludes(html, 'name="priority"');
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+Deno.test({
+  name: "renderChangeForm: GET add form has Save button",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const site = makeSite();
+      site.register(PostModel, ModelAdmin);
+      const req = makeGetRequest("/admin/postmodel/add/", makeValidToken());
+      const res = await renderChangeForm(
+        { request: req, params: {}, adminSite: site, backend },
+        "postmodel",
+      );
+      const html = await res.text();
+      assertStringIncludes(html, 'value="Save"');
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+Deno.test({
+  name: "renderChangeForm: GET add form has no Delete button",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const site = makeSite();
+      site.register(PostModel, ModelAdmin);
+      const req = makeGetRequest("/admin/postmodel/add/", makeValidToken());
+      const res = await renderChangeForm(
+        { request: req, params: {}, adminSite: site, backend },
+        "postmodel",
+      );
+      const html = await res.text();
+      assertEquals(html.includes("admin-delete-btn"), false);
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+// =============================================================================
+// GET: Change form
+// =============================================================================
+
+Deno.test({
+  name: "renderChangeForm: GET change form pre-fills existing instance data",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const post = await PostModel.objects.create({
+        title: "My Test Post",
+        body: "Some body text",
+        priority: 5,
+      });
+      const id = String(post.id.get());
+
+      const site = makeSite();
+      site.register(PostModel, ModelAdmin);
+      const req = makeGetRequest(`/admin/postmodel/${id}/`, makeValidToken());
+      const res = await renderChangeForm(
+        { request: req, params: { id }, adminSite: site, backend },
+        "postmodel",
+        id,
+      );
+      assertEquals(res.status, 200);
+      const html = await res.text();
+      assertStringIncludes(html, "My Test Post");
+      assertStringIncludes(html, "Some body text");
+      assertStringIncludes(html, "5");
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+Deno.test({
+  name: "renderChangeForm: GET change form has Delete button",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const post = await PostModel.objects.create({
+        title: "To Delete",
+        priority: 0,
+      });
+      const id = String(post.id.get());
+
+      const site = makeSite();
+      site.register(PostModel, ModelAdmin);
+      const req = makeGetRequest(`/admin/postmodel/${id}/`, makeValidToken());
+      const res = await renderChangeForm(
+        { request: req, params: { id }, adminSite: site, backend },
+        "postmodel",
+        id,
+      );
+      const html = await res.text();
+      assertStringIncludes(html, "admin-delete-btn");
+      assertStringIncludes(html, `/admin/postmodel/${id}/delete/`);
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+Deno.test({
+  name: "renderChangeForm: GET change form has 'Change Post' heading",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const post = await PostModel.objects.create({
+        title: "Change Me",
+        priority: 0,
+      });
+      const id = String(post.id.get());
+
+      const site = makeSite();
+      site.register(PostModel, ModelAdmin);
+      const req = makeGetRequest(`/admin/postmodel/${id}/`, makeValidToken());
+      const res = await renderChangeForm(
+        { request: req, params: { id }, adminSite: site, backend },
+        "postmodel",
+        id,
+      );
+      const html = await res.text();
+      assertStringIncludes(html, "Change Post");
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+// =============================================================================
+// POST: Create
+// =============================================================================
+
+Deno.test({
+  name: "renderChangeForm: POST add with valid data redirects to changelist",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const site = makeSite();
+      site.register(PostModel, ModelAdmin);
+      const req = makePostRequest(
+        "/admin/postmodel/add/",
+        { title: "New Post", body: "Content here", priority: "3" },
+        makeValidToken(),
+      );
+      const res = await renderChangeForm(
+        { request: req, params: {}, adminSite: site, backend },
+        "postmodel",
+      );
+      assertEquals(res.status, 302);
+      assertEquals(res.headers.get("Location"), "/admin/postmodel/");
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+Deno.test({
+  name: "renderChangeForm: POST add actually persists the object",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const site = makeSite();
+      site.register(PostModel, ModelAdmin);
+      const req = makePostRequest(
+        "/admin/postmodel/add/",
+        { title: "Persisted Post", body: "", priority: "0" },
+        makeValidToken(),
+      );
+      await renderChangeForm(
+        { request: req, params: {}, adminSite: site, backend },
+        "postmodel",
+      );
+
+      // Verify the object was created
+      const posts = await PostModel.objects.filter({
+        title: "Persisted Post",
+      }).fetch();
+      assertEquals(posts.array().length, 1);
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+// =============================================================================
+// POST: Update
+// =============================================================================
+
+Deno.test({
+  name: "renderChangeForm: POST change with valid data redirects to changelist",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const post = await PostModel.objects.create({
+        title: "Original",
+        priority: 1,
+      });
+      const id = String(post.id.get());
+
+      const site = makeSite();
+      site.register(PostModel, ModelAdmin);
+      const req = makePostRequest(
+        `/admin/postmodel/${id}/`,
+        { title: "Updated Title", body: "", priority: "2" },
+        makeValidToken(),
+      );
+      const res = await renderChangeForm(
+        { request: req, params: { id }, adminSite: site, backend },
+        "postmodel",
+        id,
+      );
+      assertEquals(res.status, 302);
+      assertEquals(res.headers.get("Location"), "/admin/postmodel/");
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+Deno.test({
+  name: "renderChangeForm: POST change actually updates the object",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const post = await PostModel.objects.create({
+        title: "Before Update",
+        priority: 0,
+      });
+      const id = String(post.id.get());
+
+      const site = makeSite();
+      site.register(PostModel, ModelAdmin);
+      const req = makePostRequest(
+        `/admin/postmodel/${id}/`,
+        { title: "After Update", body: "", priority: "99" },
+        makeValidToken(),
+      );
+      await renderChangeForm(
+        { request: req, params: { id }, adminSite: site, backend },
+        "postmodel",
+        id,
+      );
+
+      const updated = await PostModel.objects.get({
+        id: parseInt(id, 10),
+      });
+      assertEquals(updated.title.get(), "After Update");
+      assertEquals(updated.priority.get(), 99);
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+// =============================================================================
+// POST: Validation errors
+// =============================================================================
+
+Deno.test({
+  name: "renderChangeForm: POST with missing required field returns 422",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const site = makeSite();
+      site.register(PostModel, ModelAdmin);
+      // title is required (no blank=true), so omit it
+      const req = makePostRequest(
+        "/admin/postmodel/add/",
+        { body: "no title", priority: "0" },
+        makeValidToken(),
+      );
+      const res = await renderChangeForm(
+        { request: req, params: {}, adminSite: site, backend },
+        "postmodel",
+      );
+      assertEquals(res.status, 422);
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "renderChangeForm: POST validation error re-renders form with error message",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const site = makeSite();
+      site.register(PostModel, ModelAdmin);
+      const req = makePostRequest(
+        "/admin/postmodel/add/",
+        { body: "no title", priority: "0" },
+        makeValidToken(),
+      );
+      const res = await renderChangeForm(
+        { request: req, params: {}, adminSite: site, backend },
+        "postmodel",
+      );
+      const html = await res.text();
+      assertStringIncludes(html, "This field is required.");
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+Deno.test({
+  name: "renderChangeForm: POST with invalid integer returns 422",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const site = makeSite();
+      site.register(PostModel, ModelAdmin);
+      const req = makePostRequest(
+        "/admin/postmodel/add/",
+        { title: "Test", body: "", priority: "not-a-number" },
+        makeValidToken(),
+      );
+      const res = await renderChangeForm(
+        { request: req, params: {}, adminSite: site, backend },
+        "postmodel",
+      );
+      assertEquals(res.status, 422);
+      const html = await res.text();
+      assertStringIncludes(html, "Enter a whole number.");
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "renderChangeForm: POST validation re-renders with global error message",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const site = makeSite();
+      site.register(PostModel, ModelAdmin);
+      const req = makePostRequest(
+        "/admin/postmodel/add/",
+        { body: "missing title", priority: "0" },
+        makeValidToken(),
+      );
+      const res = await renderChangeForm(
+        { request: req, params: {}, adminSite: site, backend },
+        "postmodel",
+      );
+      const html = await res.text();
+      assertStringIncludes(html, "Please correct the errors below.");
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});

--- a/src/admin/urls.ts
+++ b/src/admin/urls.ts
@@ -8,7 +8,7 @@
 
 import type { DatabaseBackend } from "@alexi/db";
 import type { AdminSite } from "./site.ts";
-import { renderModelDetail } from "./views/admin_views.ts";
+import { renderChangeForm } from "./views/changeform_views.ts";
 import { renderChangeList } from "./views/changelist_views.ts";
 import { renderDashboard } from "./views/dashboard_views.ts";
 import {
@@ -283,11 +283,11 @@ export function getAdminUrls(
           admin.getAddUrl(),
           `admin:${modelName}_add`,
           "add",
-          (_request, _params) => {
-            return new Response("Add form not implemented yet", {
-              status: 501,
-              headers: { "Content-Type": "text/html; charset=utf-8" },
-            });
+          (request, params) => {
+            return renderChangeForm(
+              { request, params, adminSite: site, backend, settings },
+              modelName,
+            );
           },
           modelName,
         ),
@@ -299,19 +299,12 @@ export function getAdminUrls(
           `${prefix}/${modelName}/:id/`,
           `admin:${modelName}_change`,
           "change",
-          async (request, params) => {
-            const result = await renderModelDetail(
-              { request, params, adminSite: site, backend: backend },
+          (request, params) => {
+            return renderChangeForm(
+              { request, params, adminSite: site, backend, settings },
               modelName,
               params.id,
             );
-            return new Response(result.html, {
-              status: result.status ?? 200,
-              headers: {
-                "Content-Type": "text/html; charset=utf-8",
-                ...result.headers,
-              },
-            });
           },
           modelName,
         ),

--- a/src/admin/views/changeform_views.ts
+++ b/src/admin/views/changeform_views.ts
@@ -1,0 +1,748 @@
+/**
+ * Alexi Admin Change Form View
+ *
+ * Renders the add/change form page for a model instance.
+ * Handles both GET (render form) and POST (save data).
+ *
+ * - GET  /admin/<model>/add/       → blank add form
+ * - GET  /admin/<model>/<id>/      → edit form pre-filled with instance data
+ * - POST /admin/<model>/add/       → create new instance
+ * - POST /admin/<model>/<id>/      → update existing instance
+ *
+ * @module
+ */
+
+import type { DatabaseBackend } from "@alexi/db";
+import type { AdminSite } from "../site.ts";
+import type { ModelAdmin } from "../model_admin.ts";
+import type { FieldInfo } from "../introspection.ts";
+import {
+  getEditableFields,
+  getModelFields,
+  getModelMeta,
+  getWidgetForField,
+} from "../introspection.ts";
+import { baseTemplate } from "../templates/mpa/base.ts";
+import { verifyAdminToken } from "./auth_guard.ts";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface ChangeFormViewContext {
+  request: Request;
+  params: Record<string, string>;
+  adminSite: AdminSite;
+  backend: DatabaseBackend;
+  settings?: Record<string, unknown>;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function escapeHtml(str: string): string {
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#x27;");
+}
+
+function humanize(str: string): string {
+  return str
+    .replace(/([A-Z])/g, " $1")
+    .replace(/_/g, " ")
+    .replace(/^./, (s) => s.toUpperCase())
+    .trim();
+}
+
+function buildNavItems(
+  site: AdminSite,
+  currentPath: string,
+): Array<{ name: string; url: string; active: boolean }> {
+  const items: Array<{ name: string; url: string; active: boolean }> = [
+    {
+      name: "Dashboard",
+      url: `${site.urlPrefix}/`,
+      active: currentPath === `${site.urlPrefix}/`,
+    },
+  ];
+
+  for (const model of site.getRegisteredModels()) {
+    const admin = site.getModelAdmin(model);
+    const url = admin.getListUrl();
+    items.push({
+      name: admin.getVerboseNamePlural(),
+      url,
+      active: currentPath.startsWith(url),
+    });
+  }
+
+  return items;
+}
+
+/**
+ * Format a raw field value for display in an HTML form input.
+ * Dates become ISO strings suitable for date/datetime-local inputs.
+ */
+function formatForInput(
+  fieldInfo: FieldInfo,
+  value: unknown,
+): string {
+  if (value === null || value === undefined) return "";
+  if (fieldInfo.type === "DateTimeField" && value instanceof Date) {
+    // datetime-local requires "YYYY-MM-DDTHH:MM"
+    return value.toISOString().slice(0, 16);
+  }
+  if (fieldInfo.type === "DateField" && value instanceof Date) {
+    return value.toISOString().slice(0, 10);
+  }
+  return String(value);
+}
+
+// =============================================================================
+// Widget rendering
+// =============================================================================
+
+function renderWidget(
+  fieldInfo: FieldInfo,
+  value: unknown,
+  errors: string[],
+): string {
+  const name = fieldInfo.name;
+  const label = fieldInfo.options.verboseName ?? humanize(name);
+  const required = fieldInfo.isRequired;
+  const helpText = fieldInfo.options.helpText ?? "";
+  const widget = getWidgetForField(fieldInfo);
+  const hasError = errors.length > 0;
+
+  const errorHtml = hasError
+    ? `<ul class="admin-errorlist">${
+      errors.map((e) => `<li>${escapeHtml(e)}</li>`).join("")
+    }</ul>`
+    : "";
+
+  const helpHtml = helpText
+    ? `<p class="admin-help">${escapeHtml(helpText)}</p>`
+    : "";
+
+  let inputHtml = "";
+
+  if (widget === "admin-checkbox") {
+    // BooleanField → checkbox
+    const checked = value ? " checked" : "";
+    inputHtml = `<input type="checkbox" name="${escapeHtml(name)}" id="id_${
+      escapeHtml(name)
+    }"${checked} class="admin-checkbox">`;
+  } else if (widget === "admin-select") {
+    // Field with choices → <select>
+    const choices = fieldInfo.options.choices ?? [];
+    const options = choices
+      .map(([v, display]) => {
+        const selected = String(v) === String(value) ? " selected" : "";
+        return `<option value="${escapeHtml(String(v))}"${selected}>${
+          escapeHtml(display)
+        }</option>`;
+      })
+      .join("");
+    const req = required ? " required" : "";
+    inputHtml = `<select name="${escapeHtml(name)}" id="id_${
+      escapeHtml(name)
+    }" class="admin-select"${req}>
+      ${required ? "" : '<option value="">---------</option>'}
+      ${options}
+    </select>`;
+  } else if (widget === "admin-textarea") {
+    // TextField / JSONField → <textarea>
+    const req = required ? " required" : "";
+    inputHtml = `<textarea name="${escapeHtml(name)}" id="id_${
+      escapeHtml(name)
+    }" class="admin-textarea" rows="10"${req}>${
+      escapeHtml(String(value ?? ""))
+    }</textarea>`;
+  } else if (widget === "admin-input[readonly]") {
+    // AutoField → readonly text input
+    inputHtml = `<input type="text" name="${escapeHtml(name)}" id="id_${
+      escapeHtml(name)
+    }" value="${
+      escapeHtml(String(value ?? ""))
+    }" class="admin-input" readonly>`;
+  } else if (widget === "admin-input[type=number]") {
+    const req = required ? " required" : "";
+    inputHtml = `<input type="number" name="${escapeHtml(name)}" id="id_${
+      escapeHtml(name)
+    }" value="${escapeHtml(String(value ?? ""))}" class="admin-input"${req}>`;
+  } else if (widget === "admin-input[type=date]") {
+    const req = required ? " required" : "";
+    inputHtml = `<input type="date" name="${escapeHtml(name)}" id="id_${
+      escapeHtml(name)
+    }" value="${
+      escapeHtml(formatForInput(fieldInfo, value))
+    }" class="admin-input"${req}>`;
+  } else if (widget === "admin-input[type=datetime-local]") {
+    const req = required ? " required" : "";
+    inputHtml = `<input type="datetime-local" name="${
+      escapeHtml(name)
+    }" id="id_${escapeHtml(name)}" value="${
+      escapeHtml(formatForInput(fieldInfo, value))
+    }" class="admin-input"${req}>`;
+  } else if (widget === "admin-foreign-key-select") {
+    // ForeignKey — render a number input (select would need related choices)
+    const req = required ? " required" : "";
+    const rawId =
+      value && typeof value === "object" && "id" in (value as object)
+        ? (value as { id: unknown }).id
+        : value;
+    inputHtml = `<input type="number" name="${escapeHtml(name)}" id="id_${
+      escapeHtml(name)
+    }" value="${
+      escapeHtml(String(rawId ?? ""))
+    }" class="admin-input" placeholder="ID"${req}>`;
+  } else {
+    // Default text input
+    const req = required ? " required" : "";
+    const maxLen = fieldInfo.options.maxLength
+      ? ` maxlength="${fieldInfo.options.maxLength}"`
+      : "";
+    inputHtml = `<input type="text" name="${escapeHtml(name)}" id="id_${
+      escapeHtml(name)
+    }" value="${
+      escapeHtml(String(value ?? ""))
+    }" class="admin-input"${req}${maxLen}>`;
+  }
+
+  const requiredMark = required ? ' <span class="required">*</span>' : "";
+
+  return `
+  <div class="admin-form-row${hasError ? " admin-error" : ""}">
+    <label for="id_${escapeHtml(name)}" class="admin-label">
+      ${escapeHtml(label)}${requiredMark}
+    </label>
+    <div class="admin-form-field">
+      ${errorHtml}
+      ${inputHtml}
+      ${helpHtml}
+    </div>
+  </div>`;
+}
+
+// =============================================================================
+// Parse POST body → flat record
+// =============================================================================
+
+async function parseFormData(
+  request: Request,
+): Promise<Record<string, string>> {
+  const data: Record<string, string> = {};
+  try {
+    const formData = await request.formData();
+    for (const [key, value] of formData.entries()) {
+      if (typeof value === "string") {
+        data[key] = value;
+      }
+    }
+  } catch {
+    // Unable to parse body
+  }
+  return data;
+}
+
+// =============================================================================
+// Validate and coerce form data to model values
+// =============================================================================
+
+interface ValidationResult {
+  data: Record<string, unknown>;
+  errors: Record<string, string[]>;
+  isValid: boolean;
+}
+
+function validateFormData(
+  fields: FieldInfo[],
+  formData: Record<string, string>,
+): ValidationResult {
+  const data: Record<string, unknown> = {};
+  const errors: Record<string, string[]> = {};
+
+  for (const field of fields) {
+    if (!field.isEditable || field.isPrimaryKey) continue;
+
+    const raw = formData[field.name];
+    const fieldErrors: string[] = [];
+
+    // BooleanField — checkbox is absent when unchecked
+    if (field.type === "BooleanField") {
+      data[field.name] = raw === "on" || raw === "true" || raw === "1";
+      continue;
+    }
+
+    // Empty value handling
+    if (raw === undefined || raw === "") {
+      if (field.isRequired) {
+        fieldErrors.push("This field is required.");
+        errors[field.name] = fieldErrors;
+        continue;
+      }
+      // Allow null/blank
+      data[field.name] = field.options.null
+        ? null
+        : (field.options.default ?? "");
+      continue;
+    }
+
+    // Type coercion
+    if (
+      field.type === "IntegerField" ||
+      field.type === "AutoField" ||
+      field.type === "ForeignKey" ||
+      field.type === "OneToOneField"
+    ) {
+      const num = parseInt(raw, 10);
+      if (isNaN(num)) {
+        fieldErrors.push("Enter a whole number.");
+        errors[field.name] = fieldErrors;
+        continue;
+      }
+      data[field.name] = num;
+    } else if (field.type === "FloatField" || field.type === "DecimalField") {
+      const num = parseFloat(raw);
+      if (isNaN(num)) {
+        fieldErrors.push("Enter a number.");
+        errors[field.name] = fieldErrors;
+        continue;
+      }
+      data[field.name] = num;
+    } else if (
+      field.type === "DateTimeField" ||
+      field.type === "DateField"
+    ) {
+      const d = new Date(raw);
+      if (isNaN(d.getTime())) {
+        fieldErrors.push("Enter a valid date/time.");
+        errors[field.name] = fieldErrors;
+        continue;
+      }
+      data[field.name] = d;
+    } else if (field.type === "JSONField") {
+      try {
+        data[field.name] = JSON.parse(raw);
+      } catch {
+        fieldErrors.push("Enter valid JSON.");
+        errors[field.name] = fieldErrors;
+        continue;
+      }
+    } else {
+      // CharField, TextField, UUIDField, etc.
+      if (
+        field.options.maxLength !== undefined &&
+        raw.length > field.options.maxLength
+      ) {
+        fieldErrors.push(
+          `Ensure this value has at most ${field.options.maxLength} characters.`,
+        );
+        errors[field.name] = fieldErrors;
+        continue;
+      }
+      data[field.name] = raw;
+    }
+  }
+
+  return {
+    data,
+    errors,
+    isValid: Object.keys(errors).length === 0,
+  };
+}
+
+// =============================================================================
+// Fetch instance data from backend
+// =============================================================================
+
+async function fetchInstance(
+  modelAdmin: ModelAdmin,
+  backend: DatabaseBackend,
+  id: string,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const manager = (modelAdmin.model as unknown as {
+      objects: {
+        using: (b: DatabaseBackend) => {
+          get(q: Record<string, unknown>): Promise<unknown>;
+        };
+      };
+    }).objects;
+
+    const instance = await manager.using(backend).get({ id: parseInt(id, 10) });
+    if (!instance) return null;
+
+    // Serialize to plain object
+    const fields = getModelFields(modelAdmin.model);
+    const obj: Record<string, unknown> = {};
+    const r = instance as Record<string, unknown>;
+    for (const f of fields) {
+      const v = r[f.name];
+      obj[f.name] = v && typeof v === "object" && "get" in v
+        ? (v as { get(): unknown }).get()
+        : v;
+    }
+    return obj;
+  } catch {
+    return null;
+  }
+}
+
+// =============================================================================
+// Save instance to backend
+// =============================================================================
+
+async function saveInstance(
+  modelAdmin: ModelAdmin,
+  backend: DatabaseBackend,
+  data: Record<string, unknown>,
+  existingId?: string,
+): Promise<{ success: boolean; id?: unknown; error?: string }> {
+  try {
+    const manager = (modelAdmin.model as unknown as {
+      objects: {
+        using: (b: DatabaseBackend) => {
+          create(data: Record<string, unknown>): Promise<unknown>;
+          get(q: Record<string, unknown>): Promise<unknown>;
+        };
+      };
+    }).objects;
+
+    if (existingId) {
+      // Update existing — fetch then mutate and save
+      const instance = await manager.using(backend).get({
+        id: parseInt(existingId, 10),
+      });
+      if (!instance) {
+        return { success: false, error: "Instance not found" };
+      }
+
+      const r = instance as Record<string, { set(v: unknown): void }>;
+      for (const [key, value] of Object.entries(data)) {
+        if (r[key] && typeof r[key].set === "function") {
+          r[key].set(value);
+        }
+      }
+
+      await (instance as { save(): Promise<void> }).save();
+      const id = (instance as Record<string, { get(): unknown }>).id?.get();
+      return { success: true, id };
+    } else {
+      // Create new
+      const instance = await manager.using(backend).create(data);
+      const id = (instance as Record<string, { get(): unknown }>).id?.get();
+      return { success: true, id };
+    }
+  } catch (err) {
+    return { success: false, error: String(err) };
+  }
+}
+
+// =============================================================================
+// Render the form HTML
+// =============================================================================
+
+function renderFormHtml(
+  fields: FieldInfo[],
+  values: Record<string, unknown>,
+  errors: Record<string, string[]>,
+): string {
+  return fields
+    .filter((f) => f.isEditable)
+    .map((f) => renderWidget(f, values[f.name], errors[f.name] ?? []))
+    .join("\n");
+}
+
+// =============================================================================
+// Change Form View (GET + POST)
+// =============================================================================
+
+/**
+ * Render the add/change form for a model instance.
+ *
+ * @param context  - View context
+ * @param modelName - Lowercase model name from the URL
+ * @param objectId  - Object PK for edit, undefined for add
+ */
+export async function renderChangeForm(
+  context: ChangeFormViewContext,
+  modelName: string,
+  objectId?: string,
+): Promise<Response> {
+  const { request, adminSite, backend, settings } = context;
+  const urlPrefix = adminSite.urlPrefix.replace(/\/$/, "");
+
+  // --- Auth guard ---
+  const authResult = await verifyAdminToken(request, settings);
+  if (!authResult.authenticated) {
+    const loginUrl = `${urlPrefix}/login/`;
+    return new Response(null, {
+      status: 302,
+      headers: { Location: loginUrl, "HX-Redirect": loginUrl },
+    });
+  }
+
+  const userEmail = authResult.email;
+
+  // --- Find model admin ---
+  const modelAdmin = adminSite.getModelAdminByName(modelName);
+  if (!modelAdmin) {
+    return new Response("Model not found", { status: 404 });
+  }
+
+  const meta = getModelMeta(modelAdmin.model);
+  const allFields = getModelFields(modelAdmin.model);
+  const editableFields = getEditableFields(modelAdmin.model);
+
+  const isAdd = !objectId;
+  const listUrl = modelAdmin.getListUrl();
+  const formAction = isAdd
+    ? modelAdmin.getAddUrl()
+    : modelAdmin.getDetailUrl(objectId);
+
+  const url = new URL(request.url);
+  const currentPath = url.pathname;
+  const navItems = buildNavItems(adminSite, currentPath);
+
+  // --- Breadcrumbs ---
+  const breadcrumbs = `
+  <div class="admin-breadcrumbs">
+    <a href="${escapeHtml(urlPrefix)}/">Home</a> ›
+    <a href="${escapeHtml(listUrl)}">${escapeHtml(meta.verboseNamePlural)}</a> ›
+    ${
+    isAdd ? `Add ${escapeHtml(meta.verboseName)}` : escapeHtml(meta.verboseName)
+  }
+  </div>`;
+
+  // =========================================================================
+  // GET: Render form
+  // =========================================================================
+
+  if (request.method === "GET") {
+    let values: Record<string, unknown> = {};
+
+    if (!isAdd && objectId) {
+      const instance = await fetchInstance(modelAdmin, backend, objectId);
+      if (!instance) {
+        return new Response("Object not found", { status: 404 });
+      }
+      values = instance;
+    } else {
+      // Populate defaults
+      for (const f of allFields) {
+        if (f.options.default !== undefined) {
+          values[f.name] = f.options.default;
+        }
+      }
+    }
+
+    const formHtml = renderFormHtml(editableFields, values, {});
+    const title = isAdd
+      ? `Add ${meta.verboseName}`
+      : `Change ${meta.verboseName}`;
+
+    const content = buildPageContent({
+      breadcrumbs,
+      title,
+      formAction,
+      formHtml,
+      isAdd,
+      objectId,
+      modelAdmin,
+      modelName,
+      urlPrefix,
+    });
+
+    const html = baseTemplate({
+      title,
+      siteTitle: adminSite.title,
+      urlPrefix,
+      userEmail,
+      navItems,
+      content,
+    });
+
+    return new Response(html, {
+      status: 200,
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+  }
+
+  // =========================================================================
+  // POST: Save and redirect
+  // =========================================================================
+
+  if (request.method === "POST") {
+    const formData = await parseFormData(request);
+    const validation = validateFormData(editableFields, formData);
+
+    if (!validation.isValid) {
+      // Re-render form with errors
+      const displayValues: Record<string, unknown> = { ...formData };
+      const formHtml = renderFormHtml(
+        editableFields,
+        displayValues,
+        validation.errors,
+      );
+      const title = isAdd
+        ? `Add ${meta.verboseName}`
+        : `Change ${meta.verboseName}`;
+
+      const content = buildPageContent({
+        breadcrumbs,
+        title,
+        formAction,
+        formHtml,
+        isAdd,
+        objectId,
+        modelAdmin,
+        modelName,
+        urlPrefix,
+        globalError: "Please correct the errors below.",
+      });
+
+      const html = baseTemplate({
+        title,
+        siteTitle: adminSite.title,
+        urlPrefix,
+        userEmail,
+        navItems,
+        content,
+      });
+
+      return new Response(html, {
+        status: 422,
+        headers: { "Content-Type": "text/html; charset=utf-8" },
+      });
+    }
+
+    const result = await saveInstance(
+      modelAdmin,
+      backend,
+      validation.data,
+      isAdd ? undefined : objectId,
+    );
+
+    if (!result.success) {
+      const displayValues: Record<string, unknown> = { ...formData };
+      const formHtml = renderFormHtml(editableFields, displayValues, {});
+      const title = isAdd
+        ? `Add ${meta.verboseName}`
+        : `Change ${meta.verboseName}`;
+
+      const content = buildPageContent({
+        breadcrumbs,
+        title,
+        formAction,
+        formHtml,
+        isAdd,
+        objectId,
+        modelAdmin,
+        modelName,
+        urlPrefix,
+        globalError: result.error ?? "An error occurred while saving.",
+      });
+
+      const html = baseTemplate({
+        title,
+        siteTitle: adminSite.title,
+        urlPrefix,
+        userEmail,
+        navItems,
+        content,
+      });
+
+      return new Response(html, {
+        status: 500,
+        headers: { "Content-Type": "text/html; charset=utf-8" },
+      });
+    }
+
+    // Redirect to change list on success
+    const redirectUrl = listUrl;
+    return new Response(null, {
+      status: 302,
+      headers: { Location: redirectUrl, "HX-Redirect": redirectUrl },
+    });
+  }
+
+  return new Response("Method not allowed", { status: 405 });
+}
+
+// =============================================================================
+// Page content builder
+// =============================================================================
+
+interface PageContentOptions {
+  breadcrumbs: string;
+  title: string;
+  formAction: string;
+  formHtml: string;
+  isAdd: boolean;
+  objectId?: string;
+  modelAdmin: ModelAdmin;
+  modelName: string;
+  urlPrefix: string;
+  globalError?: string;
+}
+
+function buildPageContent(opts: PageContentOptions): string {
+  const {
+    breadcrumbs,
+    title,
+    formAction,
+    formHtml,
+    isAdd,
+    objectId,
+    modelAdmin,
+    modelName,
+    urlPrefix,
+    globalError,
+  } = opts;
+
+  const globalErrorHtml = globalError
+    ? `<p class="admin-error-message">${escapeHtml(globalError)}</p>`
+    : "";
+
+  const deleteBtn = !isAdd && objectId
+    ? `<a href="${
+      escapeHtml(`${urlPrefix}/${modelName}/${objectId}/delete/`)
+    }" class="admin-btn admin-btn-danger admin-delete-btn">Delete</a>`
+    : "";
+
+  const saveContinue = modelAdmin.saveContinue
+    ? `<input type="submit" name="_continue" value="Save and continue editing" class="admin-btn admin-btn-default">`
+    : "";
+
+  const saveAsNew = !isAdd && modelAdmin.saveAsNew
+    ? `<input type="submit" name="_saveasnew" value="Save as new" class="admin-btn admin-btn-default">`
+    : "";
+
+  return `
+  ${breadcrumbs}
+  <div class="admin-changeform">
+    <div class="admin-content-title">
+      <h1>${escapeHtml(title)}</h1>
+    </div>
+
+    ${globalErrorHtml}
+
+    <form method="post" action="${escapeHtml(formAction)}" id="changeform">
+      <div class="admin-form-fields">
+        ${formHtml}
+      </div>
+
+      <div class="admin-submit-row">
+        <input type="submit" name="_save" value="Save" class="admin-btn admin-btn-primary admin-save-btn">
+        ${saveContinue}
+        ${saveAsNew}
+        ${deleteBtn}
+      </div>
+    </form>
+  </div>`;
+}


### PR DESCRIPTION
## Summary

- Implements `renderChangeForm()` view handling GET (blank add / pre-filled edit) and POST (create/update with redirect)
- Widget rendering for all field types: text, number, date, datetime-local, checkbox, select, textarea, readonly
- Server-side validation with per-field error messages and 422 re-render on failure
- Delete button on change form, absent on add form
- Breadcrumbs: Home › Model List › Add/Change title
- 20 passing tests covering auth guard, 404s, GET/POST scenarios, validation errors

Closes #129