### PR TITLE
fix(db): replace dynamic import() with static import in _resolveBackend and ForeignKey.fetch()

### DIFF
--- a/src/db/fields/relations.ts
+++ b/src/db/fields/relations.ts
@@ -7,6 +7,7 @@ import { Field, FieldOptions } from "./field.ts";
 import type { QuerySet } from "../query/queryset.ts";
 import type { Model } from "../models/model.ts";
 import type { DatabaseBackend } from "../backends/backend.ts";
+import { getBackend, isInitialized } from "../setup.ts";
 
 // ============================================================================
 // Relation Types
@@ -285,8 +286,6 @@ export class ForeignKey<T> extends Field<T> {
     // Get the backend - try instance backend first, then global
     let backend = this._backend;
     if (!backend) {
-      // Import dynamically to avoid circular dependency
-      const { getBackend, isInitialized } = await import("../setup.ts");
       if (!isInitialized()) {
         throw new Error(
           `Database not initialized. Call setup() before fetching related objects.`,

--- a/src/db/models/model.ts
+++ b/src/db/models/model.ts
@@ -13,6 +13,7 @@ import {
   setModelResolver,
 } from "../fields/relations.ts";
 import type { DatabaseBackend } from "../backends/backend.ts";
+import { getBackend, getBackendByName, isInitialized } from "../setup.ts";
 
 // ============================================================================
 // Save/Delete Options
@@ -777,7 +778,7 @@ export abstract class Model {
   async save(options?: ModelOperationOptions): Promise<this> {
     this._ensureFieldsInitialized();
 
-    const backend = await this._resolveBackend(options?.using);
+    const backend = this._resolveBackend(options?.using);
     const pk = this.pk;
 
     if (pk === null || pk === undefined) {
@@ -815,7 +816,7 @@ export abstract class Model {
       throw new Error("Cannot delete an instance without a primary key");
     }
 
-    const backend = await this._resolveBackend(options?.using);
+    const backend = this._resolveBackend(options?.using);
     await backend.delete(this);
   }
 
@@ -831,14 +832,9 @@ export abstract class Model {
    * @returns The resolved DatabaseBackend
    * @throws Error if no backend is available
    */
-  private async _resolveBackend(
+  private _resolveBackend(
     using?: DatabaseBackend | string,
-  ): Promise<DatabaseBackend> {
-    // Import dynamically to avoid circular dependency
-    const { getBackend, getBackendByName, isInitialized } = await import(
-      "../setup.ts"
-    );
-
+  ): DatabaseBackend {
     // 1. Explicit using parameter
     if (using) {
       if (typeof using === "string") {
@@ -894,7 +890,7 @@ export abstract class Model {
       throw new Error("Cannot refresh an instance without a primary key");
     }
 
-    const backend = await this._resolveBackend(options?.using);
+    const backend = this._resolveBackend(options?.using);
     const ModelClass = this.constructor as new () => this;
     const data = await backend.getById(ModelClass, pk);
 


### PR DESCRIPTION
## Summary

- Replace unnecessary dynamic `import()` in `Model._resolveBackend()` with a static import, fixing `TypeError: import() is disallowed on ServiceWorkerGlobalScope`
- Replace the same pattern in `ForeignKey.fetch()` (`relations.ts`) for consistency
- Make `_resolveBackend` synchronous (removes `async`/`await` overhead from `save()`, `delete()`, and `refresh()`)

The dynamic imports were added with a comment claiming to avoid circular dependencies, but no circular dependency exists: `setup.ts` only imports `DatabaseBackend` via `import type` (erased at runtime) and does not import `model.ts` or `relations.ts`. This matches how `queryset.ts` and `manager.ts` already use a static import from `setup.ts`.

Closes #200