### PR TITLE
fix(create): embed version constant instead of reading deno.jsonc at runtime

### DIFF
--- a/scripts/sync-versions.ts
+++ b/scripts/sync-versions.ts
@@ -150,6 +150,22 @@ async function main() {
   console.log(`   Total: ${subpackages.length}`);
 
   if (updatedCount > 0) {
+    // Update the embedded VERSION constant in src/create/version.ts
+    const versionTsPath = join("src", "create", "version.ts");
+    try {
+      const versionTs = await Deno.readTextFile(versionTsPath);
+      const updatedVersionTs = versionTs.replace(
+        /export const VERSION = "[^"]+";/,
+        `export const VERSION = "${targetVersion}";`,
+      );
+      if (updatedVersionTs !== versionTs) {
+        await Deno.writeTextFile(versionTsPath, updatedVersionTs);
+        console.log(`\n✓ Updated ${versionTsPath} to ${targetVersion}`);
+      }
+    } catch {
+      console.log(`\n⚠️  Could not update ${versionTsPath}`);
+    }
+
     console.log(`\n🔄 Regenerating deno.lock...`);
 
     // Remove old lock file

--- a/src/create/main.ts
+++ b/src/create/main.ts
@@ -17,16 +17,7 @@
 import { parseArgs } from "./args.ts";
 import { createProject, installSkills } from "./project.ts";
 import { printHelp, printVersion } from "./help.ts";
-
-/**
- * Read the package version from deno.jsonc at runtime.
- */
-async function getVersion(): Promise<string> {
-  const configUrl = new URL("./deno.jsonc", import.meta.url);
-  const content = await Deno.readTextFile(configUrl);
-  const config = JSON.parse(content);
-  return config.version ?? "0.0.0";
-}
+import { VERSION } from "./version.ts";
 
 async function main(): Promise<number> {
   const args = parseArgs(Deno.args);
@@ -37,8 +28,7 @@ async function main(): Promise<number> {
   }
 
   if (args.version) {
-    const version = await getVersion();
-    printVersion(version);
+    printVersion(VERSION);
     return 0;
   }
 

--- a/src/create/project.ts
+++ b/src/create/project.ts
@@ -56,6 +56,8 @@ import { generateAlexiViewsSkillMd } from "./templates/skills/alexi_views_skill_
 import { generateAlexiWebSkillMd } from "./templates/skills/alexi_web_skill_md.ts";
 import { generateAlexiWebuiSkillMd } from "./templates/skills/alexi_webui_skill_md.ts";
 
+import { VERSION } from "./version.ts";
+
 export interface ProjectOptions {
   name: string;
 }
@@ -63,16 +65,6 @@ export interface ProjectOptions {
 export interface InstallSkillsOptions {
   /** Target directory (defaults to current working directory) */
   targetDir?: string;
-}
-
-/**
- * Read the package version from deno.jsonc.
- */
-async function getPackageVersion(): Promise<string> {
-  const configUrl = new URL("./deno.jsonc", import.meta.url);
-  const content = await Deno.readTextFile(configUrl);
-  const config = JSON.parse(content);
-  return config.version ?? "0.0.0";
 }
 
 /**
@@ -104,7 +96,7 @@ export async function createProject(options: ProjectOptions): Promise<void> {
   console.log("");
 
   // Read the framework version for import map generation
-  const version = await getPackageVersion();
+  const version = VERSION;
 
   // Create directory structure
   await createDirectories(name);

--- a/src/create/version.ts
+++ b/src/create/version.ts
@@ -1,0 +1,12 @@
+/**
+ * Package version for @alexi/create
+ *
+ * This constant is automatically updated by `deno task version:sync`.
+ * Do NOT read the version from deno.jsonc at runtime — that fails when
+ * the package runs from JSR because `import.meta.url` is an https:// URL
+ * and `Deno.readTextFile()` requires a file:// URL.
+ *
+ * @module @alexi/create/version
+ */
+
+export const VERSION = "0.29.1";


### PR DESCRIPTION
## Summary

- Replace runtime `Deno.readTextFile()` of `deno.jsonc` with an embedded `VERSION` constant in `src/create/version.ts`
- Update `scripts/sync-versions.ts` to automatically sync the embedded version when running `deno task version:sync`
- Fixes the `"Must be a file URL"` crash when running `deno run -A jsr:@alexi/create` (where `import.meta.url` is `https://`)

Closes #184