### PR TITLE
fix(db): fix Windows path bug, DenoKV schema editor, and migration command exports

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -15,7 +15,8 @@
     "jsr:@zip-js/zip-js@^2.8.7": "2.8.22",
     "npm:esbuild@0.24": "0.24.2",
     "npm:fake-indexeddb@6": "6.2.5",
-    "npm:pg@8": "8.19.0"
+    "npm:pg@8": "8.19.0",
+    "npm:playwright@^1.48.0": "1.58.2"
   },
   "jsr": {
     "@luca/esbuild-deno-loader@0.11.1": {
@@ -227,6 +228,11 @@
     "fake-indexeddb@6.2.5": {
       "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w=="
     },
+    "fsevents@2.3.2": {
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "os": ["darwin"],
+      "scripts": true
+    },
     "pg-cloudflare@1.3.0": {
       "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ=="
     },
@@ -273,6 +279,20 @@
       "dependencies": [
         "split2"
       ]
+    },
+    "playwright-core@1.58.2": {
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "bin": true
+    },
+    "playwright@1.58.2": {
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dependencies": [
+        "playwright-core"
+      ],
+      "optionalDependencies": [
+        "fsevents"
+      ],
+      "bin": true
     },
     "postgres-array@2.0.0": {
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="

--- a/src/db/backends/denokv/backend.ts
+++ b/src/db/backends/denokv/backend.ts
@@ -96,6 +96,7 @@ import {
   type SchemaEditor,
   type Transaction,
 } from "../backend.ts";
+import { DenoKVMigrationSchemaEditor } from "../../migrations/schema/denokv.ts";
 
 // ============================================================================
 // DenoKV Configuration
@@ -710,7 +711,10 @@ export class DenoKVBackend extends DatabaseBackend {
 
   getSchemaEditor(): SchemaEditor {
     this.ensureConnected();
-    return new DenoKVSchemaEditor(this._kv!);
+    // deno-lint-ignore no-explicit-any
+    return new DenoKVMigrationSchemaEditor(
+      this._kv! as any,
+    ) as unknown as SchemaEditor;
   }
 
   async tableExists(tableName: string): Promise<boolean> {

--- a/src/db/migrations/loader.ts
+++ b/src/db/migrations/loader.ts
@@ -284,7 +284,8 @@ export class MigrationLoader {
   private async _loadMigrationsFromDir(dir: string): Promise<void> {
     // Extract app label from directory path
     // e.g., "project/apps/users/migrations" -> "users"
-    const parts = dir.split("/");
+    // Normalise separators so this works on Windows too.
+    const parts = dir.replace(/\\/g, "/").split("/");
     const migrationsIndex = parts.indexOf("migrations");
     const appLabel = migrationsIndex > 0
       ? parts[migrationsIndex - 1]
@@ -313,7 +314,14 @@ export class MigrationLoader {
   ): Promise<void> {
     try {
       // Dynamic import of the migration file
-      const module = await import(`file://${Deno.realPathSync(filePath)}`);
+      // Use a proper file:// URL that works on both Unix and Windows.
+      // On Windows, Deno.realPathSync() returns "C:\...", so we need
+      // file:///C:/... (three slashes + forward-slash-normalised path).
+      const realPath = Deno.realPathSync(filePath).replace(/\\/g, "/");
+      const fileUrl = realPath.startsWith("/")
+        ? `file://${realPath}`
+        : `file:///${realPath}`;
+      const module = await import(fileUrl);
 
       // Get the default export (the migration class)
       const MigrationClass = module.default;
@@ -328,7 +336,7 @@ export class MigrationLoader {
 
       // Derive app label if not provided
       if (!appLabel) {
-        const parts = filePath.split("/");
+        const parts = filePath.replace(/\\/g, "/").split("/");
         const migrationsIndex = parts.indexOf("migrations");
         appLabel = migrationsIndex > 0 ? parts[migrationsIndex - 1] : "default";
       }

--- a/src/db/migrations/schema/denokv.ts
+++ b/src/db/migrations/schema/denokv.ts
@@ -22,7 +22,9 @@ type AnyField = Field<any>;
 
 // DenoKV type definitions
 interface DenoKv {
-  get<T>(key: Deno.KvKey): Promise<{ value: T | null; versionstamp: string }>;
+  get<T>(
+    key: Deno.KvKey,
+  ): Promise<{ value: T | null; versionstamp: string | null }>;
   set(
     key: Deno.KvKey,
     value: unknown,


### PR DESCRIPTION
## Summary

- **#110** — `MigrationLoader` Windows path bug: `file://${realPath}` produced `file://C:\...` on Windows. Fixed to normalise backslashes and produce `file:///C:/...`. Also normalised path separators in `appLabel` derivation.
- **#112** — `DenoKVBackend.getSchemaEditor()` returned the legacy `DenoKVSchemaEditor` which lacks `addColumn()` and other `IBackendSchemaEditor` methods. It now returns `DenoKVMigrationSchemaEditor` which fully implements the interface.
- **#113** — `MakemigrationsCommand`, `MigrateCommand`, `ShowmigrationsCommand` are already correctly exported from `@alexi/core/management`. The issue was fixed in a prior refactor; closing as resolved.

Closes #110
Closes #112
Closes #113