### PR TITLE
feat(core): add global settings registry (conf) and fix AdminRouter backend fallback

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -3,6 +3,7 @@
   "specifiers": {
     "jsr:@luca/esbuild-deno-loader@~0.11.1": "0.11.1",
     "jsr:@std/assert@*": "1.0.19",
+    "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/bytes@^1.0.2": "1.0.6",
     "jsr:@std/encoding@^1.0.5": "1.0.10",
     "jsr:@std/fs@^1.0.19": "1.0.23",
@@ -15,7 +16,8 @@
     "jsr:@zip-js/zip-js@^2.8.7": "2.8.22",
     "npm:esbuild@0.24": "0.24.2",
     "npm:fake-indexeddb@6": "6.2.5",
-    "npm:pg@8": "8.19.0"
+    "npm:pg@8": "8.19.0",
+    "npm:playwright@^1.48.0": "1.58.2"
   },
   "jsr": {
     "@luca/esbuild-deno-loader@0.11.1": {
@@ -227,6 +229,11 @@
     "fake-indexeddb@6.2.5": {
       "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w=="
     },
+    "fsevents@2.3.2": {
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "os": ["darwin"],
+      "scripts": true
+    },
     "pg-cloudflare@1.3.0": {
       "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ=="
     },
@@ -274,6 +281,20 @@
         "split2"
       ]
     },
+    "playwright-core@1.58.2": {
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "bin": true
+    },
+    "playwright@1.58.2": {
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dependencies": [
+        "playwright-core"
+      ],
+      "optionalDependencies": [
+        "fsevents"
+      ],
+      "bin": true
+    },
     "postgres-array@2.0.0": {
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
     },
