### PR TITLE
feat(views): Django-style template engine with inheritance, loops, and conditionals

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -3,10 +3,12 @@
   "specifiers": {
     "jsr:@luca/esbuild-deno-loader@~0.11.1": "0.11.1",
     "jsr:@std/assert@*": "1.0.19",
+    "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/bytes@^1.0.2": "1.0.6",
     "jsr:@std/encoding@^1.0.5": "1.0.10",
     "jsr:@std/fs@^1.0.19": "1.0.23",
     "jsr:@std/internal@^1.0.12": "1.0.12",
+    "jsr:@std/path@1": "1.1.4",
     "jsr:@std/path@^1.0.6": "1.1.4",
     "jsr:@std/path@^1.1.2": "1.1.4",
     "jsr:@std/path@^1.1.4": "1.1.4",
@@ -14,7 +16,8 @@
     "jsr:@zip-js/zip-js@^2.8.7": "2.8.21",
     "npm:esbuild@0.24": "0.24.2",
     "npm:fake-indexeddb@6": "6.2.5",
-    "npm:pg@8": "8.19.0"
+    "npm:pg@8": "8.19.0",
+    "npm:playwright@^1.48.0": "1.58.2"
   },
   "jsr": {
     "@luca/esbuild-deno-loader@0.11.1": {
@@ -226,6 +229,11 @@
     "fake-indexeddb@6.2.5": {
       "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w=="
     },
+    "fsevents@2.3.2": {
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "os": ["darwin"],
+      "scripts": true
+    },
     "pg-cloudflare@1.3.0": {
       "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ=="
     },
@@ -273,6 +281,20 @@
         "split2"
       ]
     },
+    "playwright-core@1.58.2": {
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "bin": true
+    },
+    "playwright@1.58.2": {
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dependencies": [
+        "playwright-core"
+      ],
+      "optionalDependencies": [
+        "fsevents"
+      ],
+      "bin": true
+    },
     "postgres-array@2.0.0": {
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
     },
