### PR TITLE
fix(staticfiles): bundle only active settings apps; fix resolveDir on Windows

### DIFF
--- a/src/web/commands/runserver.ts
+++ b/src/web/commands/runserver.ts
@@ -212,9 +212,9 @@ export class RunServerCommand extends BaseCommand {
           } else {
             await (this.bundler as {
               bundleAndWatch: (
-                opts: { debug: boolean },
+                opts: { debug: boolean; settingsPath?: string },
               ) => Promise<{ success: boolean }>;
-            }).bundleAndWatch({ debug });
+            }).bundleAndWatch({ debug, settingsPath });
           }
 
           createHmrResponse = () =>


### PR DESCRIPTION
## Summary

- `BundleCommand.loadSettings()` now accepts an optional `settingsPath` parameter — when provided (e.g. passed from `runserver`), only `INSTALLED_APPS` from that single file are loaded. This prevents apps from unrelated settings files from bleeding into the wrong bundle context.
- Added `--settings` flag to `BundleCommand` so it can also be scoped from the CLI (`deno task manage bundle --settings farmhub-sw`).
- `RunServerCommand.handle()` now passes the resolved `settingsPath` down to `bundleAndWatch()` so the correct apps are always bundled for the active server context.
- The virtual entry esbuild plugin now uses the already-normalised `cwdNorm` variable for `resolveDir` instead of calling `Deno.cwd()` a second time, fixing import resolution failures on Windows where backslash paths break esbuild.

Closes #169
Closes #170