### PR TITLE
fix(admin): use fetch() in createStaticHandler to support JSR https:// URLs

### DIFF
--- a/src/admin/urls.ts
+++ b/src/admin/urls.ts
@@ -153,7 +153,11 @@ function createStaticHandler(prefix: string): AdminHandler {
     const moduleDir = new URL("./static/", import.meta.url);
     const fileUrl = new URL(filePath, moduleDir);
     try {
-      const content = await Deno.readTextFile(fileUrl);
+      const response = await fetch(fileUrl);
+      if (!response.ok) {
+        return new Response("Not Found", { status: 404 });
+      }
+      const content = await response.text();
       return new Response(content, {
         status: 200,
         headers: { "Content-Type": contentType },


### PR DESCRIPTION
## Summary

- Replace `Deno.readTextFile(fileUrl)` with `fetch(fileUrl)` in `createStaticHandler` in `src/admin/urls.ts`
- `Deno.readTextFile()` only supports `file://` URLs; when `@alexi/admin` is installed from JSR, `import.meta.url` is an `https://` URL pointing to the JSR cache, causing admin static files (`/admin/static/css/admin.css`, `/admin/static/js/admin.js`) to return 404
- `fetch()` works for both `file://` (local dev) and `https://` (JSR) URLs
- Also fix pre-existing `override` modifier errors on `static meta` in `urls_test.ts` and add explicit static-serving tests to that file

Closes #148