### PR TITLE
feat(db,create): add production.ts scaffold and remote Deno KV url support

### DIFF
--- a/.opencode/skills/alexi-implement/SKILL.md
+++ b/.opencode/skills/alexi-implement/SKILL.md
@@ -216,14 +216,15 @@ When implementing new features, update relevant documentation:
 
 ### Files to Update
 
-| Feature Type   | Documentation to Update                    |
-| -------------- | ------------------------------------------ |
-| New backend    | `AGENTS.md`, `docs/django-comparison.md`   |
-| New field type | `AGENTS.md` field tables                   |
-| New serializer | `AGENTS.md` REST Framework section         |
-| API changes    | `AGENTS.md` relevant section               |
-| New command    | `AGENTS.md` Management Commands table      |
-| Django parity  | `docs/django-comparison.md` feature tables |
+| Feature Type          | Documentation to Update                    |
+| --------------------- | ------------------------------------------ |
+| New backend           | `AGENTS.md`, `docs/django-comparison.md`   |
+| New field type        | `AGENTS.md` field tables                   |
+| New serializer        | `AGENTS.md` REST Framework section         |
+| API changes           | `AGENTS.md` relevant section               |
+| New command           | `AGENTS.md` Management Commands table      |
+| Django parity         | `docs/django-comparison.md` feature tables |
+| Scaffolding templates | `AGENTS.md` Settings Configuration section |
 
 ### AGENTS.md Updates
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2376,11 +2376,64 @@ Used for server-side applications with Deno's built-in KV store.
 ```typescript
 import { DenoKVBackend } from "@alexi/db/backends/denokv";
 
+// Local development
 const backend = new DenoKVBackend({
   name: "myapp",
   path: "./data/myapp.db", // Optional, uses default if not specified
 });
 await backend.connect();
+
+// Remote Deno Deploy KV (production)
+// Set DENO_KV_ACCESS_TOKEN env var — picked up automatically by Deno runtime
+const prodBackend = new DenoKVBackend({
+  name: "myapp",
+  url: Deno.env.get("DENO_KV_URL"), // e.g. https://api.deno.com/databases/<uuid>/connect
+});
+await prodBackend.connect();
+```
+
+#### DenoKVConfig Reference
+
+| Option | Type     | Default     | Description                                                    |
+| ------ | -------- | ----------- | -------------------------------------------------------------- |
+| `name` | `string` | (required)  | Logical name for this database instance                        |
+| `path` | `string` | `undefined` | Local file path (e.g. `"./data/app.db"` or `":memory:"`)       |
+| `url`  | `string` | `undefined` | Remote Deno Deploy KV URL; takes precedence over `path` if set |
+
+#### Production Settings Pattern
+
+Scaffold a `project/production.ts` settings file for connecting to Deno Deploy
+KV locally:
+
+```typescript
+// project/production.ts
+import { DenoKVBackend } from "@alexi/db/backends/denokv";
+
+export const DEBUG = false;
+export const SECRET_KEY = Deno.env.get("SECRET_KEY")!;
+
+export const DATABASES = {
+  default: new DenoKVBackend({
+    name: "myapp",
+    url: Deno.env.get("DENO_KV_URL"),
+  }),
+};
+```
+
+Store secrets in `.env.production.local` (git-ignored automatically via
+`.env.*.local`):
+
+```dotenv
+# .env.production.local
+DENO_KV_ACCESS_TOKEN=<your-token>
+DENO_KV_URL=https://api.deno.com/databases/<uuid>/connect
+SECRET_KEY=<your-production-secret>
+```
+
+Run management commands against production KV locally:
+
+```bash
+deno run -A --unstable-kv --env-file .env.production.local manage.ts createsuperuser --settings ./project/production.ts
 ```
 
 ### IndexedDB Backend (Browser)

