### PR TITLE
fix(db): lazily resolve ForeignKey string-ref model from registry

### DIFF
--- a/src/db/models/model.ts
+++ b/src/db/models/model.ts
@@ -10,6 +10,7 @@ import {
   ManyToManyField,
   ManyToManyManager,
   RelatedManager,
+  setModelResolver,
 } from "../fields/relations.ts";
 import type { DatabaseBackend } from "../backends/backend.ts";
 
@@ -136,6 +137,10 @@ export class ModelRegistry {
   static get instance(): ModelRegistry {
     if (!ModelRegistry._instance) {
       ModelRegistry._instance = new ModelRegistry();
+      // Inject the registry as the model resolver for ForeignKey and ManyToManyField
+      // so that string-based model references can be resolved lazily on any instance,
+      // without requiring setRelatedModel() to have been called on that specific instance.
+      setModelResolver((name: string) => ModelRegistry._instance.get(name));
     }
     return ModelRegistry._instance;
   }


### PR DESCRIPTION
## Summary

- `ForeignKey` and `ManyToManyField` with string-based model references (e.g. `new ForeignKey<Unit>("Unit", ...)`) now correctly resolve on any model instance, not just the prototype-level instance that `_resolveRelations()` touched
- Adds a `setModelResolver()` function in `relations.ts` that `ModelRegistry` uses to inject itself as a lazy resolver — avoids circular imports since `model.ts` already imports from `relations.ts`
- `getRelatedModel()` falls back to the resolver for string references and caches the result, fixing both the silent no-op in `selectRelated()` and the thrown error in `.fetch()`
- Added two regression tests covering both failure modes from the issue

Closes #161