@@ -294,6 +316,75 @@
     "xtend@4.0.2": {
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     }
+  },
+  "remote": {
+    "https://deno.land/std@0.208.0/assert/_constants.ts": "8a9da298c26750b28b326b297316cdde860bc237533b07e1337c021379e6b2a9",
+    "https://deno.land/std@0.208.0/assert/_diff.ts": "58e1461cc61d8eb1eacbf2a010932bf6a05b79344b02ca38095f9b805795dc48",
+    "https://deno.land/std@0.208.0/assert/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
+    "https://deno.land/std@0.208.0/assert/assert.ts": "9a97dad6d98c238938e7540736b826440ad8c1c1e54430ca4c4e623e585607ee",
+    "https://deno.land/std@0.208.0/assert/assert_almost_equals.ts": "e15ca1f34d0d5e0afae63b3f5d975cbd18335a132e42b0c747d282f62ad2cd6c",
+    "https://deno.land/std@0.208.0/assert/assert_array_includes.ts": "6856d7f2c3544bc6e62fb4646dfefa3d1df5ff14744d1bca19f0cbaf3b0d66c9",
+    "https://deno.land/std@0.208.0/assert/assert_equals.ts": "d8ec8a22447fbaf2fc9d7c3ed2e66790fdb74beae3e482855d75782218d68227",
+    "https://deno.land/std@0.208.0/assert/assert_exists.ts": "407cb6b9fb23a835cd8d5ad804e2e2edbbbf3870e322d53f79e1c7a512e2efd7",
+    "https://deno.land/std@0.208.0/assert/assert_false.ts": "0ccbcaae910f52c857192ff16ea08bda40fdc79de80846c206bfc061e8c851c6",
+    "https://deno.land/std@0.208.0/assert/assert_greater.ts": "ae2158a2d19313bf675bf7251d31c6dc52973edb12ac64ac8fc7064152af3e63",
+    "https://deno.land/std@0.208.0/assert/assert_greater_or_equal.ts": "1439da5ebbe20855446cac50097ac78b9742abe8e9a43e7de1ce1426d556e89c",
+    "https://deno.land/std@0.208.0/assert/assert_instance_of.ts": "3aedb3d8186e120812d2b3a5dea66a6e42bf8c57a8bd927645770bd21eea554c",
+    "https://deno.land/std@0.208.0/assert/assert_is_error.ts": "c21113094a51a296ffaf036767d616a78a2ae5f9f7bbd464cd0197476498b94b",
+    "https://deno.land/std@0.208.0/assert/assert_less.ts": "aec695db57db42ec3e2b62e97e1e93db0063f5a6ec133326cc290ff4b71b47e4",
+    "https://deno.land/std@0.208.0/assert/assert_less_or_equal.ts": "5fa8b6a3ffa20fd0a05032fe7257bf985d207b85685fdbcd23651b70f928c848",
+    "https://deno.land/std@0.208.0/assert/assert_match.ts": "c4083f80600bc190309903c95e397a7c9257ff8b5ae5c7ef91e834704e672e9b",
+    "https://deno.land/std@0.208.0/assert/assert_not_equals.ts": "9f1acab95bd1f5fc9a1b17b8027d894509a745d91bac1718fdab51dc76831754",
+    "https://deno.land/std@0.208.0/assert/assert_not_instance_of.ts": "0c14d3dfd9ab7a5276ed8ed0b18c703d79a3d106102077ec437bfe7ed912bd22",
+    "https://deno.land/std@0.208.0/assert/assert_not_match.ts": "3796a5b0c57a1ce6c1c57883dd4286be13a26f715ea662318ab43a8491a13ab0",
+    "https://deno.land/std@0.208.0/assert/assert_not_strict_equals.ts": "4cdef83df17488df555c8aac1f7f5ec2b84ad161b6d0645ccdbcc17654e80c99",
+    "https://deno.land/std@0.208.0/assert/assert_object_match.ts": "d8fc2867cfd92eeacf9cea621e10336b666de1874a6767b5ec48988838370b54",
+    "https://deno.land/std@0.208.0/assert/assert_rejects.ts": "45c59724de2701e3b1f67c391d6c71c392363635aad3f68a1b3408f9efca0057",
+    "https://deno.land/std@0.208.0/assert/assert_strict_equals.ts": "b1f538a7ea5f8348aeca261d4f9ca603127c665e0f2bbfeb91fa272787c87265",
+    "https://deno.land/std@0.208.0/assert/assert_string_includes.ts": "b821d39ebf5cb0200a348863c86d8c4c4b398e02012ce74ad15666fc4b631b0c",
+    "https://deno.land/std@0.208.0/assert/assert_throws.ts": "63784e951475cb7bdfd59878cd25a0931e18f6dc32a6077c454b2cd94f4f4bcd",
+    "https://deno.land/std@0.208.0/assert/assertion_error.ts": "4d0bde9b374dfbcbe8ac23f54f567b77024fb67dbb1906a852d67fe050d42f56",
+    "https://deno.land/std@0.208.0/assert/equal.ts": "9f1a46d5993966d2596c44e5858eec821859b45f783a5ee2f7a695dfc12d8ece",
+    "https://deno.land/std@0.208.0/assert/fail.ts": "c36353d7ae6e1f7933d45f8ea51e358c8c4b67d7e7502028598fe1fea062e278",
+    "https://deno.land/std@0.208.0/assert/mod.ts": "37c49a26aae2b254bbe25723434dc28cd7532e444cf0b481a97c045d110ec085",
+    "https://deno.land/std@0.208.0/assert/unimplemented.ts": "d56fbeecb1f108331a380f72e3e010a1f161baa6956fd0f7cf3e095ae1a4c75a",
+    "https://deno.land/std@0.208.0/assert/unreachable.ts": "4600dc0baf7d9c15a7f7d234f00c23bca8f3eba8b140286aaca7aa998cf9a536",
+    "https://deno.land/std@0.208.0/fmt/colors.ts": "34b3f77432925eb72cf0bfb351616949746768620b8e5ead66da532f93d10ba2",
+    "https://deno.land/std@0.208.0/testing/_test_suite.ts": "30f018feeb3835f12ab198d8a518f9089b1bcb2e8c838a8b615ab10d5005465c",
+    "https://deno.land/std@0.208.0/testing/bdd.ts": "c41f019786c4a9112aadb7e5a7bbcc711f58429ac5904b3855fa248ba5fa0ba6",
+    "https://deno.land/std@0.224.0/assert/_constants.ts": "a271e8ef5a573f1df8e822a6eb9d09df064ad66a4390f21b3e31f820a38e0975",
+    "https://deno.land/std@0.224.0/assert/assert.ts": "09d30564c09de846855b7b071e62b5974b001bb72a4b797958fe0660e7849834",
+    "https://deno.land/std@0.224.0/assert/assert_almost_equals.ts": "9e416114322012c9a21fa68e187637ce2d7df25bcbdbfd957cd639e65d3cf293",
+    "https://deno.land/std@0.224.0/assert/assert_array_includes.ts": "14c5094471bc8e4a7895fc6aa5a184300d8a1879606574cb1cd715ef36a4a3c7",
+    "https://deno.land/std@0.224.0/assert/assert_equals.ts": "3bbca947d85b9d374a108687b1a8ba3785a7850436b5a8930d81f34a32cb8c74",
+    "https://deno.land/std@0.224.0/assert/assert_exists.ts": "43420cf7f956748ae6ed1230646567b3593cb7a36c5a5327269279c870c5ddfd",
+    "https://deno.land/std@0.224.0/assert/assert_false.ts": "3e9be8e33275db00d952e9acb0cd29481a44fa0a4af6d37239ff58d79e8edeff",
+    "https://deno.land/std@0.224.0/assert/assert_greater.ts": "5e57b201fd51b64ced36c828e3dfd773412c1a6120c1a5a99066c9b261974e46",
+    "https://deno.land/std@0.224.0/assert/assert_greater_or_equal.ts": "9870030f997a08361b6f63400273c2fb1856f5db86c0c3852aab2a002e425c5b",
+    "https://deno.land/std@0.224.0/assert/assert_instance_of.ts": "e22343c1fdcacfaea8f37784ad782683ec1cf599ae9b1b618954e9c22f376f2c",
+    "https://deno.land/std@0.224.0/assert/assert_is_error.ts": "f856b3bc978a7aa6a601f3fec6603491ab6255118afa6baa84b04426dd3cc491",
+    "https://deno.land/std@0.224.0/assert/assert_less.ts": "60b61e13a1982865a72726a5fa86c24fad7eb27c3c08b13883fb68882b307f68",
+    "https://deno.land/std@0.224.0/assert/assert_less_or_equal.ts": "d2c84e17faba4afe085e6c9123a63395accf4f9e00150db899c46e67420e0ec3",
+    "https://deno.land/std@0.224.0/assert/assert_match.ts": "ace1710dd3b2811c391946954234b5da910c5665aed817943d086d4d4871a8b7",
+    "https://deno.land/std@0.224.0/assert/assert_not_equals.ts": "78d45dd46133d76ce624b2c6c09392f6110f0df9b73f911d20208a68dee2ef29",
+    "https://deno.land/std@0.224.0/assert/assert_not_instance_of.ts": "3434a669b4d20cdcc5359779301a0588f941ffdc2ad68803c31eabdb4890cf7a",
+    "https://deno.land/std@0.224.0/assert/assert_not_match.ts": "df30417240aa2d35b1ea44df7e541991348a063d9ee823430e0b58079a72242a",
+    "https://deno.land/std@0.224.0/assert/assert_not_strict_equals.ts": "37f73880bd672709373d6dc2c5f148691119bed161f3020fff3548a0496f71b8",
+    "https://deno.land/std@0.224.0/assert/assert_object_match.ts": "411450fd194fdaabc0089ae68f916b545a49d7b7e6d0026e84a54c9e7eed2693",
+    "https://deno.land/std@0.224.0/assert/assert_rejects.ts": "4bee1d6d565a5b623146a14668da8f9eb1f026a4f338bbf92b37e43e0aa53c31",
+    "https://deno.land/std@0.224.0/assert/assert_strict_equals.ts": "b4f45f0fd2e54d9029171876bd0b42dd9ed0efd8f853ab92a3f50127acfa54f5",
+    "https://deno.land/std@0.224.0/assert/assert_string_includes.ts": "496b9ecad84deab72c8718735373feb6cdaa071eb91a98206f6f3cb4285e71b8",
+    "https://deno.land/std@0.224.0/assert/assert_throws.ts": "c6508b2879d465898dab2798009299867e67c570d7d34c90a2d235e4553906eb",
+    "https://deno.land/std@0.224.0/assert/assertion_error.ts": "ba8752bd27ebc51f723702fac2f54d3e94447598f54264a6653d6413738a8917",
+    "https://deno.land/std@0.224.0/assert/equal.ts": "bddf07bb5fc718e10bb72d5dc2c36c1ce5a8bdd3b647069b6319e07af181ac47",
+    "https://deno.land/std@0.224.0/assert/fail.ts": "0eba674ffb47dff083f02ced76d5130460bff1a9a68c6514ebe0cdea4abadb68",
+    "https://deno.land/std@0.224.0/assert/mod.ts": "48b8cb8a619ea0b7958ad7ee9376500fe902284bb36f0e32c598c3dc34cbd6f3",
+    "https://deno.land/std@0.224.0/assert/unimplemented.ts": "8c55a5793e9147b4f1ef68cd66496b7d5ba7a9e7ca30c6da070c1a58da723d73",
+    "https://deno.land/std@0.224.0/assert/unreachable.ts": "5ae3dbf63ef988615b93eb08d395dda771c96546565f9e521ed86f6510c29e19",
+    "https://deno.land/std@0.224.0/fmt/colors.ts": "508563c0659dd7198ba4bbf87e97f654af3c34eb56ba790260f252ad8012e1c5",
+    "https://deno.land/std@0.224.0/internal/diff.ts": "6234a4b493ebe65dc67a18a0eb97ef683626a1166a1906232ce186ae9f65f4e6",
+    "https://deno.land/std@0.224.0/internal/format.ts": "0a98ee226fd3d43450245b1844b47003419d34d210fa989900861c79820d21c2",
+    "https://deno.land/std@0.224.0/internal/mod.ts": "534125398c8e7426183e12dc255bb635d94e06d0f93c60a297723abe69d3b22e"
   },
   "workspace": {
     "dependencies": [

--- a/docs/offline-mpa.md
+++ b/docs/offline-mpa.md
@@ -1,0 +1,510 @@
+# Offline-First MPA with Alexi and Service Workers
+
+Alexi is a Django-inspired full-stack framework for Deno. Most of the time you
+reach for it to build a REST API on the server and a client-side SPA in the
+browser. But there is a second architecture hiding in plain sight — one that
+trades the SPA model for something older and, in many ways, simpler: a
+**Multi-Page Application running entirely inside a Service Worker**.
+
+This guide walks through building an offline-first MPA with Alexi and
+[HTMX](https://htmx.org). A cloud-hosted Alexi server provides the REST API. The
+browser runs its own Alexi application inside a Service Worker, intercepts every
+navigation and HTMX request, serves server-rendered HTML from local data, and
+syncs with the cloud whenever a connection is available.
+
+---
+
+## The Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Browser                                            │
+│                                                     │
+│  ┌─────────────┐   fetch/navigate   ┌────────────┐  │
+│  │  HTML page  │ ─────────────────► │  Service   │  │
+│  │  + HTMX     │ ◄───────────────── │  Worker    │  │
+│  └─────────────┘   HTML response    │            │  │
+│                                     │  Alexi app │  │
+│                                     │  ─────── │  │
+│                                     │  URLs      │  │
+│                                     │  Views     │  │
+│                                     │  ORM       │  │
+│                                     │  IndexedDB │  │
+│                                     └─────┬──────┘  │
+└───────────────────────────────────────────┼─────────┘
+                                            │ sync (when online)
+                                            ▼
+                              ┌─────────────────────────┐
+                              │  Cloud                  │
+                              │  Alexi web server       │
+                              │  REST API               │
+                              └─────────────────────────┘
+```
+
+The key insight is that `Application.handler` — the heart of every Alexi
+application — is a plain `(Request) => Promise<Response>` function. It has no
+dependency on `Deno.serve()` or any other runtime-specific API. A Service Worker
+intercepts HTTP requests using exactly that same interface. The two fit together
+naturally.
+
+---
+
+## Why This Works
+
+Alexi's internals were designed around Web-standard primitives:
+
+| Component                               | Deno-specific APIs? | Works in SW? |
+| --------------------------------------- | ------------------- | ------------ |
+| `Application.handler`                   | None                | Yes          |
+| URL routing (`@alexi/urls`)             | None                | Yes          |
+| Middleware (`@alexi/middleware`)        | None                | Yes          |
+| REST framework (`@alexi/restframework`) | None                | Yes          |
+| IndexedDB backend                       | None (browser APIs) | Yes          |
+| REST backend                            | None (`fetch` only) | Yes          |
+| `templateView`                          | None                | Yes          |
+
+The only parts of Alexi that use Deno-specific APIs (`Deno.serve`,
+`Deno.readFile`, `Deno.openKv`) are the server-side infrastructure — the web
+server command and the DenoKV backend. Those simply don't belong in a Service
+Worker, and you don't need them there.
+
+---
+
+## Project Structure
+
+A project using this architecture has two Alexi apps:
+
+```
+my-project/
+├── manage.ts
+├── deno.jsonc
+├── project/
+│   ├── web.settings.ts      # Cloud server settings
+│   └── sw.settings.ts       # Service Worker bundle settings
+└── src/
+    ├── my-app-web/          # Cloud: REST API (DenoKV backend)
+    │   ├── mod.ts
+    │   ├── models.ts
+    │   ├── serializers.ts
+    │   ├── viewsets.ts
+    │   └── urls.ts
+    └── my-app-sw/           # Client: MPA Service Worker
+        ├── mod.ts
+        ├── models.ts        # Same model definitions
+        ├── settings.ts      # Backend configuration
+        ├── views.ts         # Server-renders HTML
+        ├── urls.ts
+        ├── sw.ts            # SW entry point
+        └── static/
+            └── my-app/
+                └── index.html
+```
+
+The cloud app and the SW app share model definitions — same field types, same
+`dbTable` names. They differ only in which backend they talk to.
+
+---
+
+## Setting Up the Service Worker App
+
+### Settings
+
+Backends are declared in the app's `settings.ts`. The `DATABASES` object maps
+string keys to backend instances — the same keys are then passed to `.using()`
+in views and sync code.
+
+```typescript
+// src/my-app-sw/settings.ts
+import { IndexedDBBackend } from "@alexi/db/backends/indexeddb";
+import { ModelEndpoint, RestBackend } from "@alexi/db/backends/rest";
+import { NoteModel } from "./models.ts";
+
+class NoteEndpoint extends ModelEndpoint {
+  model = NoteModel;
+  path = "/notes/";
+}
+
+export const DATABASES = {
+  default: new IndexedDBBackend({ name: "my-app" }),
+  remote: new RestBackend({
+    apiUrl: "https://api.my-app.com/api",
+    endpoints: [NoteEndpoint],
+  }),
+};
+```
+
+### Models
+
+Model definitions are identical to any other Alexi app. The difference is only
+in which backend gets injected at runtime.
+
+```typescript
+// src/my-app-sw/models.ts
+import { AutoField, CharField, Manager, Model, TextField } from "@alexi/db";
+
+export class NoteModel extends Model {
+  id = new AutoField({ primaryKey: true });
+  title = new CharField({ maxLength: 200 });
+  body = new TextField({ blank: true });
+  synced = new BooleanField({ default: false });
+
+  static objects = new Manager(NoteModel);
+  static meta = { dbTable: "notes" };
+}
+```
+
+### Templates
+
+SW views use Alexi's `templateView` with `.html` template files — the same way
+views work on the server. The template engine resolves templates from the app's
+`templates/` directory and supports Django-style variable substitution,
+conditionals, loops, and template inheritance.
+
+```
+src/my-app-sw/
+├── views.ts
+├── urls.ts
+└── templates/
+    └── my-app/
+        ├── base.html
+        ├── note_list.html
+        └── note_detail.html
+```
+
+A base template provides the page shell with HTMX:
+
+```html
+<!-- src/my-app-sw/templates/my-app/base.html -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>{% block title %}My App{% endblock %}</title>
+    <script src="https://unpkg.com/htmx.org@2" defer></script>
+    <link rel="stylesheet" href="/static/my-app/styles.css">
+  </head>
+  <body>
+    <nav>
+      <a hx-get="/notes/" hx-target="#content" hx-push-url="true">Notes</a>
+      <button hx-post="/sync/" hx-target="#status">Sync</button>
+      <span id="status"></span>
+    </nav>
+    <main id="content">
+      {% block content %}{% endblock %}
+    </main>
+  </body>
+</html>
+```
+
+List and detail templates extend the base:
+
+```html
+<!-- src/my-app-sw/templates/my-app/note_list.html -->
+{% extends "my-app/base.html" %} {% block title %}Notes{% endblock %} {% block
+content %}
+<h1>Notes</h1>
+<ul>
+  {% for note in notes %}
+  <li>
+    <a hx-get="/notes/{{ note.id }}/" hx-target="#content" hx-push-url="true">
+      {{ note.title }}
+    </a>
+  </li>
+  {% endfor %}
+</ul>
+<a hx-get="/notes/add/" hx-target="#content" hx-push-url="true">Add note</a>
+{% endblock %}
+```
+
+```html
+<!-- src/my-app-sw/templates/my-app/note_detail.html -->
+{% extends "my-app/base.html" %} {% block title %}{{ note.title }}{% endblock %}
+{% block content %}
+<h1>{{ note.title }}</h1>
+<p>{{ note.body }}</p>
+<note-actions note-id="{{ note.id }}"></note-actions>
+<a hx-get="/notes/" hx-target="#content" hx-push-url="true">← Back</a>
+{% endblock %}
+```
+
+Notice `<note-actions>` — Web Components work naturally here. The SW returns
+plain HTML text, and the browser hydrates any custom elements it finds using the
+component JS loaded from `/static/`.
+
+### Views
+
+Views use `templateView` exactly as on the server — pass a template path and a
+context function. The `.using("default")` call refers to the key defined in
+`settings.ts`:
+
+```typescript
+// src/my-app-sw/views.ts
+import { templateView } from "@alexi/views";
+import { NoteModel } from "./models.ts";
+
+export const noteListView = templateView({
+  templateName: "my-app/note_list.html",
+  context: async () => ({
+    notes: (await NoteModel.objects.using("default").orderBy("-id").fetch())
+      .array().map((n) => ({
+        id: n.id.get(),
+        title: n.title.get(),
+      })),
+  }),
+});
+
+export const noteDetailView = templateView({
+  templateName: "my-app/note_detail.html",
+  context: async (_request, params) => {
+    const note = await NoteModel.objects.using("default").get({
+      id: Number(params.id),
+    });
+    return {
+      note: {
+        id: note.id.get(),
+        title: note.title.get(),
+        body: note.body.get(),
+      },
+    };
+  },
+});
+```
+
+### URL Routing
+
+```typescript
+// src/my-app-sw/urls.ts
+import { path } from "@alexi/urls";
+import { noteDetailView, noteListView } from "./views.ts";
+
+export const urlpatterns = [
+  path("notes/", noteListView, { name: "note-list" }),
+  path("notes/:id/", noteDetailView, { name: "note-detail" }),
+];
+```
+
+### The Service Worker Entry Point
+
+The SW entry point wires the Alexi `Application` into the Service Worker `fetch`
+event. It imports backends from `settings.ts` and connects them on install.
+
+```typescript
+// src/my-app-sw/sw.ts
+import { Application } from "@alexi/core";
+import { setup } from "@alexi/db";
+import { urlpatterns } from "./urls.ts";
+import { DATABASES } from "./settings.ts";
+
+declare const self: ServiceWorkerGlobalScope;
+
+const app = new Application({ urls: urlpatterns });
+
+// Connect backends on SW install
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    (async () => {
+      await DATABASES.default.connect();
+      await setup({ backend: DATABASES.default });
+      await self.skipWaiting();
+    })(),
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+// Hand every navigation and HTMX request to Alexi
+self.addEventListener("fetch", (event) => {
+  const url = new URL(event.request.url);
+
+  // Only intercept same-origin requests
+  if (url.origin !== self.location.origin) return;
+
+  // Let static files through to the network
+  if (url.pathname.startsWith("/static/")) return;
+
+  event.respondWith(app.handler(event.request));
+});
+```
+
+### Registering the Service Worker
+
+The `index.html` shell page registers the SW and bootstraps the first render. On
+the very first visit the SW is not yet in control, so the page triggers an HTMX
+request to the SW app's root view instead of reloading. HTMX swaps the response
+into `#content` — no full page reload, no flash.
+
+```html
+<!-- src/my-app-sw/static/my-app/index.html -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>My App</title>
+    <script src="https://unpkg.com/htmx.org@2" defer></script>
+    <link rel="stylesheet" href="/static/my-app/styles.css">
+  </head>
+  <body>
+    <div id="content"></div>
+    <script>
+      if ("serviceWorker" in navigator) {
+        navigator.serviceWorker.register("/sw.js").then((reg) => {
+          function render() {
+            htmx.ajax("GET", location.href, {
+              target: "#content",
+              swap: "innerHTML",
+            });
+          }
+
+          if (navigator.serviceWorker.controller) {
+            // SW already in control — trigger the first HTMX render
+            render();
+          } else {
+            // First visit — wait for the SW to activate, then render
+            const worker = reg.installing || reg.waiting;
+            worker.addEventListener("statechange", function () {
+              if (this.state === "activated") render();
+            });
+          }
+        });
+      }
+    </script>
+  </body>
+</html>
+```
+
+On subsequent visits the SW is already in control when the page loads, so the
+HTMX request fires immediately and the initial render is instant.
+
+---
+
+## Bundling the Service Worker
+
+The existing `bundle` management command handles this. Add a `bundle` config to
+your SW app's `AppConfig`:
+
+```typescript
+// src/my-app-sw/mod.ts
+import type { AppConfig } from "@alexi/core";
+
+const config: AppConfig = {
+  name: "my-app-sw",
+  bundle: {
+    entrypoint: "src/sw.ts",
+    outputDir: "static/my-app",
+    outputName: "sw.js",
+  },
+};
+
+export default config;
+```
+
+Build:
+
+```bash
+deno task manage bundle --settings sw
+```
+
+This produces `src/my-app-sw/static/my-app/sw.js` — a single self-contained file
+that the browser registers as a Service Worker.
+
+For development with live reload:
+
+```bash
+deno task manage bundle --settings sw --watch
+```
+
+---
+
+## Syncing with the Cloud
+
+The cloud server is a standard Alexi web application with a REST API. Syncing is
+just the ORM's `.using()` and `.save()` — backends are referenced by the string
+keys defined in `settings.ts`.
+
+### Pulling from the Cloud
+
+```typescript
+// Fetch notes from the REST API and cache them in IndexedDB
+const remoteNotes = await NoteModel.objects
+  .using("remote")
+  .all()
+  .fetch();
+
+await remoteNotes.using("default").save();
+```
+
+### Pushing to the Cloud
+
+```typescript
+// Find unsynced local changes and push them
+const unsynced = await NoteModel.objects
+  .using("default")
+  .filter({ synced: false })
+  .fetch();
+
+await unsynced.using("remote").save();
+
+// Mark as synced locally
+for (const note of unsynced.array()) {
+  note.synced.set(true);
+}
+await unsynced.using("default").save();
+```
+
+### Triggering Sync
+
+Sync can be triggered anywhere — on app load, on user action, or when the
+browser comes back online:
+
+```typescript
+// In a view, after a write operation
+self.addEventListener("online", async () => {
+  await syncToCloud();
+});
+
+// Or expose a sync endpoint in the SW app itself
+export async function syncView(request: Request): Promise<Response> {
+  await syncToCloud();
+  return Response.redirect("/notes/", 303);
+}
+```
+
+Add it to your URL patterns and wire an HTMX button to it:
+
+```html
+<button hx-post="/sync/" hx-target="#status">Sync now</button>
+```
+
+---
+
+## What You Get
+
+**Full offline support** — The application works with no network connection.
+Every page load and HTMX request is served by the local Alexi instance from
+IndexedDB. The user experience is identical online and offline.
+
+**MPA simplicity** — No client-side routing framework, no component lifecycle,
+no hydration. The server renders HTML and HTMX swaps it in. Forms work. The back
+button works. Deep links work. It is just HTTP.
+
+**One codebase, two targets** — The cloud server and the SW app share model
+definitions and can share serializer or utility code. The REST framework on the
+cloud and the view layer in the SW are the same Alexi abstractions.
+
+**Progressive enhancement** — The sync is explicit and in your control. You
+decide when to pull from the cloud, when to push local changes, and how to
+resolve conflicts. The ORM's `.using()` makes the mechanics transparent.
+
+---
+
+## Limitations
+
+**Static files are served from the network.** The SW app does not serve CSS,
+images, or other static assets — those are handled by the browser's normal cache
+or a separate caching strategy. For full offline static file support, cache them
+in the SW `install` event using the Cache API.
+
+**HTTPS required in production.** Service Workers only register on secure
+origins. `localhost` is exempt for development.

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -620,4 +620,29 @@ export interface AppConfig {
    * @example () => import("./commands/mod.ts")
    */
   commandsImport?: () => Promise<Record<string, unknown>>;
+
+  /**
+   * Template directory for this app.
+   *
+   * Django-style namespacing: a template named `"my-app/note_list.html"`
+   * should live at `<templatesDir>/my-app/note_list.html`.
+   *
+   * Can be either:
+   * - A path relative to the project root: `"src/my-app/templates"`
+   * - An absolute `file://` URL (recommended for published packages):
+   *   `new URL("./templates/", import.meta.url).href`
+   *
+   * When the Application starts, it reads all `.html` files from this
+   * directory tree and registers them in the global `templateRegistry`
+   * so templates are available to `templateView`.
+   *
+   * @example
+   * // Relative path (project-local apps)
+   * templatesDir: "src/my-app/templates"
+   *
+   * @example
+   * // Absolute URL (published packages)
+   * templatesDir: new URL("./templates/", import.meta.url).href
+   */
+  templatesDir?: string;
 }

--- a/src/views/engine/lexer.ts
+++ b/src/views/engine/lexer.ts
@@ -1,0 +1,84 @@
+/**
+ * Alexi Template Engine - Lexer
+ *
+ * Tokenizes Django-style template syntax into a stream of tokens.
+ * Handles `{{ var }}`, `{% tag %}`, and raw text.
+ *
+ * No Deno-specific APIs — compatible with Service Workers and browsers.
+ */
+
+// =============================================================================
+// Token Types
+// =============================================================================
+
+export type TokenType =
+  | "text" // Raw text / HTML
+  | "variable" // {{ expression }}
+  | "block_start" // {% tag ... %}
+  | "comment"; // {# comment #}
+
+export interface Token {
+  type: TokenType;
+  value: string; // Trimmed inner content (for variable/block/comment)
+  raw: string; // Original source text
+}
+
+// =============================================================================
+// Lexer
+// =============================================================================
+
+/**
+ * Tokenize a template string into a flat list of tokens.
+ *
+ * Recognises:
+ * - `{{ expr }}`  → variable token
+ * - `{% tag %}`   → block_start token
+ * - `{# text #}`  → comment token (discarded by parser)
+ * - Everything else → text token
+ */
+export function tokenize(source: string): Token[] {
+  const tokens: Token[] = [];
+  // Matches {{ }}, {% %}, {# #} — in that priority order.
+  const pattern = /(\{\{[\s\S]*?\}\}|\{%[\s\S]*?%\}|\{#[\s\S]*?#\})/g;
+
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(source)) !== null) {
+    const before = source.slice(lastIndex, match.index);
+    if (before) {
+      tokens.push({ type: "text", value: before, raw: before });
+    }
+
+    const raw = match[0];
+    if (raw.startsWith("{{")) {
+      tokens.push({
+        type: "variable",
+        value: raw.slice(2, -2).trim(),
+        raw,
+      });
+    } else if (raw.startsWith("{%")) {
+      tokens.push({
+        type: "block_start",
+        value: raw.slice(2, -2).trim(),
+        raw,
+      });
+    } else {
+      // {# comment #} — emit as comment so parser can skip it
+      tokens.push({
+        type: "comment",
+        value: raw.slice(2, -2).trim(),
+        raw,
+      });
+    }
+
+    lastIndex = match.index + raw.length;
+  }
+
+  const trailing = source.slice(lastIndex);
+  if (trailing) {
+    tokens.push({ type: "text", value: trailing, raw: trailing });
+  }
+
+  return tokens;
+}

--- a/src/views/engine/mod.ts
+++ b/src/views/engine/mod.ts
@@ -1,0 +1,23 @@
+/**
+ * Alexi Template Engine - Public API
+ *
+ * Re-exports all public symbols from the template engine sub-modules.
+ */
+
+export { tokenize } from "./lexer.ts";
+export type { Token, TokenType } from "./lexer.ts";
+
+export type { ASTNode } from "./nodes.ts";
+
+export { parse, TemplateParseError } from "./parser.ts";
+
+export { render } from "./renderer.ts";
+export type { TemplateContext, TemplateLoader } from "./renderer.ts";
+
+export {
+  ChainTemplateLoader,
+  FilesystemTemplateLoader,
+  MemoryTemplateLoader,
+  TemplateNotFoundError,
+  templateRegistry,
+} from "./registry.ts";

--- a/src/views/engine/nodes.ts
+++ b/src/views/engine/nodes.ts
@@ -1,0 +1,81 @@
+/**
+ * Alexi Template Engine - AST Node Types
+ *
+ * Abstract Syntax Tree nodes produced by the parser and consumed
+ * by the renderer.
+ *
+ * No Deno-specific APIs — compatible with Service Workers and browsers.
+ */
+
+// =============================================================================
+// AST Nodes
+// =============================================================================
+
+export type ASTNode =
+  | TextNode
+  | VariableNode
+  | BlockNode
+  | ForNode
+  | IfNode
+  | ExtendsNode
+  | IncludeNode
+  | CommentNode;
+
+/** Raw text / HTML output */
+export interface TextNode {
+  type: "text";
+  content: string;
+}
+
+/** `{{ expression }}` — dot-notation path into context */
+export interface VariableNode {
+  type: "variable";
+  /** e.g. "user.profile.name" */
+  path: string;
+}
+
+/** `{% block name %}...{% endblock %}` */
+export interface BlockNode {
+  type: "block";
+  name: string;
+  body: ASTNode[];
+}
+
+/** `{% for item in items %}...{% endfor %}` */
+export interface ForNode {
+  type: "for";
+  /** Loop variable name */
+  variable: string;
+  /** Context path for iterable */
+  iterable: string;
+  body: ASTNode[];
+  /** Optional `{% empty %}` body */
+  emptyBody: ASTNode[];
+}
+
+/** `{% if cond %}...{% elif cond %}...{% else %}...{% endif %}` */
+export interface IfNode {
+  type: "if";
+  branches: Array<{
+    /** null means the `else` branch */
+    condition: string | null;
+    body: ASTNode[];
+  }>;
+}
+
+/** `{% extends "base.html" %}` — must be first node in template */
+export interface ExtendsNode {
+  type: "extends";
+  templateName: string;
+}
+
+/** `{% include "partial.html" %}` */
+export interface IncludeNode {
+  type: "include";
+  templateName: string;
+}
+
+/** `{# comment #}` — no output */
+export interface CommentNode {
+  type: "comment";
+}

--- a/src/views/engine/parser.ts
+++ b/src/views/engine/parser.ts
@@ -1,0 +1,271 @@
+/**
+ * Alexi Template Engine - Parser
+ *
+ * Converts a flat token stream (from the lexer) into an AST.
+ *
+ * No Deno-specific APIs — compatible with Service Workers and browsers.
+ */
+
+import { tokenize } from "./lexer.ts";
+import type {
+  ASTNode,
+  BlockNode,
+  ExtendsNode,
+  ForNode,
+  IfNode,
+  IncludeNode,
+} from "./nodes.ts";
+
+// =============================================================================
+// Parse Error
+// =============================================================================
+
+export class TemplateParseError extends Error {
+  constructor(message: string) {
+    super(`TemplateParseError: ${message}`);
+    this.name = "TemplateParseError";
+  }
+}
+
+// =============================================================================
+// Parser
+// =============================================================================
+
+/**
+ * Parse a template source string into an AST node list.
+ */
+export function parse(source: string): ASTNode[] {
+  const tokens = tokenize(source);
+  const iter = new TokenIterator(tokens);
+  return parseBody(iter, null);
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+import type { Token } from "./lexer.ts";
+
+class TokenIterator {
+  private pos = 0;
+
+  constructor(private readonly tokens: Token[]) {}
+
+  peek(): Token | undefined {
+    return this.tokens[this.pos];
+  }
+
+  next(): Token | undefined {
+    return this.tokens[this.pos++];
+  }
+
+  hasMore(): boolean {
+    return this.pos < this.tokens.length;
+  }
+}
+
+/**
+ * Parse tokens into AST nodes until one of the `stopTags` is encountered
+ * (e.g. `endblock`, `endfor`, `endif`, `else`, `elif`, `empty`).
+ *
+ * @param iter    - Token stream
+ * @param stopAt  - Set of block tag names that terminate this body, or null
+ * @returns Parsed nodes (the stop tag token is NOT consumed)
+ */
+function parseBody(
+  iter: TokenIterator,
+  stopAt: Set<string> | null,
+): ASTNode[] {
+  const nodes: ASTNode[] = [];
+
+  while (iter.hasMore()) {
+    const tok = iter.peek()!;
+
+    if (tok.type === "text") {
+      iter.next();
+      nodes.push({ type: "text", content: tok.value });
+      continue;
+    }
+
+    if (tok.type === "comment") {
+      iter.next();
+      nodes.push({ type: "comment" });
+      continue;
+    }
+
+    if (tok.type === "variable") {
+      iter.next();
+      nodes.push({ type: "variable", path: tok.value });
+      continue;
+    }
+
+    // block_start
+    if (tok.type === "block_start") {
+      const tagName = firstWord(tok.value);
+
+      // Check if this is a stop tag
+      if (stopAt && stopAt.has(tagName)) {
+        // Leave the token in the stream for the caller to consume
+        return nodes;
+      }
+
+      iter.next(); // consume the tag
+
+      switch (tagName) {
+        case "extends":
+          nodes.push(parseExtends(tok.value));
+          break;
+        case "block":
+          nodes.push(parseBlock(tok.value, iter));
+          break;
+        case "for":
+          nodes.push(parseFor(tok.value, iter));
+          break;
+        case "if":
+          nodes.push(parseIf(tok.value, iter));
+          break;
+        case "include":
+          nodes.push(parseInclude(tok.value));
+          break;
+        case "endblock":
+        case "endfor":
+        case "endif":
+          throw new TemplateParseError(
+            `Unexpected tag "${tagName}" with no matching opening tag`,
+          );
+        default:
+          // Unknown tags → emit as-is so they don't silently disappear
+          nodes.push({ type: "text", content: tok.raw });
+      }
+      continue;
+    }
+
+    // Should never reach here
+    iter.next();
+  }
+
+  return nodes;
+}
+
+// ---------------------------------------------------------------------------
+// Tag parsers
+// ---------------------------------------------------------------------------
+
+function parseExtends(tagContent: string): ExtendsNode {
+  // {% extends "base.html" %} or {% extends 'base.html' %}
+  const m = tagContent.match(/^extends\s+["'](.+?)["']$/);
+  if (!m) {
+    throw new TemplateParseError(
+      `Invalid extends tag: {% ${tagContent} %}`,
+    );
+  }
+  return { type: "extends", templateName: m[1] };
+}
+
+function parseBlock(tagContent: string, iter: TokenIterator): BlockNode {
+  // {% block name %}
+  const m = tagContent.match(/^block\s+(\w+)$/);
+  if (!m) {
+    throw new TemplateParseError(`Invalid block tag: {% ${tagContent} %}`);
+  }
+  const name = m[1];
+  const body = parseBody(iter, new Set(["endblock"]));
+  consumeTag(iter, "endblock");
+  return { type: "block", name, body };
+}
+
+function parseFor(tagContent: string, iter: TokenIterator): ForNode {
+  // {% for item in items %}
+  const m = tagContent.match(/^for\s+(\w+)\s+in\s+(\S+)$/);
+  if (!m) {
+    throw new TemplateParseError(`Invalid for tag: {% ${tagContent} %}`);
+  }
+  const variable = m[1];
+  const iterable = m[2];
+
+  const body = parseBody(iter, new Set(["endfor", "empty"]));
+
+  // Check for optional {% empty %}
+  let emptyBody: ASTNode[] = [];
+  const next = iter.peek();
+  if (
+    next && next.type === "block_start" && firstWord(next.value) === "empty"
+  ) {
+    iter.next(); // consume {% empty %}
+    emptyBody = parseBody(iter, new Set(["endfor"]));
+  }
+
+  consumeTag(iter, "endfor");
+  return { type: "for", variable, iterable, body, emptyBody };
+}
+
+function parseIf(tagContent: string, iter: TokenIterator): IfNode {
+  // {% if condition %}
+  const condition = tagContent.replace(/^if\s+/, "").trim();
+  if (!condition) {
+    throw new TemplateParseError(`Empty if condition: {% ${tagContent} %}`);
+  }
+
+  const branches: IfNode["branches"] = [];
+
+  let currentCondition: string | null = condition;
+  let currentBody = parseBody(
+    iter,
+    new Set(["elif", "else", "endif"]),
+  );
+  branches.push({ condition: currentCondition, body: currentBody });
+
+  while (iter.hasMore()) {
+    const tok = iter.peek()!;
+    if (tok.type !== "block_start") break;
+    const tag = firstWord(tok.value);
+    if (tag === "endif") {
+      iter.next(); // consume {% endif %}
+      break;
+    }
+    if (tag === "elif") {
+      iter.next();
+      currentCondition = tok.value.replace(/^elif\s+/, "").trim();
+      currentBody = parseBody(iter, new Set(["elif", "else", "endif"]));
+      branches.push({ condition: currentCondition, body: currentBody });
+    } else if (tag === "else") {
+      iter.next();
+      currentBody = parseBody(iter, new Set(["endif"]));
+      branches.push({ condition: null, body: currentBody });
+    } else {
+      break;
+    }
+  }
+
+  return { type: "if", branches };
+}
+
+function parseInclude(tagContent: string): IncludeNode {
+  // {% include "partial.html" %} or {% include 'partial.html' %}
+  const m = tagContent.match(/^include\s+["'](.+?)["']$/);
+  if (!m) {
+    throw new TemplateParseError(`Invalid include tag: {% ${tagContent} %}`);
+  }
+  return { type: "include", templateName: m[1] };
+}
+
+// ---------------------------------------------------------------------------
+// Utility helpers
+// ---------------------------------------------------------------------------
+
+function firstWord(s: string): string {
+  return s.trimStart().split(/\s+/)[0] ?? "";
+}
+
+function consumeTag(iter: TokenIterator, expectedTag: string): void {
+  const tok = iter.next();
+  if (
+    !tok || tok.type !== "block_start" || firstWord(tok.value) !== expectedTag
+  ) {
+    throw new TemplateParseError(
+      `Expected {%% ${expectedTag} %%} but got ${
+        tok?.raw ?? "end of template"
+      }`,
+    );
+  }
+}

--- a/src/views/engine/registry.ts
+++ b/src/views/engine/registry.ts
@@ -1,0 +1,181 @@
+/**
+ * Alexi Template Engine - Template Registry
+ *
+ * Provides two `TemplateLoader` implementations:
+ *
+ * 1. `MemoryTemplateLoader` — in-memory map, used in Service Workers and tests.
+ *    Templates are registered programmatically (populated at bundle time).
+ *
+ * 2. `FilesystemTemplateLoader` — reads files from configured template
+ *    directories.  Server-only (uses Deno.readTextFile).
+ *
+ * Additionally, a global singleton registry (`templateRegistry`) is exposed
+ * so that `AppConfig.templatesDir` entries can be registered during
+ * Application startup.
+ */
+
+import type { TemplateLoader } from "./renderer.ts";
+
+// =============================================================================
+// MemoryTemplateLoader
+// =============================================================================
+
+/**
+ * In-memory template loader.
+ *
+ * Register templates programmatically:
+ * ```ts
+ * loader.register("my-app/note_list.html", "<html>...</html>");
+ * ```
+ *
+ * Compatible with Service Workers and browsers (no filesystem access).
+ */
+export class MemoryTemplateLoader implements TemplateLoader {
+  private readonly templates = new Map<string, string>();
+
+  /**
+   * Register a template by name.
+   *
+   * @param name    - Template name, e.g. `"my-app/note_list.html"`
+   * @param source  - Template source string
+   */
+  register(name: string, source: string): void {
+    this.templates.set(name, source);
+  }
+
+  /**
+   * Register multiple templates at once.
+   */
+  registerAll(entries: Record<string, string>): void {
+    for (const [name, source] of Object.entries(entries)) {
+      this.templates.set(name, source);
+    }
+  }
+
+  async load(name: string): Promise<string> {
+    const source = this.templates.get(name);
+    if (source === undefined) {
+      throw new TemplateNotFoundError(name);
+    }
+    // async signature for interface compatibility
+    return await Promise.resolve(source);
+  }
+
+  /** Remove all registered templates. */
+  clear(): void {
+    this.templates.clear();
+  }
+
+  /** Check whether a template is registered. */
+  has(name: string): boolean {
+    return this.templates.has(name);
+  }
+}
+
+// =============================================================================
+// FilesystemTemplateLoader  (server / Deno only)
+// =============================================================================
+
+/**
+ * Template loader that reads `.html` files from a list of template
+ * directories.
+ *
+ * Template directories are searched in order — first match wins.
+ * Django-style namespacing is supported: a template named
+ * `"my-app/note_list.html"` is looked up at
+ * `<templateDir>/my-app/note_list.html`.
+ *
+ * **Server-only** — uses `Deno.readTextFile`.
+ */
+export class FilesystemTemplateLoader implements TemplateLoader {
+  private readonly dirs: string[];
+
+  /**
+   * @param dirs - Ordered list of template root directories.
+   *               Each entry may be an absolute path or a `file://` URL string.
+   */
+  constructor(dirs: string[]) {
+    this.dirs = dirs.map(normalizeDir);
+  }
+
+  /**
+   * Add a template directory at the end of the search path.
+   */
+  addDir(dir: string): void {
+    this.dirs.push(normalizeDir(dir));
+  }
+
+  async load(name: string): Promise<string> {
+    for (const dir of this.dirs) {
+      const fullPath = `${dir}/${name}`;
+      try {
+        return await Deno.readTextFile(fullPath);
+      } catch {
+        // Not found in this directory — try next
+      }
+    }
+    throw new TemplateNotFoundError(name, this.dirs);
+  }
+}
+
+// =============================================================================
+// ChainTemplateLoader
+// =============================================================================
+
+/**
+ * Chains multiple loaders together — tries each in order.
+ * Useful for combining an in-memory override layer with a filesystem layer.
+ */
+export class ChainTemplateLoader implements TemplateLoader {
+  constructor(private readonly loaders: TemplateLoader[]) {}
+
+  async load(name: string): Promise<string> {
+    for (const loader of this.loaders) {
+      try {
+        return await loader.load(name);
+      } catch (err) {
+        if (!(err instanceof TemplateNotFoundError)) throw err;
+      }
+    }
+    throw new TemplateNotFoundError(name);
+  }
+}
+
+// =============================================================================
+// Global Registry Singleton
+// =============================================================================
+
+/**
+ * Global in-memory template registry.
+ *
+ * On the server, the `Application` populates this from each installed app's
+ * `templatesDir` at startup.  In a Service Worker, the bundle populates it
+ * during the install event.
+ *
+ * `templateView` uses this registry by default when `templateName` is given.
+ */
+export const templateRegistry = new MemoryTemplateLoader();
+
+// =============================================================================
+// TemplateNotFoundError
+// =============================================================================
+
+export class TemplateNotFoundError extends Error {
+  constructor(name: string, dirs?: string[]) {
+    const extra = dirs ? ` (searched: ${dirs.join(", ")})` : "";
+    super(`Template not found: "${name}"${extra}`);
+    this.name = "TemplateNotFoundError";
+  }
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function normalizeDir(dir: string): string {
+  // Convert file:// URLs to OS paths
+  if (dir.startsWith("file://")) {
+    return new URL(dir).pathname.replace(/\/$/, "");
+  }
+  return dir.replace(/\/$/, "");
+}

--- a/src/views/engine/renderer.ts
+++ b/src/views/engine/renderer.ts
@@ -1,0 +1,334 @@
+/**
+ * Alexi Template Engine - Renderer
+ *
+ * Renders a parsed AST against a context object, resolving template
+ * inheritance, includes, loops and conditionals.
+ *
+ * No Deno-specific APIs — compatible with Service Workers and browsers.
+ */
+
+import { parse, TemplateParseError } from "./parser.ts";
+import type {
+  ASTNode,
+  BlockNode,
+  ExtendsNode,
+  ForNode,
+  IfNode,
+} from "./nodes.ts";
+
+// =============================================================================
+// Context
+// =============================================================================
+
+/** A plain-object context passed to template rendering */
+export type TemplateContext = Record<string, unknown>;
+
+// =============================================================================
+// Template Loader Interface
+// =============================================================================
+
+/**
+ * Interface for resolving template names to source strings.
+ * Implemented differently on server (filesystem) and in SW (registry).
+ */
+export interface TemplateLoader {
+  load(templateName: string): Promise<string>;
+}
+
+// =============================================================================
+// Renderer
+// =============================================================================
+
+/**
+ * Render a template by name using the provided loader and context.
+ */
+export async function render(
+  templateName: string,
+  context: TemplateContext,
+  loader: TemplateLoader,
+): Promise<string> {
+  const source = await loader.load(templateName);
+  const nodes = parse(source);
+  return renderNodes(nodes, context, loader, new Map());
+}
+
+// ---------------------------------------------------------------------------
+// Internal rendering
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a list of AST nodes.
+ *
+ * @param nodes   - AST nodes to render
+ * @param ctx     - Template context
+ * @param loader  - Template loader for extends/include
+ * @param blocks  - Block overrides from child templates
+ */
+async function renderNodes(
+  nodes: ASTNode[],
+  ctx: TemplateContext,
+  loader: TemplateLoader,
+  blocks: Map<string, BlockNode>,
+): Promise<string> {
+  // Check if the first real node is {% extends %}
+  const firstSignificant = nodes.find(
+    (n) =>
+      n.type !== "text" || (n as { content: string }).content.trim() !== "",
+  );
+
+  if (firstSignificant?.type === "extends") {
+    return renderExtends(
+      firstSignificant as ExtendsNode,
+      nodes,
+      ctx,
+      loader,
+      blocks,
+    );
+  }
+
+  const parts: string[] = [];
+  for (const node of nodes) {
+    parts.push(await renderNode(node, ctx, loader, blocks));
+  }
+  return parts.join("");
+}
+
+async function renderNode(
+  node: ASTNode,
+  ctx: TemplateContext,
+  loader: TemplateLoader,
+  blocks: Map<string, BlockNode>,
+): Promise<string> {
+  switch (node.type) {
+    case "text":
+      return node.content;
+
+    case "comment":
+      return "";
+
+    case "variable":
+      return String(resolvePath(node.path, ctx) ?? "");
+
+    case "block": {
+      // If a child template overrode this block, use the override
+      const override = blocks.get(node.name);
+      const bodyToRender = override ? override.body : node.body;
+      return renderNodes(bodyToRender, ctx, loader, blocks);
+    }
+
+    case "for":
+      return renderFor(node as ForNode, ctx, loader, blocks);
+
+    case "if":
+      return renderIf(node as IfNode, ctx, loader, blocks);
+
+    case "include": {
+      const partial = await loader.load(node.templateName);
+      const partialNodes = parse(partial);
+      return renderNodes(partialNodes, ctx, loader, blocks);
+    }
+
+    case "extends":
+      throw new TemplateParseError(
+        "{% extends %} must be the first tag in a template",
+      );
+
+    default:
+      return "";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// {% extends %}
+// ---------------------------------------------------------------------------
+
+async function renderExtends(
+  extendsNode: ExtendsNode,
+  childNodes: ASTNode[],
+  ctx: TemplateContext,
+  loader: TemplateLoader,
+  inheritedBlocks: Map<string, BlockNode>,
+): Promise<string> {
+  // Collect block definitions from the child template.
+  // Blocks defined in the child override blocks with the same name in parent.
+  const childBlocks = new Map<string, BlockNode>(inheritedBlocks);
+  for (const node of childNodes) {
+    if (node.type === "block") {
+      // Child block overrides parent — but only if not already set by a
+      // grandchild (deeper inheritance keeps the deepest override).
+      if (!childBlocks.has(node.name)) {
+        childBlocks.set(node.name, node);
+      }
+    }
+  }
+
+  // Load and parse the parent template
+  const parentSource = await loader.load(extendsNode.templateName);
+  const parentNodes = parse(parentSource);
+
+  // Render the parent with the child's block overrides
+  return renderNodes(parentNodes, ctx, loader, childBlocks);
+}
+
+// ---------------------------------------------------------------------------
+// {% for %}
+// ---------------------------------------------------------------------------
+
+async function renderFor(
+  node: ForNode,
+  ctx: TemplateContext,
+  loader: TemplateLoader,
+  blocks: Map<string, BlockNode>,
+): Promise<string> {
+  const iterable = resolvePath(node.iterable, ctx);
+  if (!Array.isArray(iterable) || iterable.length === 0) {
+    // Render {% empty %} body if present
+    if (node.emptyBody.length > 0) {
+      return renderNodes(node.emptyBody, ctx, loader, blocks);
+    }
+    return "";
+  }
+
+  const parts: string[] = [];
+  for (let i = 0; i < iterable.length; i++) {
+    const loopCtx: TemplateContext = {
+      ...ctx,
+      [node.variable]: iterable[i],
+      forloop: {
+        counter: i + 1,
+        counter0: i,
+        revcounter: iterable.length - i,
+        revcounter0: iterable.length - i - 1,
+        first: i === 0,
+        last: i === iterable.length - 1,
+      },
+    };
+    parts.push(await renderNodes(node.body, loopCtx, loader, blocks));
+  }
+  return parts.join("");
+}
+
+// ---------------------------------------------------------------------------
+// {% if %}
+// ---------------------------------------------------------------------------
+
+async function renderIf(
+  node: IfNode,
+  ctx: TemplateContext,
+  loader: TemplateLoader,
+  blocks: Map<string, BlockNode>,
+): Promise<string> {
+  for (const branch of node.branches) {
+    // `else` branch has condition === null
+    if (branch.condition === null || evaluateCondition(branch.condition, ctx)) {
+      return renderNodes(branch.body, ctx, loader, blocks);
+    }
+  }
+  return "";
+}
+
+// ---------------------------------------------------------------------------
+// Condition evaluation
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate a simple condition expression.
+ *
+ * Supported forms:
+ * - `variable`          — truthy check
+ * - `not variable`      — negation
+ * - `a == b`            — equality
+ * - `a != b`            — inequality
+ * - `a > b`             — greater than
+ * - `a >= b`            — >=
+ * - `a < b`             — less than
+ * - `a <= b`            — <=
+ */
+function evaluateCondition(expr: string, ctx: TemplateContext): boolean {
+  const trimmed = expr.trim();
+
+  // `not X`
+  const notMatch = trimmed.match(/^not\s+(.+)$/);
+  if (notMatch) {
+    return !isTruthy(resolveValue(notMatch[1].trim(), ctx));
+  }
+
+  // Binary operators
+  const binMatch = trimmed.match(/^(.+?)\s*(==|!=|>=|<=|>|<)\s*(.+)$/);
+  if (binMatch) {
+    const left = resolveValue(binMatch[1].trim(), ctx);
+    const right = resolveValue(binMatch[3].trim(), ctx);
+    switch (binMatch[2]) {
+      case "==":
+        return left == right; // intentional loose equality
+      case "!=":
+        return left != right;
+      case ">":
+        return (left as number) > (right as number);
+      case ">=":
+        return (left as number) >= (right as number);
+      case "<":
+        return (left as number) < (right as number);
+      case "<=":
+        return (left as number) <= (right as number);
+    }
+  }
+
+  // Simple truthy
+  return isTruthy(resolveValue(trimmed, ctx));
+}
+
+// ---------------------------------------------------------------------------
+// Value resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a single value token — either a literal or a context path.
+ */
+function resolveValue(token: string, ctx: TemplateContext): unknown {
+  // String literals
+  if (
+    (token.startsWith('"') && token.endsWith('"')) ||
+    (token.startsWith("'") && token.endsWith("'"))
+  ) {
+    return token.slice(1, -1);
+  }
+  // Numeric literals
+  if (/^-?\d+(\.\d+)?$/.test(token)) {
+    return Number(token);
+  }
+  // Boolean / null literals
+  if (token === "true") return true;
+  if (token === "false") return false;
+  if (token === "null" || token === "None") return null;
+
+  // Context path
+  return resolvePath(token, ctx);
+}
+
+/**
+ * Resolve a dot-notation path into a context object.
+ *
+ * @example resolvePath("user.profile.name", ctx)
+ */
+function resolvePath(path: string, ctx: TemplateContext): unknown {
+  const parts = path.split(".");
+  let value: unknown = ctx;
+  for (const part of parts) {
+    if (value == null || typeof value !== "object") return undefined;
+    value = (value as Record<string, unknown>)[part];
+  }
+  return value;
+}
+
+/**
+ * Django-style truthiness: false for `false`, `0`, `""`, `null`,
+ * `undefined`, and empty arrays/objects.
+ */
+function isTruthy(value: unknown): boolean {
+  if (value === false || value === null || value === undefined) return false;
+  if (value === 0 || value === "") return false;
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof value === "object") return Object.keys(value as object).length > 0;
+  return true;
+}

--- a/src/views/engine_test.ts
+++ b/src/views/engine_test.ts
@@ -1,0 +1,423 @@
+/**
+ * Tests for the Alexi template engine.
+ *
+ * Covers: lexer, parser, renderer (variables, for, if, extends, include, empty)
+ * and the MemoryTemplateLoader.
+ *
+ * No Deno-specific filesystem access — all tests use MemoryTemplateLoader.
+ */
+
+import { assertEquals, assertMatch, assertRejects } from "jsr:@std/assert@1";
+
+import { tokenize } from "./engine/lexer.ts";
+import { parse, TemplateParseError } from "./engine/parser.ts";
+import { render } from "./engine/renderer.ts";
+import {
+  MemoryTemplateLoader,
+  TemplateNotFoundError,
+} from "./engine/registry.ts";
+
+// =============================================================================
+// Helper
+// =============================================================================
+
+/** Render a template string directly using an in-memory loader. */
+async function renderStr(
+  source: string,
+  ctx: Record<string, unknown> = {},
+  extra: Record<string, string> = {},
+): Promise<string> {
+  const loader = new MemoryTemplateLoader();
+  loader.register("__main__", source);
+  for (const [name, src] of Object.entries(extra)) {
+    loader.register(name, src);
+  }
+  return render("__main__", ctx, loader);
+}
+
+// =============================================================================
+// Lexer
+// =============================================================================
+
+Deno.test("lexer: tokenises text-only source", () => {
+  const tokens = tokenize("<p>Hello</p>");
+  assertEquals(tokens.length, 1);
+  assertEquals(tokens[0].type, "text");
+  assertEquals(tokens[0].value, "<p>Hello</p>");
+});
+
+Deno.test("lexer: tokenises variable", () => {
+  const tokens = tokenize("{{ name }}");
+  assertEquals(tokens.length, 1);
+  assertEquals(tokens[0].type, "variable");
+  assertEquals(tokens[0].value, "name");
+});
+
+Deno.test("lexer: tokenises block tag", () => {
+  const tokens = tokenize("{% if x %}y{% endif %}");
+  assertEquals(tokens[0].type, "block_start");
+  assertEquals(tokens[0].value, "if x");
+  assertEquals(tokens[1].type, "text");
+  assertEquals(tokens[2].type, "block_start");
+  assertEquals(tokens[2].value, "endif");
+});
+
+Deno.test("lexer: tokenises comment", () => {
+  const tokens = tokenize("{# this is a comment #}");
+  assertEquals(tokens.length, 1);
+  assertEquals(tokens[0].type, "comment");
+});
+
+Deno.test("lexer: mixed content", () => {
+  const tokens = tokenize("<h1>{{ title }}</h1>");
+  assertEquals(tokens.length, 3);
+  assertEquals(tokens[0].type, "text");
+  assertEquals(tokens[1].type, "variable");
+  assertEquals(tokens[2].type, "text");
+});
+
+// =============================================================================
+// Parser — basic structure
+// =============================================================================
+
+Deno.test("parser: text node", () => {
+  const nodes = parse("hello");
+  assertEquals(nodes.length, 1);
+  assertEquals(nodes[0].type, "text");
+});
+
+Deno.test("parser: variable node", () => {
+  const nodes = parse("{{ title }}");
+  assertEquals(nodes.length, 1);
+  assertEquals(nodes[0].type, "variable");
+  assertEquals((nodes[0] as { path: string }).path, "title");
+});
+
+Deno.test("parser: for node", () => {
+  const nodes = parse("{% for item in items %}{{ item }}{% endfor %}");
+  assertEquals(nodes.length, 1);
+  assertEquals(nodes[0].type, "for");
+});
+
+Deno.test("parser: if/elif/else node", () => {
+  const nodes = parse(
+    "{% if x %}a{% elif y %}b{% else %}c{% endif %}",
+  );
+  assertEquals(nodes.length, 1);
+  const ifNode = nodes[0] as { type: string; branches: unknown[] };
+  assertEquals(ifNode.type, "if");
+  assertEquals(ifNode.branches.length, 3);
+});
+
+Deno.test("parser: block node", () => {
+  const nodes = parse("{% block title %}Default{% endblock %}");
+  assertEquals(nodes.length, 1);
+  assertEquals(nodes[0].type, "block");
+});
+
+Deno.test("parser: comment is discarded", () => {
+  const nodes = parse("{# this is ignored #}");
+  assertEquals(nodes.length, 1);
+  assertEquals(nodes[0].type, "comment");
+});
+
+Deno.test("parser: extends node", () => {
+  const nodes = parse('{% extends "base.html" %}');
+  assertEquals(nodes.length, 1);
+  assertEquals(nodes[0].type, "extends");
+  assertEquals(
+    (nodes[0] as { templateName: string }).templateName,
+    "base.html",
+  );
+});
+
+Deno.test("parser: throws on invalid for", () => {
+  const fn = () => parse("{% for bad %} {% endfor %}");
+  let threw = false;
+  try {
+    fn();
+  } catch (e) {
+    threw = true;
+    assertEquals(e instanceof TemplateParseError, true);
+  }
+  assertEquals(threw, true);
+});
+
+// =============================================================================
+// Renderer — variables
+// =============================================================================
+
+Deno.test("renderer: simple variable", async () => {
+  const out = await renderStr("Hello {{ name }}!", { name: "World" });
+  assertEquals(out, "Hello World!");
+});
+
+Deno.test("renderer: dot-notation", async () => {
+  const out = await renderStr("{{ user.profile.name }}", {
+    user: { profile: { name: "Alice" } },
+  });
+  assertEquals(out, "Alice");
+});
+
+Deno.test("renderer: missing variable renders empty string", async () => {
+  const out = await renderStr("{{ missing }}", {});
+  assertEquals(out, "");
+});
+
+Deno.test("renderer: comment produces no output", async () => {
+  const out = await renderStr("{# hidden #}visible");
+  assertEquals(out, "visible");
+});
+
+// =============================================================================
+// Renderer — for loop
+// =============================================================================
+
+Deno.test("renderer: for loop", async () => {
+  const out = await renderStr(
+    "{% for item in items %}[{{ item }}]{% endfor %}",
+    { items: ["a", "b", "c"] },
+  );
+  assertEquals(out, "[a][b][c]");
+});
+
+Deno.test("renderer: for loop with object properties", async () => {
+  const out = await renderStr(
+    "{% for note in notes %}{{ note.title }}|{% endfor %}",
+    { notes: [{ title: "First" }, { title: "Second" }] },
+  );
+  assertEquals(out, "First|Second|");
+});
+
+Deno.test("renderer: for loop forloop variable", async () => {
+  const out = await renderStr(
+    "{% for item in items %}{{ forloop.counter }}{% endfor %}",
+    { items: ["x", "y"] },
+  );
+  assertEquals(out, "12");
+});
+
+Deno.test("renderer: for loop empty body", async () => {
+  const out = await renderStr(
+    "{% for item in items %}{{ item }}{% empty %}nothing{% endfor %}",
+    { items: [] },
+  );
+  assertEquals(out, "nothing");
+});
+
+Deno.test("renderer: for loop non-array shows empty body", async () => {
+  const out = await renderStr(
+    "{% for item in items %}{{ item }}{% empty %}nada{% endfor %}",
+    { items: null },
+  );
+  assertEquals(out, "nada");
+});
+
+// =============================================================================
+// Renderer — if/elif/else
+// =============================================================================
+
+Deno.test("renderer: if true branch", async () => {
+  const out = await renderStr(
+    "{% if show %}yes{% endif %}",
+    { show: true },
+  );
+  assertEquals(out, "yes");
+});
+
+Deno.test("renderer: if false branch skipped", async () => {
+  const out = await renderStr(
+    "{% if show %}yes{% endif %}",
+    { show: false },
+  );
+  assertEquals(out, "");
+});
+
+Deno.test("renderer: if/else", async () => {
+  const out = await renderStr(
+    "{% if x %}A{% else %}B{% endif %}",
+    { x: false },
+  );
+  assertEquals(out, "B");
+});
+
+Deno.test("renderer: if/elif/else", async () => {
+  const out = await renderStr(
+    "{% if x %}A{% elif y %}B{% else %}C{% endif %}",
+    { x: false, y: true },
+  );
+  assertEquals(out, "B");
+});
+
+Deno.test("renderer: if with equality check", async () => {
+  const out = await renderStr(
+    '{% if status == "open" %}Open{% else %}Closed{% endif %}',
+    { status: "open" },
+  );
+  assertEquals(out, "Open");
+});
+
+Deno.test("renderer: if with not", async () => {
+  const out = await renderStr(
+    "{% if not hidden %}visible{% endif %}",
+    { hidden: false },
+  );
+  assertEquals(out, "visible");
+});
+
+Deno.test("renderer: if with greater-than", async () => {
+  const out = await renderStr(
+    "{% if count > 0 %}has items{% endif %}",
+    { count: 5 },
+  );
+  assertEquals(out, "has items");
+});
+
+// =============================================================================
+// Renderer — include
+// =============================================================================
+
+Deno.test("renderer: include", async () => {
+  const out = await renderStr(
+    'Before{% include "partial.html" %}After',
+    {},
+    { "partial.html": "<b>partial</b>" },
+  );
+  assertEquals(out, "Before<b>partial</b>After");
+});
+
+Deno.test("renderer: include passes context", async () => {
+  const out = await renderStr(
+    '{% include "partial.html" %}',
+    { name: "Alexi" },
+    { "partial.html": "Hello {{ name }}" },
+  );
+  assertEquals(out, "Hello Alexi");
+});
+
+// =============================================================================
+// Renderer — template inheritance
+// =============================================================================
+
+Deno.test("renderer: extends with block override", async () => {
+  const base =
+    `<html><title>{% block title %}Base{% endblock %}</title></html>`;
+  const child = `{% extends "base.html" %}{% block title %}Child{% endblock %}`;
+
+  const out = await renderStr(child, {}, { "base.html": base });
+  assertEquals(out, "<html><title>Child</title></html>");
+});
+
+Deno.test("renderer: extends uses default block content", async () => {
+  const base = `<main>{% block content %}default{% endblock %}</main>`;
+  const child = `{% extends "base.html" %}`;
+
+  const out = await renderStr(child, {}, { "base.html": base });
+  assertEquals(out, "<main>default</main>");
+});
+
+Deno.test("renderer: extends with context variable in block", async () => {
+  const base = `{% block title %}{% endblock %}`;
+  const child =
+    `{% extends "base.html" %}{% block title %}{{ pageTitle }}{% endblock %}`;
+
+  const out = await renderStr(child, { pageTitle: "Notes" }, {
+    "base.html": base,
+  });
+  assertEquals(out, "Notes");
+});
+
+Deno.test("renderer: three-level inheritance", async () => {
+  const grandparent = `GP:{% block x %}gp{% endblock %}`;
+  const parent =
+    `{% extends "gp.html" %}{% block x %}parent-{% block y %}py{% endblock %}{% endblock %}`;
+  const child = `{% extends "parent.html" %}{% block y %}child{% endblock %}`;
+
+  const loader = new MemoryTemplateLoader();
+  loader.register("gp.html", grandparent);
+  loader.register("parent.html", parent);
+  loader.register("child.html", child);
+
+  const out = await render("child.html", {}, loader);
+  assertEquals(out, "GP:parent-child");
+});
+
+// =============================================================================
+// MemoryTemplateLoader
+// =============================================================================
+
+Deno.test("MemoryTemplateLoader: throws TemplateNotFoundError", async () => {
+  const loader = new MemoryTemplateLoader();
+  await assertRejects(
+    () => loader.load("missing.html"),
+    TemplateNotFoundError,
+  );
+});
+
+Deno.test("MemoryTemplateLoader: registerAll", async () => {
+  const loader = new MemoryTemplateLoader();
+  loader.registerAll({ "a.html": "A", "b.html": "B" });
+  assertEquals(await loader.load("a.html"), "A");
+  assertEquals(await loader.load("b.html"), "B");
+});
+
+Deno.test("MemoryTemplateLoader: has", () => {
+  const loader = new MemoryTemplateLoader();
+  loader.register("x.html", "content");
+  assertEquals(loader.has("x.html"), true);
+  assertEquals(loader.has("y.html"), false);
+});
+
+Deno.test("MemoryTemplateLoader: clear", async () => {
+  const loader = new MemoryTemplateLoader();
+  loader.register("x.html", "content");
+  loader.clear();
+  await assertRejects(
+    () => loader.load("x.html"),
+    TemplateNotFoundError,
+  );
+});
+
+// =============================================================================
+// Full integration — issue example templates
+// =============================================================================
+
+Deno.test("integration: issue #163 example templates", async () => {
+  const baseHtml = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>{% block title %}My App{% endblock %}</title>
+</head>
+<body>
+  <main id="content">
+    {% block content %}{% endblock %}
+  </main>
+</body>
+</html>`;
+
+  const noteListHtml = `{% extends "my-app/base.html" %}
+
+{% block title %}Notes{% endblock %}
+
+{% block content %}
+<h1>Notes</h1>
+<ul>
+  {% for note in notes %}
+  <li>{{ note.title }}</li>
+  {% endfor %}
+</ul>
+{% endblock %}`;
+
+  const loader = new MemoryTemplateLoader();
+  loader.register("my-app/base.html", baseHtml);
+  loader.register("my-app/note_list.html", noteListHtml);
+
+  const out = await render("my-app/note_list.html", {
+    notes: [{ title: "Alpha" }, { title: "Beta" }],
+  }, loader);
+
+  assertMatch(out, /<title>Notes<\/title>/);
+  assertMatch(out, /<h1>Notes<\/h1>/);
+  assertMatch(out, /Alpha/);
+  assertMatch(out, /Beta/);
+});

--- a/src/views/mod.ts
+++ b/src/views/mod.ts
@@ -4,9 +4,41 @@
  * Provides view helper functions for common response patterns like
  * template rendering, redirects, and JSON responses.
  *
+ * Includes a full Django-style template engine with support for:
+ * - `{{ variable }}` — dot-notation variable output
+ * - `{% extends "base.html" %}` — template inheritance
+ * - `{% block name %}...{% endblock %}` — block definitions
+ * - `{% for item in items %}...{% endfor %}` — iteration
+ * - `{% if condition %}...{% elif %}...{% else %}...{% endif %}` — conditionals
+ * - `{% include "partial.html" %}` — sub-template inclusion
+ *
  * @module @alexi/views
  *
- * @example Template view
+ * @example New API — Django-style template engine
+ * ```ts
+ * import { templateView, templateRegistry } from "@alexi/views";
+ *
+ * // Register templates (done by Application on startup)
+ * templateRegistry.register("my-app/note_list.html", `
+ *   {% extends "my-app/base.html" %}
+ *   {% block content %}
+ *   <ul>
+ *     {% for note in notes %}
+ *     <li>{{ note.title }}</li>
+ *     {% endfor %}
+ *   </ul>
+ *   {% endblock %}
+ * `);
+ *
+ * export const noteListView = templateView({
+ *   templateName: "my-app/note_list.html",
+ *   context: async (request, params) => ({
+ *     notes: await getNotes(),
+ *   }),
+ * });
+ * ```
+ *
+ * @example Legacy API — static file with placeholder substitution
  * ```ts
  * import { templateView } from "@alexi/views";
  * import { path } from "@alexi/urls";
@@ -23,6 +55,31 @@
  */
 
 // ============================================================================
+// Template Engine
+// ============================================================================
+
+export {
+  // Loaders / Registry
+  ChainTemplateLoader,
+  FilesystemTemplateLoader,
+  MemoryTemplateLoader,
+  // Renderer
+  render,
+  // Errors
+  TemplateNotFoundError,
+  TemplateParseError,
+  templateRegistry,
+} from "./engine/mod.ts";
+
+export type {
+  ASTNode,
+  TemplateContext,
+  TemplateLoader,
+  Token,
+  TokenType,
+} from "./engine/mod.ts";
+
+// ============================================================================
 // Template Views
 // ============================================================================
 
@@ -32,4 +89,9 @@ export {
   templateView,
 } from "./template.ts";
 
-export type { TemplateViewOptions } from "./template.ts";
+export type {
+  ContextFunction,
+  LegacyTemplateViewOptions,
+  NewTemplateViewOptions,
+  TemplateViewOptions,
+} from "./template.ts";


### PR DESCRIPTION
## Summary

- Implements a full Django-style template engine in `src/views/engine/` with zero Deno-specific APIs — runs identically in Deno and Service Workers
- Supports `{{ var }}` (dot-notation), `{% extends %}` / `{% block %}` (multi-level inheritance), `{% for %}` / `{% empty %}`, `{% if %}` / `{% elif %}` / `{% else %}`, `{% include %}`, and `{# comments #}`
- Adds `MemoryTemplateLoader`, `FilesystemTemplateLoader`, `ChainTemplateLoader`, and a global `templateRegistry` singleton
- Updates `templateView` with a new `templateName` + async `context` function API while keeping the legacy `templatePath` + static context API for backwards compatibility
- Adds `templatesDir` to `AppConfig` in `@alexi/types` for automatic template registration at startup
- 40 new tests covering lexer, parser, renderer, loaders, and a full integration test using the example templates from the issue

Closes #163