@@ -295,6 +316,75 @@
     "xtend@4.0.2": {
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     }
+  },
+  "remote": {
+    "https://deno.land/std@0.208.0/assert/_constants.ts": "8a9da298c26750b28b326b297316cdde860bc237533b07e1337c021379e6b2a9",
+    "https://deno.land/std@0.208.0/assert/_diff.ts": "58e1461cc61d8eb1eacbf2a010932bf6a05b79344b02ca38095f9b805795dc48",
+    "https://deno.land/std@0.208.0/assert/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
+    "https://deno.land/std@0.208.0/assert/assert.ts": "9a97dad6d98c238938e7540736b826440ad8c1c1e54430ca4c4e623e585607ee",
+    "https://deno.land/std@0.208.0/assert/assert_almost_equals.ts": "e15ca1f34d0d5e0afae63b3f5d975cbd18335a132e42b0c747d282f62ad2cd6c",
+    "https://deno.land/std@0.208.0/assert/assert_array_includes.ts": "6856d7f2c3544bc6e62fb4646dfefa3d1df5ff14744d1bca19f0cbaf3b0d66c9",
+    "https://deno.land/std@0.208.0/assert/assert_equals.ts": "d8ec8a22447fbaf2fc9d7c3ed2e66790fdb74beae3e482855d75782218d68227",
+    "https://deno.land/std@0.208.0/assert/assert_exists.ts": "407cb6b9fb23a835cd8d5ad804e2e2edbbbf3870e322d53f79e1c7a512e2efd7",
+    "https://deno.land/std@0.208.0/assert/assert_false.ts": "0ccbcaae910f52c857192ff16ea08bda40fdc79de80846c206bfc061e8c851c6",
+    "https://deno.land/std@0.208.0/assert/assert_greater.ts": "ae2158a2d19313bf675bf7251d31c6dc52973edb12ac64ac8fc7064152af3e63",
+    "https://deno.land/std@0.208.0/assert/assert_greater_or_equal.ts": "1439da5ebbe20855446cac50097ac78b9742abe8e9a43e7de1ce1426d556e89c",
+    "https://deno.land/std@0.208.0/assert/assert_instance_of.ts": "3aedb3d8186e120812d2b3a5dea66a6e42bf8c57a8bd927645770bd21eea554c",
+    "https://deno.land/std@0.208.0/assert/assert_is_error.ts": "c21113094a51a296ffaf036767d616a78a2ae5f9f7bbd464cd0197476498b94b",
+    "https://deno.land/std@0.208.0/assert/assert_less.ts": "aec695db57db42ec3e2b62e97e1e93db0063f5a6ec133326cc290ff4b71b47e4",
+    "https://deno.land/std@0.208.0/assert/assert_less_or_equal.ts": "5fa8b6a3ffa20fd0a05032fe7257bf985d207b85685fdbcd23651b70f928c848",
+    "https://deno.land/std@0.208.0/assert/assert_match.ts": "c4083f80600bc190309903c95e397a7c9257ff8b5ae5c7ef91e834704e672e9b",
+    "https://deno.land/std@0.208.0/assert/assert_not_equals.ts": "9f1acab95bd1f5fc9a1b17b8027d894509a745d91bac1718fdab51dc76831754",
+    "https://deno.land/std@0.208.0/assert/assert_not_instance_of.ts": "0c14d3dfd9ab7a5276ed8ed0b18c703d79a3d106102077ec437bfe7ed912bd22",
+    "https://deno.land/std@0.208.0/assert/assert_not_match.ts": "3796a5b0c57a1ce6c1c57883dd4286be13a26f715ea662318ab43a8491a13ab0",
+    "https://deno.land/std@0.208.0/assert/assert_not_strict_equals.ts": "4cdef83df17488df555c8aac1f7f5ec2b84ad161b6d0645ccdbcc17654e80c99",
+    "https://deno.land/std@0.208.0/assert/assert_object_match.ts": "d8fc2867cfd92eeacf9cea621e10336b666de1874a6767b5ec48988838370b54",
+    "https://deno.land/std@0.208.0/assert/assert_rejects.ts": "45c59724de2701e3b1f67c391d6c71c392363635aad3f68a1b3408f9efca0057",
+    "https://deno.land/std@0.208.0/assert/assert_strict_equals.ts": "b1f538a7ea5f8348aeca261d4f9ca603127c665e0f2bbfeb91fa272787c87265",
+    "https://deno.land/std@0.208.0/assert/assert_string_includes.ts": "b821d39ebf5cb0200a348863c86d8c4c4b398e02012ce74ad15666fc4b631b0c",
+    "https://deno.land/std@0.208.0/assert/assert_throws.ts": "63784e951475cb7bdfd59878cd25a0931e18f6dc32a6077c454b2cd94f4f4bcd",
+    "https://deno.land/std@0.208.0/assert/assertion_error.ts": "4d0bde9b374dfbcbe8ac23f54f567b77024fb67dbb1906a852d67fe050d42f56",
+    "https://deno.land/std@0.208.0/assert/equal.ts": "9f1a46d5993966d2596c44e5858eec821859b45f783a5ee2f7a695dfc12d8ece",
+    "https://deno.land/std@0.208.0/assert/fail.ts": "c36353d7ae6e1f7933d45f8ea51e358c8c4b67d7e7502028598fe1fea062e278",
+    "https://deno.land/std@0.208.0/assert/mod.ts": "37c49a26aae2b254bbe25723434dc28cd7532e444cf0b481a97c045d110ec085",
+    "https://deno.land/std@0.208.0/assert/unimplemented.ts": "d56fbeecb1f108331a380f72e3e010a1f161baa6956fd0f7cf3e095ae1a4c75a",
+    "https://deno.land/std@0.208.0/assert/unreachable.ts": "4600dc0baf7d9c15a7f7d234f00c23bca8f3eba8b140286aaca7aa998cf9a536",
+    "https://deno.land/std@0.208.0/fmt/colors.ts": "34b3f77432925eb72cf0bfb351616949746768620b8e5ead66da532f93d10ba2",
+    "https://deno.land/std@0.208.0/testing/_test_suite.ts": "30f018feeb3835f12ab198d8a518f9089b1bcb2e8c838a8b615ab10d5005465c",
+    "https://deno.land/std@0.208.0/testing/bdd.ts": "c41f019786c4a9112aadb7e5a7bbcc711f58429ac5904b3855fa248ba5fa0ba6",
+    "https://deno.land/std@0.224.0/assert/_constants.ts": "a271e8ef5a573f1df8e822a6eb9d09df064ad66a4390f21b3e31f820a38e0975",
+    "https://deno.land/std@0.224.0/assert/assert.ts": "09d30564c09de846855b7b071e62b5974b001bb72a4b797958fe0660e7849834",
+    "https://deno.land/std@0.224.0/assert/assert_almost_equals.ts": "9e416114322012c9a21fa68e187637ce2d7df25bcbdbfd957cd639e65d3cf293",
+    "https://deno.land/std@0.224.0/assert/assert_array_includes.ts": "14c5094471bc8e4a7895fc6aa5a184300d8a1879606574cb1cd715ef36a4a3c7",
+    "https://deno.land/std@0.224.0/assert/assert_equals.ts": "3bbca947d85b9d374a108687b1a8ba3785a7850436b5a8930d81f34a32cb8c74",
+    "https://deno.land/std@0.224.0/assert/assert_exists.ts": "43420cf7f956748ae6ed1230646567b3593cb7a36c5a5327269279c870c5ddfd",
+    "https://deno.land/std@0.224.0/assert/assert_false.ts": "3e9be8e33275db00d952e9acb0cd29481a44fa0a4af6d37239ff58d79e8edeff",
+    "https://deno.land/std@0.224.0/assert/assert_greater.ts": "5e57b201fd51b64ced36c828e3dfd773412c1a6120c1a5a99066c9b261974e46",
+    "https://deno.land/std@0.224.0/assert/assert_greater_or_equal.ts": "9870030f997a08361b6f63400273c2fb1856f5db86c0c3852aab2a002e425c5b",
+    "https://deno.land/std@0.224.0/assert/assert_instance_of.ts": "e22343c1fdcacfaea8f37784ad782683ec1cf599ae9b1b618954e9c22f376f2c",
+    "https://deno.land/std@0.224.0/assert/assert_is_error.ts": "f856b3bc978a7aa6a601f3fec6603491ab6255118afa6baa84b04426dd3cc491",
+    "https://deno.land/std@0.224.0/assert/assert_less.ts": "60b61e13a1982865a72726a5fa86c24fad7eb27c3c08b13883fb68882b307f68",
+    "https://deno.land/std@0.224.0/assert/assert_less_or_equal.ts": "d2c84e17faba4afe085e6c9123a63395accf4f9e00150db899c46e67420e0ec3",
+    "https://deno.land/std@0.224.0/assert/assert_match.ts": "ace1710dd3b2811c391946954234b5da910c5665aed817943d086d4d4871a8b7",
+    "https://deno.land/std@0.224.0/assert/assert_not_equals.ts": "78d45dd46133d76ce624b2c6c09392f6110f0df9b73f911d20208a68dee2ef29",
+    "https://deno.land/std@0.224.0/assert/assert_not_instance_of.ts": "3434a669b4d20cdcc5359779301a0588f941ffdc2ad68803c31eabdb4890cf7a",
+    "https://deno.land/std@0.224.0/assert/assert_not_match.ts": "df30417240aa2d35b1ea44df7e541991348a063d9ee823430e0b58079a72242a",
+    "https://deno.land/std@0.224.0/assert/assert_not_strict_equals.ts": "37f73880bd672709373d6dc2c5f148691119bed161f3020fff3548a0496f71b8",
+    "https://deno.land/std@0.224.0/assert/assert_object_match.ts": "411450fd194fdaabc0089ae68f916b545a49d7b7e6d0026e84a54c9e7eed2693",
+    "https://deno.land/std@0.224.0/assert/assert_rejects.ts": "4bee1d6d565a5b623146a14668da8f9eb1f026a4f338bbf92b37e43e0aa53c31",
+    "https://deno.land/std@0.224.0/assert/assert_strict_equals.ts": "b4f45f0fd2e54d9029171876bd0b42dd9ed0efd8f853ab92a3f50127acfa54f5",
+    "https://deno.land/std@0.224.0/assert/assert_string_includes.ts": "496b9ecad84deab72c8718735373feb6cdaa071eb91a98206f6f3cb4285e71b8",
+    "https://deno.land/std@0.224.0/assert/assert_throws.ts": "c6508b2879d465898dab2798009299867e67c570d7d34c90a2d235e4553906eb",
+    "https://deno.land/std@0.224.0/assert/assertion_error.ts": "ba8752bd27ebc51f723702fac2f54d3e94447598f54264a6653d6413738a8917",
+    "https://deno.land/std@0.224.0/assert/equal.ts": "bddf07bb5fc718e10bb72d5dc2c36c1ce5a8bdd3b647069b6319e07af181ac47",
+    "https://deno.land/std@0.224.0/assert/fail.ts": "0eba674ffb47dff083f02ced76d5130460bff1a9a68c6514ebe0cdea4abadb68",
+    "https://deno.land/std@0.224.0/assert/mod.ts": "48b8cb8a619ea0b7958ad7ee9376500fe902284bb36f0e32c598c3dc34cbd6f3",
+    "https://deno.land/std@0.224.0/assert/unimplemented.ts": "8c55a5793e9147b4f1ef68cd66496b7d5ba7a9e7ca30c6da070c1a58da723d73",
+    "https://deno.land/std@0.224.0/assert/unreachable.ts": "5ae3dbf63ef988615b93eb08d395dda771c96546565f9e521ed86f6510c29e19",
+    "https://deno.land/std@0.224.0/fmt/colors.ts": "508563c0659dd7198ba4bbf87e97f654af3c34eb56ba790260f252ad8012e1c5",
+    "https://deno.land/std@0.224.0/internal/diff.ts": "6234a4b493ebe65dc67a18a0eb97ef683626a1166a1906232ce186ae9f65f4e6",
+    "https://deno.land/std@0.224.0/internal/format.ts": "0a98ee226fd3d43450245b1844b47003419d34d210fa989900861c79820d21c2",
+    "https://deno.land/std@0.224.0/internal/mod.ts": "534125398c8e7426183e12dc255bb635d94e06d0f93c60a297723abe69d3b22e"
   },
   "workspace": {
     "dependencies": [

--- a/src/admin/urls.ts
+++ b/src/admin/urls.ts
@@ -6,6 +6,7 @@
  * @module
  */
 
+import { getBackend, hasBackend } from "@alexi/db";
 import type { DatabaseBackend } from "@alexi/db";
 import type { AdminSite } from "./site.ts";
 import { renderChangeForm } from "./views/changeform_views.ts";
@@ -444,7 +445,13 @@ export class AdminRouter {
     backend?: DatabaseBackend,
     settings?: Record<string, unknown>,
   ) {
-    this.patterns = getAdminUrls(site, backend, settings);
+    // If no backend is explicitly provided, fall back to the globally registered
+    // default backend from @alexi/db. This mirrors Django's behaviour where
+    // django.conf.settings.DATABASES["default"] is always the active database
+    // regardless of which settings file was imported by the caller.
+    const resolvedBackend = backend ??
+      (hasBackend("default") ? getBackend() : undefined);
+    this.patterns = getAdminUrls(site, resolvedBackend, settings);
   }
 
   /**

--- a/src/core/conf.ts
+++ b/src/core/conf.ts
@@ -1,0 +1,110 @@
+/**
+ * Alexi Global Settings Registry
+ *
+ * Django-style `django.conf.settings` equivalent for Alexi.
+ *
+ * `conf` is a global, lazily-loaded settings proxy that always reflects the
+ * *active* settings module regardless of how the application was started.
+ * It is populated by `getApplication()` / `setup()` and can be imported from
+ * any module without hardcoding the settings file path.
+ *
+ * @module @alexi/core/conf
+ *
+ * @example
+ * ```ts
+ * // Instead of:
+ * import * as settings from "../../project/settings.ts"; // ❌ hardcoded path
+ * const backend = settings.DATABASES.default;
+ *
+ * // Do this:
+ * import { conf } from "@alexi/core";
+ * const backend = conf.DATABASES?.default;              // ✅ always active settings
+ * ```
+ */
+
+import type { GetApplicationSettings } from "./get_application.ts";
+
+// =============================================================================
+// Module-level global state
+// =============================================================================
+
+let _settings: GetApplicationSettings | null = null;
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Configure the global settings registry.
+ *
+ * This is called automatically by `getApplication()`. You do not normally need
+ * to call this directly.
+ *
+ * @param settings - The settings object passed to `getApplication()`
+ */
+export function configureSettings(settings: GetApplicationSettings): void {
+  _settings = settings;
+}
+
+/**
+ * Reset the global settings registry.
+ *
+ * Clears the stored settings. Useful in tests.
+ */
+export function resetSettings(): void {
+  _settings = null;
+}
+
+/**
+ * Whether the global settings registry has been configured.
+ */
+export function isSettingsConfigured(): boolean {
+  return _settings !== null;
+}
+
+/**
+ * Global settings proxy — always reflects the active settings module.
+ *
+ * This is the Alexi equivalent of Django's `django.conf.settings`.
+ * Access it after `getApplication()` has been called.
+ *
+ * @example
+ * ```ts
+ * import { conf } from "@alexi/core";
+ *
+ * // In a view, middleware, or any module:
+ * const debug = conf.DEBUG ?? false;
+ * const db = conf.DATABASES?.default;
+ * ```
+ *
+ * @throws {Error} If accessed before `getApplication()` has been called.
+ */
+export const conf: GetApplicationSettings = new Proxy(
+  {} as GetApplicationSettings,
+  {
+    get(_target, prop: string | symbol) {
+      if (_settings === null) {
+        throw new Error(
+          "Alexi settings are not configured. " +
+            "Call getApplication(settings) before accessing conf.",
+        );
+      }
+      return _settings[prop as keyof GetApplicationSettings];
+    },
+
+    has(_target, prop: string | symbol) {
+      if (_settings === null) return false;
+      return prop in _settings;
+    },
+
+    ownKeys(_target) {
+      if (_settings === null) return [];
+      return Reflect.ownKeys(_settings);
+    },
+
+    getOwnPropertyDescriptor(_target, prop: string | symbol) {
+      if (_settings === null) return undefined;
+      return Object.getOwnPropertyDescriptor(_settings, prop);
+    },
+  },
+);

--- a/src/core/get_application.ts
+++ b/src/core/get_application.ts
@@ -12,6 +12,7 @@
 
 import { Application } from "./application.ts";
 import type { ApplicationOptions } from "./application.ts";
+import { configureSettings } from "./conf.ts";
 import { setup } from "./setup.ts";
 import type { DatabasesConfig } from "./setup.ts";
 import type { URLPattern } from "@alexi/urls";
@@ -101,6 +102,9 @@ export interface GetApplicationSettings {
 export async function getApplication(
   settings: GetApplicationSettings,
 ): Promise<Application> {
+  // 0. Store settings in the global registry (django.conf.settings equivalent)
+  configureSettings(settings);
+
   // 1. Initialise databases (if configured)
   if (settings.DATABASES) {
     await setup({ DATABASES: settings.DATABASES });

--- a/src/core/mod.ts
+++ b/src/core/mod.ts
@@ -54,3 +54,15 @@ export type { GetApplicationSettings } from "./get_application.ts";
 
 export { setup } from "./setup.ts";
 export type { DatabasesConfig } from "./setup.ts";
+
+// =============================================================================
+// Global Settings Registry (Django-style django.conf.settings)
+// =============================================================================
+
+export {
+  conf,
+  configureSettings,
+  isSettingsConfigured,
+  resetSettings,
+} from "./conf.ts";
+export type { GetApplicationSettings as ConfSettings } from "./get_application.ts";

--- a/src/core/tests/conf_test.ts
+++ b/src/core/tests/conf_test.ts
@@ -1,0 +1,72 @@
+/**
+ * Tests for the global settings registry (conf)
+ */
+
+import { assertEquals, assertThrows } from "jsr:@std/assert@1";
+import {
+  conf,
+  configureSettings,
+  isSettingsConfigured,
+  resetSettings,
+} from "../conf.ts";
+
+Deno.test("conf: throws before configuration", () => {
+  resetSettings();
+  assertThrows(
+    () => conf.DEBUG,
+    Error,
+    "Alexi settings are not configured",
+  );
+});
+
+Deno.test("conf: isSettingsConfigured returns false before configure", () => {
+  resetSettings();
+  assertEquals(isSettingsConfigured(), false);
+});
+
+Deno.test("conf: isSettingsConfigured returns true after configure", () => {
+  resetSettings();
+  configureSettings({ DEBUG: true });
+  assertEquals(isSettingsConfigured(), true);
+  resetSettings();
+});
+
+Deno.test("conf: reads settings after configureSettings", () => {
+  resetSettings();
+  configureSettings({ DEBUG: true });
+  assertEquals(conf.DEBUG, true);
+  resetSettings();
+});
+
+Deno.test("conf: reads undefined for missing keys", () => {
+  resetSettings();
+  configureSettings({ DEBUG: false });
+  assertEquals(conf.DATABASES, undefined);
+  resetSettings();
+});
+
+Deno.test("conf: reflects updated settings after reconfiguration", () => {
+  resetSettings();
+  configureSettings({ DEBUG: false });
+  assertEquals(conf.DEBUG, false);
+
+  configureSettings({ DEBUG: true });
+  assertEquals(conf.DEBUG, true);
+  resetSettings();
+});
+
+Deno.test("conf: reads all configured fields correctly", () => {
+  resetSettings();
+  const mockSettings = {
+    DEBUG: true,
+    DATABASES: undefined,
+    MIDDLEWARE: [],
+  };
+  configureSettings(mockSettings);
+
+  assertEquals(conf.DEBUG, true);
+  assertEquals(conf.DATABASES, undefined);
+  assertEquals(conf.MIDDLEWARE, []);
+
+  resetSettings();
+});


### PR DESCRIPTION
## Summary

- Adds `conf` — a global settings proxy (Django's `django.conf.settings` equivalent) populated by `getApplication()`, accessible anywhere without hardcoded import paths
- Fixes `AdminRouter` to fall back to `getBackend()` when no explicit backend is passed, resolving the production login failure when `http.ts` uses a different settings file than `urls.ts` imports
- Exports `conf`, `configureSettings`, `resetSettings`, `isSettingsConfigured` from `@alexi/core`

Closes #210