### PR TITLE
feat(admin): delete confirmation view (#130)

### DIFF
--- a/src/admin/tests/delete_test.ts
+++ b/src/admin/tests/delete_test.ts
@@ -1,0 +1,434 @@
+/**
+ * Tests for the Admin Delete Confirmation view (#130)
+ *
+ * Covers:
+ *  - Auth guard redirects unauthenticated requests
+ *  - 404 for unknown model
+ *  - 404 when object does not exist
+ *  - GET: returns 200 confirmation page
+ *  - GET: page contains object summary
+ *  - GET: page has "Yes, I'm sure" and "No, go back" buttons
+ *  - POST: deletes the object and redirects to changelist
+ *  - POST: object is actually removed from the backend
+ */
+
+import { assertEquals, assertStringIncludes } from "jsr:@std/assert@1";
+import { reset, setup } from "@alexi/db";
+import { DenoKVBackend } from "@alexi/db/backends/denokv";
+import { AutoField, CharField, IntegerField, Manager, Model } from "@alexi/db";
+import { AdminSite } from "../site.ts";
+import { ModelAdmin } from "../model_admin.ts";
+import { renderDeleteConfirmation } from "../views/delete_views.ts";
+
+// =============================================================================
+// Test model
+// =============================================================================
+
+class ArticleModel extends Model {
+  id = new AutoField({ primaryKey: true });
+  title = new CharField({ maxLength: 200 });
+  views = new IntegerField({ default: 0 });
+
+  static objects = new Manager(ArticleModel);
+  static override meta = {
+    dbTable: "dv_articles",
+    verboseName: "Article",
+    verboseNamePlural: "Articles",
+  };
+}
+
+// =============================================================================
+// JWT helper (unsigned dev token)
+// =============================================================================
+
+function makeDevToken(payload: Record<string, unknown>): string {
+  const encode = (obj: Record<string, unknown>) => {
+    const json = JSON.stringify(obj);
+    return btoa(json).replace(/\+/g, "-").replace(/\//g, "_").replace(
+      /=+$/,
+      "",
+    );
+  };
+  const header = encode({ alg: "none", typ: "JWT" });
+  const body = encode(payload);
+  return `${header}.${body}.`;
+}
+
+function makeValidToken(): string {
+  const now = Math.floor(Date.now() / 1000);
+  return makeDevToken({
+    userId: 1,
+    email: "admin@example.com",
+    isAdmin: true,
+    iat: now,
+    exp: now + 900,
+  });
+}
+
+function makeGetRequest(path: string, token?: string): Request {
+  const headers: Record<string, string> = {};
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+  return new Request(`http://localhost${path}`, { method: "GET", headers });
+}
+
+function makePostRequest(path: string, token?: string): Request {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/x-www-form-urlencoded",
+  };
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+  return new Request(`http://localhost${path}`, {
+    method: "POST",
+    headers,
+    body: "_delete=confirm",
+  });
+}
+
+// =============================================================================
+// Setup / teardown helpers
+// =============================================================================
+
+async function makeBackend() {
+  const backend = new DenoKVBackend({ name: "dv_test", path: ":memory:" });
+  await backend.connect();
+  await setup({ backend });
+  return backend;
+}
+
+async function teardownBackend(backend: DenoKVBackend) {
+  await reset();
+  await backend.disconnect();
+}
+
+function makeSite(): AdminSite {
+  return new AdminSite({ title: "Test Admin", urlPrefix: "/admin" });
+}
+
+// =============================================================================
+// Auth guard
+// =============================================================================
+
+Deno.test({
+  name: "renderDeleteConfirmation: redirects to login when no token",
+  async fn() {
+    const backend = await makeBackend();
+    try {
+      const site = makeSite();
+      site.register(ArticleModel, ModelAdmin);
+      const req = makeGetRequest("/admin/articlemodel/1/delete/");
+      const res = await renderDeleteConfirmation(
+        { request: req, params: { id: "1" }, adminSite: site, backend },
+        "articlemodel",
+        "1",
+      );
+      assertEquals(res.status, 302);
+      assertEquals(res.headers.get("Location"), "/admin/login/");
+    } finally {
+      await teardownBackend(backend);
+    }
+  },
+});
+
+// =============================================================================
+// 404 cases
+// =============================================================================
+
+Deno.test({
+  name: "renderDeleteConfirmation: returns 404 for unknown model",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const site = makeSite();
+      const req = makeGetRequest("/admin/nomodel/1/delete/", makeValidToken());
+      const res = await renderDeleteConfirmation(
+        { request: req, params: { id: "1" }, adminSite: site, backend },
+        "nomodel",
+        "1",
+      );
+      assertEquals(res.status, 404);
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+Deno.test({
+  name: "renderDeleteConfirmation: returns 404 for non-existent object",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const site = makeSite();
+      site.register(ArticleModel, ModelAdmin);
+      const req = makeGetRequest(
+        "/admin/articlemodel/9999/delete/",
+        makeValidToken(),
+      );
+      const res = await renderDeleteConfirmation(
+        { request: req, params: { id: "9999" }, adminSite: site, backend },
+        "articlemodel",
+        "9999",
+      );
+      assertEquals(res.status, 404);
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+// =============================================================================
+// GET: Confirmation page
+// =============================================================================
+
+Deno.test({
+  name: "renderDeleteConfirmation: GET returns 200 HTML",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const article = await ArticleModel.objects.create({
+        title: "My Article",
+        views: 0,
+      });
+      const id = String(article.id.get());
+
+      const site = makeSite();
+      site.register(ArticleModel, ModelAdmin);
+      const req = makeGetRequest(
+        `/admin/articlemodel/${id}/delete/`,
+        makeValidToken(),
+      );
+      const res = await renderDeleteConfirmation(
+        { request: req, params: { id }, adminSite: site, backend },
+        "articlemodel",
+        id,
+      );
+      assertEquals(res.status, 200);
+      assertEquals(res.headers.get("Content-Type"), "text/html; charset=utf-8");
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+Deno.test({
+  name: "renderDeleteConfirmation: GET page contains 'Delete Article' heading",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const article = await ArticleModel.objects.create({
+        title: "Heading Test",
+        views: 0,
+      });
+      const id = String(article.id.get());
+
+      const site = makeSite();
+      site.register(ArticleModel, ModelAdmin);
+      const req = makeGetRequest(
+        `/admin/articlemodel/${id}/delete/`,
+        makeValidToken(),
+      );
+      const res = await renderDeleteConfirmation(
+        { request: req, params: { id }, adminSite: site, backend },
+        "articlemodel",
+        id,
+      );
+      const html = await res.text();
+      assertStringIncludes(html, "Delete Article");
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+Deno.test({
+  name: "renderDeleteConfirmation: GET page shows object summary",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const article = await ArticleModel.objects.create({
+        title: "Showing In Summary",
+        views: 0,
+      });
+      const id = String(article.id.get());
+
+      const site = makeSite();
+      site.register(ArticleModel, ModelAdmin);
+      const req = makeGetRequest(
+        `/admin/articlemodel/${id}/delete/`,
+        makeValidToken(),
+      );
+      const res = await renderDeleteConfirmation(
+        { request: req, params: { id }, adminSite: site, backend },
+        "articlemodel",
+        id,
+      );
+      const html = await res.text();
+      assertStringIncludes(html, "Showing In Summary");
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+Deno.test({
+  name: "renderDeleteConfirmation: GET page has Yes/No buttons",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const article = await ArticleModel.objects.create({
+        title: "Button Test",
+        views: 0,
+      });
+      const id = String(article.id.get());
+
+      const site = makeSite();
+      site.register(ArticleModel, ModelAdmin);
+      const req = makeGetRequest(
+        `/admin/articlemodel/${id}/delete/`,
+        makeValidToken(),
+      );
+      const res = await renderDeleteConfirmation(
+        { request: req, params: { id }, adminSite: site, backend },
+        "articlemodel",
+        id,
+      );
+      const html = await res.text();
+      assertStringIncludes(html, "Yes, I'm sure");
+      assertStringIncludes(html, "No, go back");
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+Deno.test({
+  name: "renderDeleteConfirmation: GET page has warning text",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const article = await ArticleModel.objects.create({
+        title: "Warning Test",
+        views: 0,
+      });
+      const id = String(article.id.get());
+
+      const site = makeSite();
+      site.register(ArticleModel, ModelAdmin);
+      const req = makeGetRequest(
+        `/admin/articlemodel/${id}/delete/`,
+        makeValidToken(),
+      );
+      const res = await renderDeleteConfirmation(
+        { request: req, params: { id }, adminSite: site, backend },
+        "articlemodel",
+        id,
+      );
+      const html = await res.text();
+      assertStringIncludes(html, "cannot be undone");
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+// =============================================================================
+// POST: Delete
+// =============================================================================
+
+Deno.test({
+  name: "renderDeleteConfirmation: POST redirects to changelist on success",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const article = await ArticleModel.objects.create({
+        title: "To Delete",
+        views: 0,
+      });
+      const id = String(article.id.get());
+
+      const site = makeSite();
+      site.register(ArticleModel, ModelAdmin);
+      const req = makePostRequest(
+        `/admin/articlemodel/${id}/delete/`,
+        makeValidToken(),
+      );
+      const res = await renderDeleteConfirmation(
+        { request: req, params: { id }, adminSite: site, backend },
+        "articlemodel",
+        id,
+      );
+      assertEquals(res.status, 302);
+      assertEquals(res.headers.get("Location"), "/admin/articlemodel/");
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+Deno.test({
+  name: "renderDeleteConfirmation: POST actually deletes the object",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const article = await ArticleModel.objects.create({
+        title: "Will Be Deleted",
+        views: 42,
+      });
+      const id = String(article.id.get());
+
+      const site = makeSite();
+      site.register(ArticleModel, ModelAdmin);
+      const req = makePostRequest(
+        `/admin/articlemodel/${id}/delete/`,
+        makeValidToken(),
+      );
+      await renderDeleteConfirmation(
+        { request: req, params: { id }, adminSite: site, backend },
+        "articlemodel",
+        id,
+      );
+
+      // Verify the object is gone
+      const remaining = await ArticleModel.objects.filter({
+        title: "Will Be Deleted",
+      }).fetch();
+      assertEquals(remaining.array().length, 0);
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});

--- a/src/admin/urls.ts
+++ b/src/admin/urls.ts
@@ -11,6 +11,7 @@ import type { AdminSite } from "./site.ts";
 import { renderChangeForm } from "./views/changeform_views.ts";
 import { renderChangeList } from "./views/changelist_views.ts";
 import { renderDashboard } from "./views/dashboard_views.ts";
+import { renderDeleteConfirmation } from "./views/delete_views.ts";
 import {
   handleLoginPost,
   handleLogout,
@@ -316,11 +317,12 @@ export function getAdminUrls(
           `${prefix}/${modelName}/:id/delete/`,
           `admin:${modelName}_delete`,
           "delete",
-          (_request, _params) => {
-            return new Response("Delete confirmation not implemented yet", {
-              status: 501,
-              headers: { "Content-Type": "text/html; charset=utf-8" },
-            });
+          (request, params) => {
+            return renderDeleteConfirmation(
+              { request, params, adminSite: site, backend, settings },
+              modelName,
+              params.id,
+            );
           },
           modelName,
         ),

--- a/src/admin/views/delete_views.ts
+++ b/src/admin/views/delete_views.ts
@@ -1,0 +1,338 @@
+/**
+ * Alexi Admin Delete Confirmation View
+ *
+ * Renders the delete confirmation page for a model instance.
+ * Handles both GET (render confirmation) and POST (perform delete).
+ *
+ * - GET  /admin/<model>/<id>/delete/  → confirmation page
+ * - POST /admin/<model>/<id>/delete/  → delete object, redirect to changelist
+ *
+ * @module
+ */
+
+import type { DatabaseBackend } from "@alexi/db";
+import type { AdminSite } from "../site.ts";
+import type { ModelAdmin } from "../model_admin.ts";
+import { getModelFields, getModelMeta } from "../introspection.ts";
+import { baseTemplate } from "../templates/mpa/base.ts";
+import { verifyAdminToken } from "./auth_guard.ts";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface DeleteViewContext {
+  request: Request;
+  params: Record<string, string>;
+  adminSite: AdminSite;
+  backend: DatabaseBackend;
+  settings?: Record<string, unknown>;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function escapeHtml(str: string): string {
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#x27;");
+}
+
+function buildNavItems(
+  site: AdminSite,
+  currentPath: string,
+): Array<{ name: string; url: string; active: boolean }> {
+  const items: Array<{ name: string; url: string; active: boolean }> = [
+    {
+      name: "Dashboard",
+      url: `${site.urlPrefix}/`,
+      active: currentPath === `${site.urlPrefix}/`,
+    },
+  ];
+
+  for (const model of site.getRegisteredModels()) {
+    const admin = site.getModelAdmin(model);
+    const url = admin.getListUrl();
+    items.push({
+      name: admin.getVerboseNamePlural(),
+      url,
+      active: currentPath.startsWith(url),
+    });
+  }
+
+  return items;
+}
+
+// =============================================================================
+// Fetch instance summary for display
+// =============================================================================
+
+async function fetchInstanceSummary(
+  modelAdmin: ModelAdmin,
+  backend: DatabaseBackend,
+  id: string,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const manager = (modelAdmin.model as unknown as {
+      objects: {
+        using: (b: DatabaseBackend) => {
+          get(q: Record<string, unknown>): Promise<unknown>;
+        };
+      };
+    }).objects;
+
+    const instance = await manager.using(backend).get({ id: parseInt(id, 10) });
+    if (!instance) return null;
+
+    // Serialize to plain object
+    const fields = getModelFields(modelAdmin.model);
+    const obj: Record<string, unknown> = {};
+    const r = instance as Record<string, unknown>;
+    for (const f of fields) {
+      const v = r[f.name];
+      obj[f.name] = v && typeof v === "object" && "get" in v
+        ? (v as { get(): unknown }).get()
+        : v;
+    }
+    return obj;
+  } catch {
+    return null;
+  }
+}
+
+// =============================================================================
+// Delete instance from backend
+// =============================================================================
+
+async function deleteInstance(
+  modelAdmin: ModelAdmin,
+  backend: DatabaseBackend,
+  id: string,
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const manager = (modelAdmin.model as unknown as {
+      objects: {
+        using: (b: DatabaseBackend) => {
+          get(q: Record<string, unknown>): Promise<unknown>;
+        };
+      };
+    }).objects;
+
+    const instance = await manager.using(backend).get({ id: parseInt(id, 10) });
+    if (!instance) {
+      return { success: false, error: "Object not found" };
+    }
+
+    await (instance as { delete(): Promise<void> }).delete();
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: String(err) };
+  }
+}
+
+// =============================================================================
+// Render a summary row of the object being deleted
+// =============================================================================
+
+function renderObjectSummary(
+  obj: Record<string, unknown>,
+  modelAdmin: ModelAdmin,
+): string {
+  const meta = getModelMeta(modelAdmin.model);
+  const pkField = meta.primaryKey ?? "id";
+  const pkValue = obj[pkField];
+
+  // Show the first meaningful text field for display
+  const fields = getModelFields(modelAdmin.model);
+  const displayField = fields.find((f) =>
+    f.name !== pkField && (f.type === "CharField" || f.type === "TextField")
+  );
+  const displayValue = displayField
+    ? String(obj[displayField.name] ?? "")
+    : String(pkValue ?? "");
+
+  return `<li><strong>${escapeHtml(meta.verboseName)}</strong>: ${
+    escapeHtml(displayValue || `#${pkValue}`)
+  }</li>`;
+}
+
+// =============================================================================
+// Delete Confirmation View (GET + POST)
+// =============================================================================
+
+/**
+ * Render the delete confirmation page for a model instance.
+ *
+ * @param context   - View context
+ * @param modelName - Lowercase model name from the URL
+ * @param objectId  - Object PK to delete
+ */
+export async function renderDeleteConfirmation(
+  context: DeleteViewContext,
+  modelName: string,
+  objectId: string,
+): Promise<Response> {
+  const { request, adminSite, backend, settings } = context;
+  const urlPrefix = adminSite.urlPrefix.replace(/\/$/, "");
+
+  // --- Auth guard ---
+  const authResult = await verifyAdminToken(request, settings);
+  if (!authResult.authenticated) {
+    const loginUrl = `${urlPrefix}/login/`;
+    return new Response(null, {
+      status: 302,
+      headers: { Location: loginUrl, "HX-Redirect": loginUrl },
+    });
+  }
+
+  const userEmail = authResult.email;
+
+  // --- Find model admin ---
+  const modelAdmin = adminSite.getModelAdminByName(modelName);
+  if (!modelAdmin) {
+    return new Response("Model not found", { status: 404 });
+  }
+
+  const meta = getModelMeta(modelAdmin.model);
+  const listUrl = modelAdmin.getListUrl();
+  const changeUrl = modelAdmin.getDetailUrl(objectId);
+  const deleteAction = modelAdmin.getDeleteUrl(objectId);
+
+  const url = new URL(request.url);
+  const currentPath = url.pathname;
+  const navItems = buildNavItems(adminSite, currentPath);
+
+  // --- Breadcrumbs ---
+  const breadcrumbs = `
+  <div class="admin-breadcrumbs">
+    <a href="${escapeHtml(urlPrefix)}/">Home</a> ›
+    <a href="${escapeHtml(listUrl)}">${escapeHtml(meta.verboseNamePlural)}</a> ›
+    <a href="${escapeHtml(changeUrl)}">${escapeHtml(meta.verboseName)} #${
+    escapeHtml(objectId)
+  }</a> ›
+    Delete
+  </div>`;
+
+  const title = `Delete ${meta.verboseName}`;
+
+  // =========================================================================
+  // GET: Render confirmation page
+  // =========================================================================
+
+  if (request.method === "GET") {
+    const instance = await fetchInstanceSummary(modelAdmin, backend, objectId);
+    if (!instance) {
+      return new Response("Object not found", { status: 404 });
+    }
+
+    const objectSummary = renderObjectSummary(instance, modelAdmin);
+
+    const content = `
+    ${breadcrumbs}
+    <div class="admin-delete-confirmation">
+      <div class="admin-content-title">
+        <h1>${escapeHtml(title)}</h1>
+      </div>
+
+      <p>Are you sure you want to delete the ${
+      escapeHtml(meta.verboseName)
+    } below?</p>
+      <p class="admin-delete-warning"><strong>Warning:</strong> This action cannot be undone.</p>
+
+      <ul class="admin-delete-summary">
+        ${objectSummary}
+      </ul>
+
+      <form method="post" action="${escapeHtml(deleteAction)}" id="deleteform">
+        <div class="admin-submit-row">
+          <a href="${
+      escapeHtml(changeUrl)
+    }" class="admin-btn admin-btn-default admin-cancel-btn">No, go back</a>
+          <input type="submit" name="_delete" value="Yes, I'm sure" class="admin-btn admin-btn-danger admin-confirm-delete-btn">
+        </div>
+      </form>
+    </div>`;
+
+    const html = baseTemplate({
+      title,
+      siteTitle: adminSite.title,
+      urlPrefix,
+      userEmail,
+      navItems,
+      content,
+    });
+
+    return new Response(html, {
+      status: 200,
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+  }
+
+  // =========================================================================
+  // POST: Perform deletion and redirect
+  // =========================================================================
+
+  if (request.method === "POST") {
+    const result = await deleteInstance(modelAdmin, backend, objectId);
+
+    if (!result.success) {
+      // Re-render page with error message
+      const instance = await fetchInstanceSummary(
+        modelAdmin,
+        backend,
+        objectId,
+      );
+      const objectSummary = instance
+        ? renderObjectSummary(instance, modelAdmin)
+        : "";
+
+      const content = `
+      ${breadcrumbs}
+      <div class="admin-delete-confirmation">
+        <div class="admin-content-title">
+          <h1>${escapeHtml(title)}</h1>
+        </div>
+
+        <p class="admin-error-message">${
+        escapeHtml(result.error ?? "An error occurred while deleting.")
+      }</p>
+
+        <ul class="admin-delete-summary">
+          ${objectSummary}
+        </ul>
+
+        <div class="admin-submit-row">
+          <a href="${
+        escapeHtml(changeUrl)
+      }" class="admin-btn admin-btn-default admin-cancel-btn">Go back</a>
+        </div>
+      </div>`;
+
+      const html = baseTemplate({
+        title,
+        siteTitle: adminSite.title,
+        urlPrefix,
+        userEmail,
+        navItems,
+        content,
+      });
+
+      return new Response(html, {
+        status: 500,
+        headers: { "Content-Type": "text/html; charset=utf-8" },
+      });
+    }
+
+    // Redirect to changelist on success
+    return new Response(null, {
+      status: 302,
+      headers: { Location: listUrl, "HX-Redirect": listUrl },
+    });
+  }
+
+  return new Response("Method not allowed", { status: 405 });
+}


### PR DESCRIPTION
## Summary

- Implements the delete confirmation view for the MPA admin panel (issue #130)
- GET renders a Django-style confirmation page with object summary, warning text, and Yes/No buttons
- POST deletes the object and redirects to the changelist (with `HX-Redirect` for HTMX)
- Returns 404 for unknown models or non-existent objects; 302 to login when unauthenticated
- Wires the delete route in `urls.ts` (replaces the 501 placeholder)
- 10 tests covering auth, 404 handling, GET rendering, and POST deletion (all passing)