--- a/deno.lock
+++ b/deno.lock
@@ -3,6 +3,7 @@
   "specifiers": {
     "jsr:@luca/esbuild-deno-loader@~0.11.1": "0.11.1",
     "jsr:@std/assert@*": "1.0.19",
+    "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/bytes@^1.0.2": "1.0.6",
     "jsr:@std/encoding@^1.0.5": "1.0.10",
     "jsr:@std/fs@^1.0.19": "1.0.23",
@@ -15,7 +16,8 @@
     "jsr:@zip-js/zip-js@^2.8.7": "2.8.22",
     "npm:esbuild@0.24": "0.24.2",
     "npm:fake-indexeddb@6": "6.2.5",
-    "npm:pg@8": "8.19.0"
+    "npm:pg@8": "8.19.0",
+    "npm:playwright@^1.48.0": "1.58.2"
   },
   "jsr": {
     "@luca/esbuild-deno-loader@0.11.1": {
@@ -227,6 +229,11 @@
     "fake-indexeddb@6.2.5": {
       "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w=="
     },
+    "fsevents@2.3.2": {
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "os": ["darwin"],
+      "scripts": true
+    },
     "pg-cloudflare@1.3.0": {
       "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ=="
     },
@@ -273,6 +280,20 @@
       "dependencies": [
         "split2"
       ]
+    },
+    "playwright-core@1.58.2": {
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "bin": true
+    },
+    "playwright@1.58.2": {
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dependencies": [
+        "playwright-core"
+      ],
+      "optionalDependencies": [
+        "fsevents"
+      ],
+      "bin": true
     },
     "postgres-array@2.0.0": {
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="

--- a/src/create/project.ts
+++ b/src/create/project.ts
@@ -15,7 +15,10 @@ import { generateGitignore } from "./templates/root/gitignore.ts";
 import { generateReadme } from "./templates/root/readme.ts";
 
 // Template imports - Project settings
-import { generateSettings } from "./templates/project/settings_ts.ts";
+import {
+  generateProductionSettings,
+  generateSettings,
+} from "./templates/project/settings_ts.ts";
 
 // Template imports - Unified app (server-side)
 import { generateAppTs } from "./templates/unified/app_ts.ts";
@@ -235,6 +238,10 @@ async function generateFiles(name: string, version: string): Promise<void> {
     {
       path: `${name}/project/settings.ts`,
       content: generateSettings(name),
+    },
+    {
+      path: `${name}/project/production.ts`,
+      content: generateProductionSettings(name),
     },
 
     // ==========================================================================

--- a/src/create/templates/project/settings_ts.ts
+++ b/src/create/templates/project/settings_ts.ts
@@ -12,7 +12,34 @@
  * static files, and middleware.
  */
 export function generateSettings(name: string): string {
-  return `/**
+  return _generateSettingsContent(name);
+}
+
+/**
+ * Generate production.ts content for a new project.
+ *
+ * This file is intended for running management commands locally against a
+ * production Deno Deploy KV database. It reads secrets from environment
+ * variables only — never from insecure fallback values.
+ *
+ * Usage:
+ * ```
+ * # .env.production.local (never commit this file)
+ * DENO_KV_ACCESS_TOKEN=<token from Deno Deploy dashboard>
+ * DENO_KV_URL=https://api.deno.com/databases/<uuid>/connect
+ * SECRET_KEY=<your production secret key>
+ * CORS_ORIGINS=https://example.com
+ *
+ * deno run -A --unstable-kv --env-file .env.production.local manage.ts createsuperuser --settings ./project/production.ts
+ * ```
+ */
+export function generateProductionSettings(name: string): string {
+  return _generateProductionSettingsContent(name);
+}
+
+function _generateSettingsContent(name: string): string {
+  return (
+    `/**
  * ${name} - Project Settings
  *
  * All project configuration in one file.
@@ -22,9 +49,9 @@ export function generateSettings(name: string): string {
 
 import { DenoKVBackend } from "@alexi/db/backends/denokv";
 import {
-  loggingMiddleware,
   corsMiddleware,
   errorHandlerMiddleware,
+  loggingMiddleware,
 } from "@alexi/middleware";
 
 // =============================================================================
@@ -162,5 +189,163 @@ export function createMiddleware() {
     errorHandlerMiddleware(),
   ];
 }
-`;
+`
+  );
+}
+
+function _generateProductionSettingsContent(name: string): string {
+  return (
+    `/**
+ * ${name} - Production Settings
+ *
+ * Use this settings file to run management commands locally against your
+ * production Deno Deploy KV database. Reads all secrets from environment
+ * variables — never falls back to insecure defaults.
+ *
+ * Setup:
+ *   1. Create .env.production.local (this file is git-ignored)
+ *   2. Add the following variables:
+ *
+ *      DENO_KV_ACCESS_TOKEN=<token from Deno Deploy dashboard>
+ *      DENO_KV_URL=https://api.deno.com/databases/<uuid>/connect
+ *      SECRET_KEY=<your production secret key>
+ *      CORS_ORIGINS=https://example.com
+ *
+ *   3. Run management commands with:
+ *
+ *      deno run -A --unstable-kv --env-file .env.production.local manage.ts <command> --settings ./project/production.ts
+ *
+ * Examples:
+ *   deno run -A --unstable-kv --env-file .env.production.local manage.ts createsuperuser --settings ./project/production.ts
+ *
+ * @module project/production
+ */
+
+import { DenoKVBackend } from "@alexi/db/backends/denokv";
+import {
+  corsMiddleware,
+  errorHandlerMiddleware,
+  loggingMiddleware,
+} from "@alexi/middleware";
+
+// =============================================================================
+// Environment
+// =============================================================================
+
+export const DEBUG = false;
+
+/**
+ * Production secret key — must be set via SECRET_KEY environment variable.
+ * Never hard-code this value or commit it to version control.
+ */
+export const SECRET_KEY = Deno.env.get("SECRET_KEY")!;
+
+// =============================================================================
+// Server Configuration
+// =============================================================================
+
+export const DEFAULT_HOST = "0.0.0.0";
+export const DEFAULT_PORT = 8000;
+
+// =============================================================================
+// Database
+// =============================================================================
+
+/**
+ * Production database connects to Deno Deploy KV via remote URL.
+ *
+ * DENO_KV_URL:          The remote database URL from Deno Deploy dashboard.
+ * DENO_KV_ACCESS_TOKEN: Auth token — picked up automatically by the Deno runtime.
+ *
+ * Both values can be found at: https://console.deno.com → your app → KV → Connect
+ */
+export const DATABASES = {
+  default: new DenoKVBackend({
+    name: "${name}",
+    url: Deno.env.get("DENO_KV_URL"),
+  }),
+};
+
+// =============================================================================
+// Installed Apps
+// =============================================================================
+
+/**
+ * INSTALLED_APPS contains import functions for each app.
+ *
+ * Using import functions ensures the import happens in this module's context,
+ * so import maps defined in deno.jsonc work correctly.
+ */
+export const INSTALLED_APPS = [
+  () => import("@alexi/staticfiles"),
+  () => import("@alexi/web"),
+  () => import("@alexi/db"),
+  () => import("@alexi/restframework"),
+  () => import("@${name}/mod.ts"),
+];
+
+// =============================================================================
+// URL Configuration
+// =============================================================================
+
+/**
+ * ROOT_URLCONF is an import function that returns the URL patterns module.
+ */
+export const ROOT_URLCONF = () => import("@${name}/urls.ts");
+
+// =============================================================================
+// Templates
+// =============================================================================
+
+export const TEMPLATES = [
+  {
+    APP_DIRS: true,
+    DIRS: [
+      "./src/${name}/templates",
+    ],
+  },
+];
+
+// =============================================================================
+// Static Files
+// =============================================================================
+
+export const STATIC_URL = "/static/";
+export const STATIC_ROOT = "./static";
+
+export const STATICFILES_DIRS: string[] = [];
+
+export const ASSETFILES_DIRS = [
+  {
+    path: "./src/${name}/workers/${name}",
+    outputDir: "./src/${name}/static/${name}",
+    entrypoints: ["worker.ts"],
+    templatesDir: "./src/${name}/templates",
+  },
+  {
+    path: "./src/${name}/assets/${name}",
+    outputDir: "./src/${name}/static/${name}",
+    entrypoints: ["${name}.ts"],
+  },
+];
+
+// =============================================================================
+// CORS
+// =============================================================================
+
+export const CORS_ORIGINS = Deno.env.get("CORS_ORIGINS")?.split(",") ?? [];
+
+// =============================================================================
+// Middleware
+// =============================================================================
+
+export function createMiddleware() {
+  return [
+    loggingMiddleware(),
+    corsMiddleware({ origins: CORS_ORIGINS }),
+    errorHandlerMiddleware(),
+  ];
+}
+`
+  );
 }

--- a/src/create/tests/scaffold_test.ts
+++ b/src/create/tests/scaffold_test.ts
@@ -181,6 +181,40 @@ Deno.test({
       }
     });
 
+    await t.step("creates production.ts settings file", async () => {
+      const fullPath = `${project.path}/project/production.ts`;
+      try {
+        const stat = await Deno.stat(fullPath);
+        assertEquals(
+          stat.isFile,
+          true,
+          "project/production.ts should be a file",
+        );
+      } catch {
+        throw new Error("Settings file project/production.ts does not exist");
+      }
+    });
+
+    await t.step("production.ts contains required exports", async () => {
+      const content = await Deno.readTextFile(
+        `${project.path}/project/production.ts`,
+      );
+      const requiredExports = [
+        "DEBUG",
+        "SECRET_KEY",
+        "DATABASES",
+        "DENO_KV_URL",
+      ];
+
+      for (const exp of requiredExports) {
+        assertEquals(
+          content.includes(exp),
+          true,
+          `production.ts should contain ${exp}`,
+        );
+      }
+    });
+
     await t.step("does NOT create old settings files", async () => {
       const oldFiles = [
         "project/web.settings.ts",

--- a/src/db/backends/denokv/backend.ts
+++ b/src/db/backends/denokv/backend.ts
@@ -109,6 +109,23 @@ export interface DenoKVConfig extends DatabaseConfig {
   engine: "denokv";
   /** Path to the KV database file (optional, uses default if not specified) */
   path?: string;
+  /**
+   * Remote Deno KV URL for connecting to a Deno Deploy hosted database.
+   *
+   * Use this to run management commands locally against a production database:
+   *
+   * ```
+   * # .env.production.local
+   * DENO_KV_ACCESS_TOKEN=<token from Deno Deploy dashboard>
+   * DENO_KV_URL=https://api.deno.com/databases/<uuid>/connect
+   * ```
+   *
+   * The `DENO_KV_ACCESS_TOKEN` environment variable is picked up automatically
+   * by the Deno runtime — no additional auth code is needed.
+   *
+   * When both `url` and `path` are set, `url` takes precedence.
+   */
+  url?: string;
 }
 
 // ============================================================================
@@ -285,11 +302,16 @@ export class DenoKVBackend extends DatabaseBackend {
   private _kv: Deno.Kv | null = null;
   private _idCounters: Map<string, number> = new Map();
 
-  constructor(config: DenoKVConfig | { name: string; path?: string }) {
+  constructor(
+    config: DenoKVConfig | { name: string; path?: string; url?: string },
+  ) {
     super({
       engine: "denokv",
       name: config.name,
-      options: { path: (config as DenoKVConfig).path },
+      options: {
+        path: (config as DenoKVConfig).path,
+        url: (config as DenoKVConfig).url,
+      },
     });
   }
 
@@ -312,8 +334,10 @@ export class DenoKVBackend extends DatabaseBackend {
       return;
     }
 
+    const url = this._config.options?.url as string | undefined;
     const path = this._config.options?.path as string | undefined;
-    this._kv = await Deno.openKv(path);
+    // url takes precedence over path (remote Deno Deploy KV over local file)
+    this._kv = await Deno.openKv(url ?? path);
     this._connected = true;
   }
 


### PR DESCRIPTION
## Summary

- Adds `url` field to `DenoKVConfig` / `DenoKVBackend` for connecting to a remote Deno Deploy KV database (`Deno.openKv(url)`)
- Scaffolds `project/production.ts` with `DEBUG=false`, `SECRET_KEY` (no dev fallback), and `url`-based `DATABASES` — generated by `startproject`
- Adds two scaffold test steps verifying `production.ts` is created and contains the required exports
- Updates `AGENTS.md` with `DenoKVConfig` reference table, production settings pattern, and `--env-file` workflow
- Updates `alexi-implement` skill docs

Closes #206