### PR TITLE
feat(staticfiles): replace AppConfig staticfiles/staticDir/templatesDir with ASSETFILES_DIRS and STATICFILES_DIRS settings

### DIFF
--- a/src/create/project.ts
+++ b/src/create/project.ts
@@ -33,7 +33,6 @@ import { generateStaticIndexHtml } from "./templates/unified/static_index_html.t
 import { generateAssetModTs } from "./templates/unified/assets/mod_ts.ts";
 
 // Template imports - Unified app (workers - Service Worker)
-import { generateWorkerAppTs } from "./templates/unified/workers/app_ts.ts";
 import { generateWorkerModTs } from "./templates/unified/workers/mod_ts.ts";
 import { generateWorkerModelsTs } from "./templates/unified/workers/models_ts.ts";
 import { generateWorkerEndpointsTs } from "./templates/unified/workers/endpoints_ts.ts";
@@ -289,7 +288,7 @@ async function generateFiles(name: string, version: string): Promise<void> {
     // Unified app — assets (frontend entry point)
     // ==========================================================================
     {
-      path: `${name}/src/${name}/assets/${name}/mod.ts`,
+      path: `${name}/src/${name}/assets/${name}/${name}.ts`,
       content: generateAssetModTs(name),
     },
 
@@ -297,11 +296,7 @@ async function generateFiles(name: string, version: string): Promise<void> {
     // Unified app — workers (Service Worker)
     // ==========================================================================
     {
-      path: `${name}/src/${name}/workers/${name}/app.ts`,
-      content: generateWorkerAppTs(name),
-    },
-    {
-      path: `${name}/src/${name}/workers/${name}/mod.ts`,
+      path: `${name}/src/${name}/workers/${name}/worker.ts`,
       content: generateWorkerModTs(name),
     },
     {

--- a/src/create/templates/project/settings_ts.ts
+++ b/src/create/templates/project/settings_ts.ts
@@ -74,7 +74,6 @@ export const INSTALLED_APPS = [
   () => import("@alexi/db"),
   () => import("@alexi/restframework"),
   () => import("@${name}/mod.ts"),
-  () => import("@${name}/workers/app.ts"),
 ];
 
 // =============================================================================
@@ -92,6 +91,34 @@ export const ROOT_URLCONF = () => import("@${name}/urls.ts");
 
 export const STATIC_URL = "/static/";
 export const STATIC_ROOT = "./static";
+
+/**
+ * Explicit extra static file directories to serve / collect.
+ * Each entry is a path relative to the project root (or an absolute path).
+ * Convention-based <appPath>/static/ directories are discovered automatically.
+ */
+export const STATICFILES_DIRS: string[] = [];
+
+/**
+ * Frontend asset bundles to build.
+ * Each entry specifies a source directory, output directory, and entry points.
+ * The output filename matches the entrypoint filename (e.g. "worker.ts" → "worker.js").
+ */
+export const ASSETFILES_DIRS = [
+  {
+    // Service Worker bundle: workers/${name}/worker.ts → static/${name}/worker.js
+    path: "./src/${name}/workers/${name}",
+    outputDir: "./src/${name}/static/${name}",
+    entrypoints: ["worker.ts"],
+    templatesDir: "./src/${name}/workers/${name}/templates",
+  },
+  {
+    // Frontend bundle: assets/${name}/${name}.ts → static/${name}/${name}.js
+    path: "./src/${name}/assets/${name}",
+    outputDir: "./src/${name}/static/${name}",
+    entrypoints: ["${name}.ts"],
+  },
+];
 
 // =============================================================================
 // CORS

--- a/src/create/templates/unified/app_ts.ts
+++ b/src/create/templates/unified/app_ts.ts
@@ -21,7 +21,6 @@ import type { AppConfig } from "@alexi/types";
 const config: AppConfig = {
   name: "${name}",
   verboseName: "${appName}",
-  staticDir: "static",
 };
 
 export default config;

--- a/src/create/templates/unified/assets/mod_ts.ts
+++ b/src/create/templates/unified/assets/mod_ts.ts
@@ -1,11 +1,11 @@
 /**
- * Assets mod.ts template generator (frontend entry point)
+ * Assets entry point template generator (frontend entry point)
  *
  * @module @alexi/create/templates/unified/assets/mod_ts
  */
 
 /**
- * Generate assets/<name>/mod.ts content
+ * Generate assets/<name>/<name>.ts content
  */
 export function generateAssetModTs(name: string): string {
   return `/**
@@ -14,7 +14,7 @@ export function generateAssetModTs(name: string): string {
  * This file is bundled by @alexi/staticfiles into static/${name}/${name}.js.
  * Import your Web Components and client-side code here.
  *
- * @module ${name}/assets/${name}/mod
+ * @module ${name}/assets/${name}/${name}
  */
 
 // Import and register components

--- a/src/create/templates/unified/workers/mod_ts.ts
+++ b/src/create/templates/unified/workers/mod_ts.ts
@@ -1,11 +1,11 @@
 /**
- * Worker mod.ts template generator (Service Worker entry point)
+ * Worker worker.ts template generator (Service Worker entry point)
  *
  * @module @alexi/create/templates/unified/workers/mod_ts
  */
 
 /**
- * Generate workers/<name>/mod.ts content
+ * Generate workers/<name>/worker.ts content
  */
 export function generateWorkerModTs(name: string): string {
   return `/**
@@ -17,7 +17,7 @@ export function generateWorkerModTs(name: string): string {
  * Analogous to Django's wsgi.py / asgi.py — a thin shell that calls
  * getApplication(settings) and wires it to the SW lifecycle events.
  *
- * @module ${name}/workers/${name}/mod
+ * @module ${name}/workers/${name}/worker
  */
 
 import { getApplication } from "@alexi/core";

--- a/src/create/tests/scaffold_test.ts
+++ b/src/create/tests/scaffold_test.ts
@@ -167,6 +167,8 @@ Deno.test({
         "STATIC_URL",
         "CORS_ORIGINS",
         "createMiddleware",
+        "ASSETFILES_DIRS",
+        "STATICFILES_DIRS",
       ];
 
       for (const exp of requiredExports) {
@@ -360,9 +362,13 @@ Deno.test({
 
     await t.step("creates assets entry point", async () => {
       const filePath =
-        `${project.path}/src/${project.name}/assets/${project.name}/mod.ts`;
+        `${project.path}/src/${project.name}/assets/${project.name}/${project.name}.ts`;
       const stat = await Deno.stat(filePath);
-      assertEquals(stat.isFile, true, "assets/mod.ts should be a file");
+      assertEquals(
+        stat.isFile,
+        true,
+        `assets/${project.name}.ts should be a file`,
+      );
     });
 
     // ==========================================================================
@@ -371,8 +377,7 @@ Deno.test({
 
     await t.step("creates worker files", async () => {
       const workerFiles = [
-        `src/${project.name}/workers/${project.name}/app.ts`,
-        `src/${project.name}/workers/${project.name}/mod.ts`,
+        `src/${project.name}/workers/${project.name}/worker.ts`,
         `src/${project.name}/workers/${project.name}/models.ts`,
         `src/${project.name}/workers/${project.name}/endpoints.ts`,
         `src/${project.name}/workers/${project.name}/settings.ts`,
@@ -394,47 +399,47 @@ Deno.test({
     });
 
     await t.step(
-      "worker app.ts defines staticfiles with two entry points",
+      "settings.ts defines ASSETFILES_DIRS with worker and asset entry points",
       async () => {
         const content = await Deno.readTextFile(
-          `${project.path}/src/${project.name}/workers/${project.name}/app.ts`,
+          `${project.path}/project/settings.ts`,
         );
         assertEquals(
-          content.includes("staticfiles"),
+          content.includes("ASSETFILES_DIRS"),
           true,
-          "worker app.ts should define staticfiles",
+          "settings.ts should define ASSETFILES_DIRS",
         );
         assertEquals(
-          content.includes("worker.js"),
+          content.includes("worker.ts"),
           true,
-          "worker app.ts should output worker.js",
+          "settings.ts ASSETFILES_DIRS should include worker.ts entry point",
         );
         assertEquals(
-          content.includes(`${project.name}.js`),
+          content.includes(`${project.name}.ts`),
           true,
-          `worker app.ts should output ${project.name}.js`,
+          `settings.ts ASSETFILES_DIRS should include ${project.name}.ts entry point`,
         );
       },
     );
 
-    await t.step("worker mod.ts sets up Service Worker", async () => {
+    await t.step("worker.ts sets up Service Worker", async () => {
       const content = await Deno.readTextFile(
-        `${project.path}/src/${project.name}/workers/${project.name}/mod.ts`,
+        `${project.path}/src/${project.name}/workers/${project.name}/worker.ts`,
       );
       assertEquals(
         content.includes("ServiceWorkerGlobalScope"),
         true,
-        "worker mod.ts should declare ServiceWorkerGlobalScope",
+        "worker.ts should declare ServiceWorkerGlobalScope",
       );
       assertEquals(
         content.includes("install"),
         true,
-        "worker mod.ts should handle install event",
+        "worker.ts should handle install event",
       );
       assertEquals(
         content.includes("fetch"),
         true,
-        "worker mod.ts should handle fetch event",
+        "worker.ts should handle fetch event",
       );
     });
 

--- a/src/staticfiles/commands/bundle.ts
+++ b/src/staticfiles/commands/bundle.ts
@@ -2,7 +2,9 @@
  * Bundle Command for Alexi Static Files
  *
  * Django-style command that bundles TypeScript frontends to JavaScript.
- * Reads INSTALLED_APPS and finds apps with bundle configuration.
+ * Reads INSTALLED_APPS and finds apps with bundle configuration, and also
+ * reads ASSETFILES_DIRS from project settings for the new settings-level
+ * bundle configuration.
  *
  * Uses esbuild with code-splitting for lazy-loading templates.
  *
@@ -22,7 +24,12 @@ import type {
   CommandResult,
   IArgumentParser,
 } from "@alexi/core/management";
-import type { AppConfig, BundleConfig, StaticfileConfig } from "@alexi/types";
+import type {
+  AppConfig,
+  AssetfilesDirConfig,
+  BundleConfig,
+  StaticfileConfig,
+} from "@alexi/types";
 import * as esbuild from "esbuild";
 import { denoPlugins } from "esbuild-deno-loader";
 import { join, toFileUrl } from "@std/path";
@@ -81,6 +88,26 @@ interface BundleResult {
   error?: string;
   outputPath?: string;
   duration?: number;
+}
+
+/**
+ * A normalised build target derived from either ASSETFILES_DIRS (new) or
+ * AppConfig.bundle / AppConfig.staticfiles (legacy).
+ */
+interface BuildTarget {
+  /** Display name shown in progress output */
+  name: string;
+  /** Entry point path relative to project root (e.g. "./src/app/worker.ts") */
+  entryPoint: string;
+  /** Absolute output file path */
+  outputPath: string;
+  /** Whether to minify (can be overridden per-entry) */
+  minify?: boolean;
+  /**
+   * Templates directory to embed — scanned when this target is a SW bundle.
+   * Absolute path or relative to project root.
+   */
+  templatesDir?: string;
 }
 
 /**
@@ -636,22 +663,34 @@ export class BundleCommand extends BaseCommand {
   private async loadSettings(settingsPath?: string): Promise<
     {
       importFunctions: AppImportFn[];
+      assetfilesDirs: AssetfilesDirConfig[];
     } | null
   > {
     try {
       const importFunctions: AppImportFn[] = [];
+      const assetfilesDirs: AssetfilesDirConfig[] = [];
+
+      const processSettingsModule = (settings: Record<string, unknown>) => {
+        const installedApps = settings.INSTALLED_APPS ?? [];
+        for (const app of installedApps as unknown[]) {
+          if (typeof app === "function") {
+            importFunctions.push(app as AppImportFn);
+          }
+        }
+        const dirs = settings.ASSETFILES_DIRS;
+        if (Array.isArray(dirs)) {
+          for (const d of dirs) {
+            assetfilesDirs.push(d as AssetfilesDirConfig);
+          }
+        }
+      };
 
       if (settingsPath) {
         // Load only the active settings file
         try {
           const settingsUrl = toImportUrl(settingsPath);
           const settings = await import(settingsUrl);
-          const installedApps = settings.INSTALLED_APPS ?? [];
-          for (const app of installedApps) {
-            if (typeof app === "function") {
-              importFunctions.push(app as AppImportFn);
-            }
-          }
+          processSettingsModule(settings as Record<string, unknown>);
         } catch {
           // Invalid settings file
         }
@@ -664,12 +703,7 @@ export class BundleCommand extends BaseCommand {
               const filePath = `${projectDir}/${entry.name}`;
               const settingsUrl = toImportUrl(filePath);
               const settings = await import(settingsUrl);
-              const installedApps = settings.INSTALLED_APPS ?? [];
-              for (const app of installedApps) {
-                if (typeof app === "function") {
-                  importFunctions.push(app as AppImportFn);
-                }
-              }
+              processSettingsModule(settings as Record<string, unknown>);
             } catch {
               // Skip invalid settings files
             }
@@ -677,11 +711,11 @@ export class BundleCommand extends BaseCommand {
         }
       }
 
-      if (importFunctions.length === 0) {
+      if (importFunctions.length === 0 && assetfilesDirs.length === 0) {
         return null;
       }
 
-      return { importFunctions };
+      return { importFunctions, assetfilesDirs };
     } catch (error) {
       if (this.watcher === null) {
         // Only log error if not in watch mode (to avoid spam)
@@ -696,31 +730,58 @@ export class BundleCommand extends BaseCommand {
   // ===========================================================================
 
   /**
-   * Find apps that have bundle configuration.
-   * Calls each import function to get the app module.
+   * Build the list of targets to bundle, combining:
+   * 1. New-style: ASSETFILES_DIRS entries from project settings
+   * 2. Legacy: AppConfig.staticfiles / AppConfig.bundle from INSTALLED_APPS
    */
   private async findAppsToBuild(
-    settings: { importFunctions: AppImportFn[] },
+    settings: {
+      importFunctions: AppImportFn[];
+      assetfilesDirs: AssetfilesDirConfig[];
+    },
     targetApp?: string,
-  ): Promise<Array<{ name: string; path: string; config: AppConfig }>> {
-    const apps: Array<{ name: string; path: string; config: AppConfig }> = [];
+  ): Promise<BuildTarget[]> {
+    const targets: BuildTarget[] = [];
 
+    // --- New-style: ASSETFILES_DIRS ---
+    for (const entry of settings.assetfilesDirs) {
+      const entryPath = entry.path.replace(/^\.\//, "");
+      for (const ep of entry.entrypoints) {
+        const epName = ep.replace(/^\.\//, "").replace(/\.ts$/, "");
+        const outputFile = `${ep.replace(/^\.\//, "").replace(/\.ts$/, "")}.js`;
+        const outputDir = entry.outputDir.replace(/^\.\//, "");
+        const outputPath = `${this.projectRoot}/${outputDir}/${outputFile}`;
+        const entryPoint = `./${entryPath}/${ep.replace(/^\.\//, "")}`;
+
+        // --app filter by path/name heuristic
+        if (targetApp) {
+          if (!entry.path.includes(targetApp) && !ep.includes(targetApp)) {
+            continue;
+          }
+        }
+
+        targets.push({
+          name: `${entry.path}/${epName}`,
+          entryPoint,
+          outputPath,
+          minify: entry.options?.minify,
+          templatesDir: entry.templatesDir,
+        });
+      }
+    }
+
+    // --- Legacy: INSTALLED_APPS with AppConfig.bundle / AppConfig.staticfiles ---
     for (const importFn of settings.importFunctions) {
       try {
-        // Call the user's import function
         const module = await importFn();
         const config = module.default as AppConfig | undefined;
 
-        if (!config) {
-          continue;
-        }
+        if (!config) continue;
 
         // Skip if targeting a specific app
-        if (targetApp && config.name !== targetApp) {
-          continue;
-        }
+        if (targetApp && config.name !== targetApp) continue;
 
-        // Check if app has bundle configuration (either bundle or staticfiles)
+        // Check if app has legacy bundle configuration
         if (
           !config.bundle &&
           (!config.staticfiles || config.staticfiles.length === 0)
@@ -729,17 +790,47 @@ export class BundleCommand extends BaseCommand {
           continue;
         }
 
-        // Get the app path from config (explicit appPath, legacy bundle.appPath, or convention)
-        const appPath = config.appPath ?? config.bundle?.appPath ??
-          `./src/${config.name}`;
+        const appPath = (config.appPath ?? config.bundle?.appPath ??
+          `./src/${config.name}`).replace(/^\.\//, "");
 
-        apps.push({ name: config.name, path: appPath, config });
+        if (config.bundle) {
+          const entrypoint = config.bundle.entrypoint.replace(/^\.\//, "");
+          const outputDirRel = config.bundle.outputDir.replace(/^\.\//, "");
+          const entryPoint = `./${appPath}/${entrypoint}`;
+          const outputPath =
+            `./${appPath}/${outputDirRel}/${config.bundle.outputName}`;
+
+          targets.push({
+            name: config.name,
+            entryPoint,
+            outputPath,
+            minify: config.bundle.options?.minify,
+            // Legacy bundle: collect templates from all apps via importFunctions
+          });
+        }
+
+        if (config.staticfiles && config.staticfiles.length > 0) {
+          for (const sf of config.staticfiles) {
+            const entrypoint = sf.entrypoint.replace(/^\.\//, "");
+            const outputFile = sf.outputFile.replace(/^\.\//, "");
+            const entryPoint = `./${appPath}/${entrypoint}`;
+            const outputPath = `./${appPath}/${outputFile}`;
+
+            targets.push({
+              name: `${config.name}/${outputFile.split("/").pop()}`,
+              entryPoint,
+              outputPath,
+              minify: sf.options?.minify,
+              // Legacy staticfiles: collect templates from all apps via importFunctions
+            });
+          }
+        }
       } catch (error) {
         this.debug(`Failed to load app: ${error}`, true);
       }
     }
 
-    return apps;
+    return targets;
   }
 
   // ===========================================================================
@@ -747,10 +838,10 @@ export class BundleCommand extends BaseCommand {
   // ===========================================================================
 
   /**
-   * Bundle all apps
+   * Bundle all targets
    */
   private async bundleApps(
-    apps: Array<{ name: string; path: string; config: AppConfig }>,
+    targets: BuildTarget[],
     options: {
       minify: boolean;
       includeCss: boolean;
@@ -760,110 +851,19 @@ export class BundleCommand extends BaseCommand {
   ): Promise<BundleResult[]> {
     const results: BundleResult[] = [];
 
-    for (const app of apps) {
-      if (app.config.bundle) {
-        const result = await this.bundleApp(app, options);
-        results.push(result);
-      } else if (app.config.staticfiles && app.config.staticfiles.length > 0) {
-        for (const staticfile of app.config.staticfiles) {
-          const result = await this.bundleStaticfile(app, staticfile, options);
-          results.push(result);
-        }
-      }
+    for (const target of targets) {
+      const result = await this.bundleTarget(target, options);
+      results.push(result);
     }
 
     return results;
   }
 
   /**
-   * Normalize path separators (Windows backslash → forward slash)
+   * Bundle a single BuildTarget
    */
-  private normalizePath(path: string): string {
-    return path.replace(/\\/g, "/");
-  }
-
-  /**
-   * Bundle a single app
-   */
-  private async bundleApp(
-    app: { name: string; path: string; config: AppConfig },
-    options: {
-      minify: boolean;
-      includeCss: boolean;
-      debug: boolean;
-      importFunctions?: AppImportFn[];
-    },
-  ): Promise<BundleResult> {
-    const startTime = performance.now();
-    const bundleConfig = app.config.bundle!;
-
-    try {
-      // Resolve paths (normalize ./ prefixes)
-      // Use relative paths for esbuild compatibility on Windows
-      const appPath = app.path.replace(/^\.\//, "");
-      const entrypoint = bundleConfig.entrypoint.replace(/^\.\//, "");
-      const outputDirRel = bundleConfig.outputDir.replace(/^\.\//, "");
-
-      // Relative paths for esbuild (works better cross-platform)
-      const appDir = `./${appPath}`;
-      const entryPoint = `${appDir}/${entrypoint}`;
-      const outputDir = `${appDir}/${outputDirRel}`;
-      const outputPath = `${outputDir}/${bundleConfig.outputName}`;
-
-      // Ensure output directory exists
-      await Deno.mkdir(outputDir, { recursive: true });
-
-      // Collect templates for embedding when bundling a Service Worker.
-      // We embed templates when the output is a JS bundle (not CSS-only) and
-      // there are import functions available from settings.
-      let templates: DiscoveredTemplate[] = [];
-      if (options.importFunctions && options.importFunctions.length > 0) {
-        templates = await collectAllTemplates(
-          options.importFunctions,
-          this.projectRoot,
-        );
-        if (templates.length > 0) {
-          this.info(
-            `  Embedding ${templates.length} templates into ${bundleConfig.outputName}...`,
-          );
-        }
-      }
-
-      // Bundle JavaScript/TypeScript
-      this.info(`Bundling ${app.name}...`);
-      await this.bundleJS(entryPoint, outputPath, options.minify, templates);
-
-      // Bundle CSS if configured
-      if (options.includeCss && bundleConfig.cssOutputName) {
-        const cssOutputPath = `${outputDir}/${bundleConfig.cssOutputName}`;
-        await this.bundleCSS(appDir, cssOutputPath);
-      }
-
-      const duration = performance.now() - startTime;
-
-      return {
-        appName: app.name,
-        success: true,
-        outputPath,
-        duration,
-      };
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      return {
-        appName: app.name,
-        success: false,
-        error: message,
-        duration: performance.now() - startTime,
-      };
-    }
-  }
-
-  /**
-   * Bundle a single staticfile entry (from config.staticfiles[])
-   */
-  private async bundleStaticfile(
-    app: { name: string; path: string; config: AppConfig },
-    staticfile: StaticfileConfig,
+  private async bundleTarget(
+    target: BuildTarget,
     options: {
       minify: boolean;
       debug: boolean;
@@ -873,40 +873,47 @@ export class BundleCommand extends BaseCommand {
     const startTime = performance.now();
 
     try {
-      const appPath = app.path.replace(/^\.\//, "");
-      const entrypoint = staticfile.entrypoint.replace(/^\.\//, "");
-      const outputFile = staticfile.outputFile.replace(/^\.\//, "");
-
-      const appDir = `./${appPath}`;
-      const entryPoint = `${appDir}/${entrypoint}`;
-      const outputPath = `${appDir}/${outputFile}`;
+      const outputPath = target.outputPath.replace(/\\/g, "/");
       const outputDir = outputPath.substring(0, outputPath.lastIndexOf("/"));
 
       // Ensure output directory exists
       await Deno.mkdir(outputDir, { recursive: true });
 
-      // Collect templates for embedding when there are import functions
+      // Determine templates to embed:
+      // 1. If target specifies its own templatesDir, use that (new ASSETFILES_DIRS style)
+      // 2. Otherwise fall back to collecting from all apps via importFunctions (legacy)
       let templates: DiscoveredTemplate[] = [];
-      if (options.importFunctions && options.importFunctions.length > 0) {
+      if (target.templatesDir) {
+        const dir = resolveTemplatesDir(target.templatesDir, this.projectRoot);
+        if (dir) {
+          templates = await scanTemplatesDir(dir);
+          if (templates.length > 0) {
+            this.info(
+              `  Embedding ${templates.length} templates from ${target.templatesDir}...`,
+            );
+          }
+        }
+      } else if (
+        options.importFunctions && options.importFunctions.length > 0
+      ) {
         templates = await collectAllTemplates(
           options.importFunctions,
           this.projectRoot,
         );
         if (templates.length > 0) {
+          const outputName = outputPath.split("/").pop() ?? outputPath;
           this.info(
-            `  Embedding ${templates.length} templates into ${outputFile}...`,
+            `  Embedding ${templates.length} templates into ${outputName}...`,
           );
         }
       }
 
-      const minify = staticfile.options?.minify ?? options.minify;
-      const outputName = outputPath.substring(outputPath.lastIndexOf("/") + 1);
-
-      this.info(`Bundling ${app.name} (${outputName})...`);
-      await this.bundleJS(entryPoint, outputPath, minify, templates);
+      const minify = target.minify ?? options.minify;
+      this.info(`Bundling ${target.name}...`);
+      await this.bundleJS(target.entryPoint, outputPath, minify, templates);
 
       return {
-        appName: `${app.name}/${outputName}`,
+        appName: target.name,
         success: true,
         outputPath,
         duration: performance.now() - startTime,
@@ -914,7 +921,7 @@ export class BundleCommand extends BaseCommand {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       return {
-        appName: app.name,
+        appName: target.name,
         success: false,
         error: message,
         duration: performance.now() - startTime,
@@ -998,7 +1005,7 @@ export class BundleCommand extends BaseCommand {
    * Start watching for file changes
    */
   private async startWatching(
-    apps: Array<{ name: string; path: string; config: AppConfig }>,
+    apps: BuildTarget[],
     options: {
       minify: boolean;
       includeCss: boolean;
@@ -1009,21 +1016,19 @@ export class BundleCommand extends BaseCommand {
     // Collect all source directories to watch
     const watchDirs: string[] = [];
 
-    for (const app of apps) {
-      const appDir = `${this.projectRoot}/${app.path}`;
-      const srcDir = `${appDir}/src`;
+    for (const target of apps) {
+      // Derive watch dir from entryPoint (e.g. "./src/my-app/worker.ts" → "<root>/src/my-app")
+      const entryRel = target.entryPoint.replace(/^\.\//, "");
+      const entryDir = entryRel.includes("/")
+        ? entryRel.substring(0, entryRel.lastIndexOf("/"))
+        : entryRel;
+      const appDir = `${this.projectRoot}/${entryDir}`;
 
       try {
-        await Deno.stat(srcDir);
-        watchDirs.push(srcDir);
+        await Deno.stat(appDir);
+        watchDirs.push(appDir);
       } catch {
-        // src directory doesn't exist, watch app directory directly
-        try {
-          await Deno.stat(appDir);
-          watchDirs.push(appDir);
-        } catch {
-          // App directory doesn't exist either
-        }
+        // Directory doesn't exist, skip
       }
     }
 
@@ -1206,7 +1211,7 @@ export class BundleCommand extends BaseCommand {
    * Start watching for file changes (non-blocking, runs in background)
    */
   private startWatchingBackground(
-    apps: Array<{ name: string; path: string; config: AppConfig }>,
+    apps: BuildTarget[],
     options: {
       minify: boolean;
       includeCss: boolean;
@@ -1217,26 +1222,21 @@ export class BundleCommand extends BaseCommand {
     // Collect all source directories to watch
     const watchDirs: string[] = [];
 
-    for (const app of apps) {
-      const appPath = app.path.replace(/^\.\//, "");
-      const appDir = `${this.projectRoot}/${appPath}`;
-      const srcDir = `${appDir}/src`;
+    for (const target of apps) {
+      // Derive watch dir from entryPoint (e.g. "./src/my-app/worker.ts" → "<root>/src/my-app")
+      const entryRel = target.entryPoint.replace(/^\.\//, "");
+      const entryDir = entryRel.includes("/")
+        ? entryRel.substring(0, entryRel.lastIndexOf("/"))
+        : entryRel;
+      const appDir = `${this.projectRoot}/${entryDir}`;
 
       try {
-        const stat = Deno.statSync(srcDir);
+        const stat = Deno.statSync(appDir);
         if (stat.isDirectory) {
-          watchDirs.push(srcDir);
+          watchDirs.push(appDir);
         }
       } catch {
-        // src directory doesn't exist, watch app directory directly
-        try {
-          const appStat = Deno.statSync(appDir);
-          if (appStat.isDirectory) {
-            watchDirs.push(appDir);
-          }
-        } catch {
-          // App directory doesn't exist either
-        }
+        // Directory doesn't exist, skip
       }
     }
 
@@ -1280,7 +1280,7 @@ export class BundleCommand extends BaseCommand {
    * Print startup banner
    */
   private printBanner(
-    apps: Array<{ name: string; path: string; config: AppConfig }>,
+    apps: BuildTarget[],
     options: { watch: boolean; minify: boolean; debug: boolean },
   ): void {
     const lines: string[] = [];
@@ -1295,8 +1295,8 @@ export class BundleCommand extends BaseCommand {
     lines.push(`  Debug mode:        ${options.debug ? "On" : "Off"}`);
     lines.push("");
     lines.push("Apps to bundle:");
-    for (const app of apps) {
-      lines.push(`  - ${app.name} (${app.path})`);
+    for (const target of apps) {
+      lines.push(`  - ${target.name} (${target.entryPoint})`);
     }
     lines.push("");
 

--- a/src/staticfiles/commands/collectstatic.ts
+++ b/src/staticfiles/commands/collectstatic.ts
@@ -183,7 +183,7 @@ export class CollectStaticCommand extends BaseCommand {
 
       const staticRoot = settings.staticRoot;
 
-      // Find apps with static directories
+      // Find apps with static directories (convention + explicit STATICFILES_DIRS)
       const appsWithStatic = await this.findAppsWithStatic(settings);
 
       if (appsWithStatic.length === 0) {
@@ -268,11 +268,12 @@ export class CollectStaticCommand extends BaseCommand {
 
   /**
    * Load project settings from specified settings module.
-   * Collects import functions from INSTALLED_APPS.
+   * Collects import functions from INSTALLED_APPS and explicit STATICFILES_DIRS.
    */
   private async loadSettings(settingsName: string): Promise<
     {
       importFunctions: AppImportFn[];
+      staticfilesDirs: string[];
       staticRoot: string;
     } | null
   > {
@@ -295,8 +296,20 @@ export class CollectStaticCommand extends BaseCommand {
         }
       }
 
+      // Collect explicit static dirs from STATICFILES_DIRS
+      const staticfilesDirs: string[] = [];
+      const rawDirs = settings.STATICFILES_DIRS;
+      if (Array.isArray(rawDirs)) {
+        for (const d of rawDirs) {
+          if (typeof d === "string") {
+            staticfilesDirs.push(d);
+          }
+        }
+      }
+
       return {
         importFunctions,
+        staticfilesDirs,
         staticRoot: settings.STATIC_ROOT ?? "./static",
       };
     } catch (error) {
@@ -313,11 +326,14 @@ export class CollectStaticCommand extends BaseCommand {
   // ===========================================================================
 
   /**
-   * Find apps that have static directories.
-   * Calls each import function to get the app module.
+   * Find all static directories to collect from, combining:
+   * 1. New-style: explicit `STATICFILES_DIRS` from project settings
+   * 2. Convention-based auto-discovery: `<appPath>/static/` for each installed app
+   *    (still respects legacy `config.staticDir` and `file://` paths)
    */
   private async findAppsWithStatic(settings: {
     importFunctions: AppImportFn[];
+    staticfilesDirs: string[];
     staticRoot: string;
   }): Promise<
     Array<{ name: string; path: string; staticDir: string; config?: AppConfig }>
@@ -326,9 +342,38 @@ export class CollectStaticCommand extends BaseCommand {
       { name: string; path: string; staticDir: string; config?: AppConfig }
     > = [];
 
+    // --- New-style: explicit STATICFILES_DIRS ---
+    for (const dir of settings.staticfilesDirs) {
+      const resolved = dir.startsWith("file://")
+        ? (() => {
+          try {
+            const url = new URL(dir);
+            let pathname = url.pathname.replace(/\/$/, "");
+            if (/^\/[a-zA-Z]:\//.test(pathname)) pathname = pathname.slice(1);
+            return pathname;
+          } catch {
+            return null;
+          }
+        })()
+        : dir.replace(/^\.\//, "").startsWith("/")
+        ? dir
+        : `${this.projectRoot}/${dir.replace(/^\.\//, "")}`;
+
+      if (!resolved) continue;
+
+      try {
+        const stat = await Deno.stat(resolved);
+        if (stat.isDirectory) {
+          apps.push({ name: dir, path: resolved, staticDir: resolved });
+        }
+      } catch {
+        // Directory doesn't exist, skip
+      }
+    }
+
+    // --- Convention-based: INSTALLED_APPS auto-discovery ---
     for (const importFn of settings.importFunctions) {
       try {
-        // Call the user's import function
         const module = await importFn();
         const config = module.default as AppConfig | undefined;
 
@@ -351,15 +396,19 @@ export class CollectStaticCommand extends BaseCommand {
           }
           staticDir = pathname;
           appPath = config.appPath ?? `./src/${config.name}`;
-        } else {
-          // Traditional: relative path resolved against project src/ directory
-          const staticDirRel = config.staticDir
-            ? config.staticDir.replace(/^\.\//, "")
-            : "static";
+        } else if (config.staticDir) {
+          // Legacy: explicit relative staticDir on AppConfig
+          const staticDirRel = config.staticDir.replace(/^\.\//, "");
           appPath = config.appPath ?? `./src/${config.name}`;
           const appPathNormalized = appPath.replace(/^\.\//, "");
           const appDir = `${this.projectRoot}/${appPathNormalized}`;
           staticDir = `${appDir}/${staticDirRel}`;
+        } else {
+          // Convention: <appPath>/static/
+          appPath = config.appPath ?? `./src/${config.name}`;
+          const appPathNormalized = appPath.replace(/^\.\//, "");
+          const appDir = `${this.projectRoot}/${appPathNormalized}`;
+          staticDir = `${appDir}/static`;
         }
 
         // Check if static directory exists

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -323,6 +323,8 @@ export interface TargetConfig {
  *
  * Used in `AppConfig.staticfiles` to declare multiple bundles per app
  * (e.g. a `worker.ts` Service Worker bundle and a `document.ts` DOM bundle).
+ *
+ * @deprecated Use `ASSETFILES_DIRS` in project settings instead.
  */
 export interface StaticfileConfig {
   /**
@@ -344,6 +346,86 @@ export interface StaticfileConfig {
 
   /**
    * Additional options for the bundler.
+   */
+  options?: {
+    /**
+     * Enable minification for production builds.
+     */
+    minify?: boolean;
+
+    /**
+     * Enable source maps.
+     */
+    sourceMaps?: boolean;
+
+    /**
+     * External modules that should not be bundled.
+     */
+    external?: string[];
+  };
+}
+
+/**
+ * Configuration for a single asset files directory entry.
+ *
+ * Replaces `AppConfig.staticfiles` — bundle configuration now lives in
+ * project settings, not in individual app configs.
+ *
+ * Each entry specifies a source directory, one or more TypeScript entry
+ * points to compile, and an output directory for the resulting JS files.
+ * An optional `templatesDir` may be provided to embed HTML templates into
+ * Service Worker bundles at build time.
+ *
+ * @example
+ * ```ts
+ * export const ASSETFILES_DIRS = [
+ *   {
+ *     path: "./src/my-project/workers/my-project",
+ *     outputDir: "./src/my-project/static/my-project",
+ *     entrypoints: ["worker.ts", "document.ts"],
+ *     templatesDir: "./src/my-project/workers/my-project/templates",
+ *   },
+ * ];
+ * ```
+ */
+export interface AssetfilesDirConfig {
+  /**
+   * Path to the source directory containing TypeScript entry points.
+   * Relative to the project root.
+   *
+   * @example "./src/my-project/workers/my-project"
+   */
+  path: string;
+
+  /**
+   * Output directory for compiled JS files.
+   * Relative to the project root.
+   *
+   * @example "./src/my-project/static/my-project"
+   */
+  outputDir: string;
+
+  /**
+   * Explicit list of entry point filenames (relative to `path`).
+   *
+   * @example ["worker.ts", "document.ts"]
+   */
+  entrypoints: string[];
+
+  /**
+   * Path to a templates directory to embed into Service Worker bundles.
+   * All `.html` files under this directory are embedded via the virtual
+   * `alexi:templates` module so that `templateView` works without filesystem
+   * access inside a Service Worker.
+   *
+   * Relative to the project root, or an absolute `file://` URL.
+   *
+   * @example "./src/my-project/workers/my-project/templates"
+   */
+  templatesDir?: string;
+
+  /**
+   * Additional bundler options applied to all entry points in this directory.
    */
   options?: {
     /**
@@ -580,6 +662,16 @@ export interface DesktopConfig {
  *
  * Django-style app configuration that tells the framework
  * what the app contains and how to handle it.
+ *
+ * Following Django conventions, `AppConfig` contains only app identity
+ * metadata (`name`, `verboseName`, `appPath`).  Build and file-serving
+ * configuration now lives in project settings:
+ * - `ASSETFILES_DIRS` — TypeScript source directories for the bundler
+ * - `STATICFILES_DIRS` — additional static file directories for collectstatic
+ *
+ * Per-app static files are auto-discovered by convention from
+ * `<appPath>/static/` (like Django's `AppDirectoriesFinder`), and templates
+ * from `<appPath>/templates/` at `runserver` time.
  */
 export interface AppConfig {
   /**
@@ -601,18 +693,23 @@ export interface AppConfig {
    *
    * If not specified, the convention `./src/${name}` is used.
    * Use this when the app's directory doesn't match the convention
-   * (e.g. a worker sub-app that lives inside another app's directory).
+   * (e.g. a published package whose static/template dirs are absolute paths).
+   *
+   * Can be a relative path (resolved against the project root) or an
+   * absolute `file://` URL (recommended for published packages).
    *
    * Path is relative to the project root.
    *
    * @example "./src/myapp"
-   * @example "./src/myapp/workers/myapp"
+   * @example "file:///path/to/package"
    */
   appPath?: string;
 
   /**
    * Frontend bundle configuration.
    * If defined, the `bundle` command will compile TypeScript → JavaScript.
+   *
+   * @deprecated Use `ASSETFILES_DIRS` in project settings instead.
    */
   bundle?: BundleConfig;
 
@@ -622,6 +719,8 @@ export interface AppConfig {
    * Use this instead of `bundle` when an app produces more than one JS output
    * (e.g. a browser app with a `worker.ts` Service Worker entry and a
    * `document.ts` DOM entry).  Each item is bundled independently.
+   *
+   * @deprecated Use `ASSETFILES_DIRS` in project settings instead.
    *
    * @example
    * staticfiles: [
@@ -635,15 +734,14 @@ export interface AppConfig {
    * Static files directory.
    * These files are copied to STATIC_ROOT by the collectstatic command.
    *
+   * @deprecated Static file discovery is now convention-based (`<appPath>/static/`).
+   * Extra directories can be registered via `STATICFILES_DIRS` in project settings.
+   *
    * Can be either:
    * - A path relative to the app's `src/<name>/` directory: `"static"`
    * - An absolute `file://` URL derived from `import.meta.url` (recommended
    *   for published packages so the path resolves correctly regardless of
    *   whether the package is installed from JSR, npm, or a local path):
-   *
-   * @example
-   * // Relative path (project-local apps)
-   * staticDir: "static"
    *
    * @example
    * // Absolute URL (published packages — works in JSR cache, local dev, etc.)
@@ -698,6 +796,10 @@ export interface AppConfig {
   /**
    * Template directory for this app.
    *
+   * @deprecated Template discovery is now convention-based (`<appPath>/templates/`)
+   * at `runserver` time, and `templatesDir` in `ASSETFILES_DIRS` is used for
+   * bundle-time SW template embedding.
+   *
    * Django-style namespacing: a template named `"my-app/note_list.html"`
    * should live at `<templatesDir>/my-app/note_list.html`.
    *
@@ -705,14 +807,6 @@ export interface AppConfig {
    * - A path relative to the project root: `"src/my-app/templates"`
    * - An absolute `file://` URL (recommended for published packages):
    *   `new URL("./templates/", import.meta.url).href`
-   *
-   * When the Application starts, it reads all `.html` files from this
-   * directory tree and registers them in the global `templateRegistry`
-   * so templates are available to `templateView`.
-   *
-   * @example
-   * // Relative path (project-local apps)
-   * templatesDir: "src/my-app/templates"
    *
    * @example
    * // Absolute URL (published packages)

--- a/src/web/commands/runserver.ts
+++ b/src/web/commands/runserver.ts
@@ -294,8 +294,9 @@ export class RunServerCommand extends BaseCommand {
    * Load all installed apps' configurations.
    *
    * This populates:
-   * - `templateRegistry` from each app's `templatesDir`
+   * - `templateRegistry` from each app's `templatesDir` (legacy) or `<appPath>/templates/` (convention)
    * - `this.appNames` and `this.appPaths` for static file serving
+   *   (includes explicit `STATICFILES_DIRS` from settings)
    *
    * Called at server startup before creating the Application.
    */
@@ -325,21 +326,82 @@ export class RunServerCommand extends BaseCommand {
           this.appPaths[config.name] = appPath;
         }
 
-        // Load templates
+        // Load templates:
+        // 1. Legacy: explicit `config.templatesDir` on AppConfig
+        // 2. Convention: `<appPath>/templates/` auto-discovery
+        let templatesDir: string | null = null;
         if (config.templatesDir) {
-          const dir = this.resolveTemplatesDir(config.templatesDir);
-          if (dir) {
-            await this.scanAndRegisterTemplates(dir);
-            templatesRegistered++;
+          templatesDir = this.resolveTemplatesDir(config.templatesDir);
+        } else if (appPath) {
+          // Convention-based: resolve appPath to absolute dir, then append /templates
+          const absAppDir = appPath.startsWith("/")
+            ? appPath
+            : `${this.projectRoot}/${appPath.replace(/^\.\//, "")}`;
+          const conventionDir = `${absAppDir}/templates`;
+          try {
+            const stat = await Deno.stat(conventionDir);
+            if (stat.isDirectory) {
+              templatesDir = conventionDir;
+            }
+          } catch {
+            // No templates dir by convention, skip
           }
+        }
+
+        if (templatesDir) {
+          await this.scanAndRegisterTemplates(templatesDir);
+          templatesRegistered++;
         }
       } catch {
         // Skip apps that fail to load or have unreadable template dirs
       }
     }
 
+    // Also register templates from explicit STATICFILES_DIRS entries that
+    // live alongside a templates/ sibling — but this is intentionally NOT done
+    // here: STATICFILES_DIRS is for static assets only; templates from
+    // ASSETFILES_DIRS are embedded at bundle time, not served by runserver.
+
     if (templatesRegistered > 0) {
       this.success(`Templates loaded from ${templatesRegistered} app(s)`);
+    }
+
+    // Handle explicit STATICFILES_DIRS: add each as a synthetic "app"
+    const staticfilesDirs = settings.STATICFILES_DIRS as string[] | undefined;
+    if (Array.isArray(staticfilesDirs)) {
+      for (const dir of staticfilesDirs) {
+        const resolved = dir.startsWith("file://")
+          ? (() => {
+            try {
+              const url = new URL(dir);
+              let pathname = url.pathname.replace(/\/$/, "");
+              if (/^\/[a-zA-Z]:\//.test(pathname)) {
+                pathname = pathname.slice(1);
+              }
+              return pathname;
+            } catch {
+              return null;
+            }
+          })()
+          : dir.startsWith("/")
+          ? dir
+          : `${this.projectRoot}/${dir.replace(/^\.\//, "")}`;
+
+        if (!resolved) continue;
+
+        try {
+          const stat = await Deno.stat(resolved);
+          if (stat.isDirectory) {
+            // Use a synthetic name based on path; store absolute path directly
+            const syntheticName = `__staticfiles_dir_${this.appNames.length}__`;
+            this.appNames.push(syntheticName);
+            // Store absolute dir path; staticFilesMiddleware resolves via appPaths
+            this.appPaths[syntheticName] = resolved;
+          }
+        } catch {
+          // Directory doesn't exist, skip
+        }
+      }
     }
 
     if (this.appNames.length > 0) {


### PR DESCRIPTION
## Summary

- Adds `AssetfilesDirConfig` interface to `@alexi/types` for declarative frontend bundle configuration
- Deprecates `AppConfig.staticfiles`, `staticDir`, `templatesDir`, and `bundle` fields (backwards compatible)
- Updates `bundle` command to read `ASSETFILES_DIRS` from project settings instead of scanning `AppConfig.staticfiles`
- Updates `collectstatic` command to use `STATICFILES_DIRS` setting + convention-based `<appPath>/static/` auto-discovery
- Updates `runserver` to use `STATICFILES_DIRS` for static serving + convention-based `<appPath>/templates/` template loading
- Updates project scaffolding: `settings.ts` now includes `ASSETFILES_DIRS` and `STATICFILES_DIRS`; workers app removed from `INSTALLED_APPS`
- Renames generated entry points to `worker.ts` and `${name}.ts` (was `mod.ts` for both)
- Updates scaffold tests to match the new file structure

Closes #191