### PR TITLE
fix(core): call configure() in migration commands before getBackend()

### DIFF
--- a/src/core/management/commands/migrate.ts
+++ b/src/core/management/commands/migrate.ts
@@ -12,6 +12,7 @@ import type {
   CommandResult,
   IArgumentParser,
 } from "../types.ts";
+import { configure } from "../config.ts";
 import { MigrationExecutor, MigrationLoader } from "@alexi/db/migrations";
 import { getBackend, getBackendByName } from "@alexi/db";
 
@@ -69,6 +70,12 @@ export class MigrateCommand extends BaseCommand {
   // ===========================================================================
 
   override addArguments(parser: IArgumentParser): void {
+    parser.addArgument("--settings", {
+      type: "string",
+      required: false,
+      help: "Settings module to use (e.g. web, desktop, or a file path)",
+    });
+
     parser.addArgument("app", {
       type: "string",
       required: false,
@@ -130,6 +137,7 @@ export class MigrateCommand extends BaseCommand {
   // ===========================================================================
 
   async handle(options: CommandOptions): Promise<CommandResult> {
+    const settingsName = options.args.settings as string | undefined;
     const appLabel = options.args.app as string | undefined;
     const targetMigration = options.args.migration as string | undefined;
     const showPlan = options.args.plan as boolean;
@@ -141,6 +149,9 @@ export class MigrateCommand extends BaseCommand {
     const verbosity = options.args.verbosity as number;
 
     try {
+      // Load settings and initialize database
+      await configure(settingsName);
+
       // Get database backend
       const backend = databaseName
         ? getBackendByName(databaseName)

--- a/src/core/management/commands/showmigrations.ts
+++ b/src/core/management/commands/showmigrations.ts
@@ -12,6 +12,7 @@ import type {
   CommandResult,
   IArgumentParser,
 } from "../types.ts";
+import { configure } from "../config.ts";
 import {
   createDeprecationRecorder,
   createMigrationRecorder,
@@ -60,6 +61,12 @@ export class ShowmigrationsCommand extends BaseCommand {
   // ===========================================================================
 
   override addArguments(parser: IArgumentParser): void {
+    parser.addArgument("--settings", {
+      type: "string",
+      required: false,
+      help: "Settings module to use (e.g. web, desktop, or a file path)",
+    });
+
     parser.addArgument("app", {
       type: "string",
       required: false,
@@ -97,6 +104,7 @@ export class ShowmigrationsCommand extends BaseCommand {
   // ===========================================================================
 
   async handle(options: CommandOptions): Promise<CommandResult> {
+    const settingsName = options.args.settings as string | undefined;
     const appLabel = options.args.app as string | undefined;
     const showDeprecations = options.args.deprecations as boolean;
     const listFormat = options.args.list as boolean;
@@ -104,6 +112,9 @@ export class ShowmigrationsCommand extends BaseCommand {
     const migrationsDir = options.args["migrations-dir"] as string | undefined;
 
     try {
+      // Load settings and initialize database
+      await configure(settingsName);
+
       // Get database backend
       const backend = databaseName
         ? getBackendByName(databaseName)

--- a/src/core/management/commands/sqlmigrate.ts
+++ b/src/core/management/commands/sqlmigrate.ts
@@ -12,6 +12,7 @@ import type {
   CommandResult,
   IArgumentParser,
 } from "../types.ts";
+import { configure } from "../config.ts";
 import {
   type CreateIndexOptions,
   type IBackendSchemaEditor,
@@ -64,6 +65,12 @@ export class SqlmigrateCommand extends BaseCommand {
   // ===========================================================================
 
   override addArguments(parser: IArgumentParser): void {
+    parser.addArgument("--settings", {
+      type: "string",
+      required: false,
+      help: "Settings module to use (e.g. web, desktop, or a file path)",
+    });
+
     parser.addArgument("app", {
       type: "string",
       required: true,
@@ -107,6 +114,7 @@ export class SqlmigrateCommand extends BaseCommand {
   // ===========================================================================
 
   async handle(options: CommandOptions): Promise<CommandResult> {
+    const settingsName = options.args.settings as string | undefined;
     const appLabel = options.args.app as string;
     const migrationName = options.args.migration as string;
     const backwards = options.args.backwards as boolean;
@@ -115,6 +123,9 @@ export class SqlmigrateCommand extends BaseCommand {
     const noColor = options.args["no-color"] as boolean;
 
     try {
+      // Load settings and initialize database
+      await configure(settingsName);
+
       // Get database backend
       const backend = databaseName
         ? getBackendByName(databaseName)


### PR DESCRIPTION
## Summary

- `migrate`, `showmigrations`, and `sqlmigrate` all called `getBackend()` without first loading settings or initialising the database
- Each command now calls `configure(settingsName)` at the start of `handle()`, which runs `loadSettings()` + `initializeDatabase()` (i.e. `setup()`) before any ORM access
- Each command also gains a `--settings` argument so the settings module can be specified explicitly (consistent with other commands like `test`)

Closes #111