### PR TITLE
refactor(types): lean AppConfig — identity metadata only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1736,27 +1736,30 @@ templateView({
 
 Reads from disk and does simple `{{KEY}}` replacement. No template inheritance.
 
-### `AppConfig.templatesDir`
+### Template Auto-Discovery
 
-Add `templatesDir` to your app config so templates are automatically available
-at runtime:
+Templates are auto-discovered by convention from `<appPath>/templates/`. Set
+`appPath` in your app config to help the framework locate the directory:
 
 ```typescript
 const config: AppConfig = {
   name: "my-app",
-  templatesDir: new URL("./templates/", import.meta.url).href,
-  // or for project-local apps:
-  // templatesDir: "src/my-app/templates",
+  // Published packages use a file:// URL so the runtime knows the absolute path:
+  appPath: new URL("./", import.meta.url).href,
+  // Project-local apps default to ./src/<name> — set appPath explicitly when
+  // the directory differs:
+  // appPath: "src/my-app",
 };
 ```
 
 **`runserver` auto-loading:** At startup, `runserver` scans each installed app's
-`templatesDir` and registers all `.html` files into the global
+`<appPath>/templates/` directory and registers all `.html` files into the global
 `templateRegistry`. Templates are available immediately in `templateView`
 without any manual registration.
 
 **`bundle` auto-embedding:** When building a Service Worker bundle, `bundle`
-scans each installed app's `templatesDir` and embeds all `.html` files as a
+discovers templates via the `TEMPLATES` setting (`APP_DIRS: true`) or an
+explicit `templatesDir` in `ASSETFILES_DIRS`, and embeds all `.html` files as a
 virtual esbuild module (`alexi:templates`). This ensures templates are available
 in the SW context at runtime without requiring filesystem access.
 
@@ -2133,7 +2136,7 @@ The `browser` type generates:
 
 ```
 src/my-app/
-├── app.ts              # AppConfig with staticfiles[] (2 entry points)
+├── app.ts              # AppConfig (name, verboseName, appPath)
 ├── mod.ts              # Re-exports models, views, urls, endpoints
 ├── models.ts           # ORM models (IndexedDB)
 ├── endpoints.ts        # REST endpoint definitions
@@ -2150,12 +2153,15 @@ src/my-app/
         └── index.html  # Home page template extending base
 ```
 
-The `app.ts` uses `staticfiles` (not `bundle`) to declare both outputs:
+Build targets are declared in project settings via `ASSETFILES_DIRS`:
 
 ```typescript
-staticfiles: [
-  { entrypoint: "./worker.ts", outputFile: "./static/my-app/worker.js" },
-  { entrypoint: "./document.ts", outputFile: "./static/my-app/document.js" },
+export const ASSETFILES_DIRS = [
+  {
+    path: "./src/my-app",
+    outputDir: "./src/my-app/static/my-app",
+    entrypoints: ["worker.ts", "document.ts"],
+  },
 ];
 ```
 

--- a/deno.lock
+++ b/deno.lock
@@ -3,6 +3,7 @@
   "specifiers": {
     "jsr:@luca/esbuild-deno-loader@~0.11.1": "0.11.1",
     "jsr:@std/assert@*": "1.0.19",
+    "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/bytes@^1.0.2": "1.0.6",
     "jsr:@std/encoding@^1.0.5": "1.0.10",
     "jsr:@std/fs@^1.0.19": "1.0.23",
@@ -15,7 +16,8 @@
     "jsr:@zip-js/zip-js@^2.8.7": "2.8.22",
     "npm:esbuild@0.24": "0.24.2",
     "npm:fake-indexeddb@6": "6.2.5",
-    "npm:pg@8": "8.19.0"
+    "npm:pg@8": "8.19.0",
+    "npm:playwright@^1.48.0": "1.58.2"
   },
   "jsr": {
     "@luca/esbuild-deno-loader@0.11.1": {
@@ -227,6 +229,11 @@
     "fake-indexeddb@6.2.5": {
       "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w=="
     },
+    "fsevents@2.3.2": {
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "os": ["darwin"],
+      "scripts": true
+    },
     "pg-cloudflare@1.3.0": {
       "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ=="
     },
@@ -274,6 +281,20 @@
         "split2"
       ]
     },
+    "playwright-core@1.58.2": {
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "bin": true
+    },
+    "playwright@1.58.2": {
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dependencies": [
+        "playwright-core"
+      ],
+      "optionalDependencies": [
+        "fsevents"
+      ],
+      "bin": true
+    },
     "postgres-array@2.0.0": {
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
     },
@@ -295,6 +316,75 @@
     "xtend@4.0.2": {
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     }
+  },
+  "remote": {
+    "https://deno.land/std@0.208.0/assert/_constants.ts": "8a9da298c26750b28b326b297316cdde860bc237533b07e1337c021379e6b2a9",
+    "https://deno.land/std@0.208.0/assert/_diff.ts": "58e1461cc61d8eb1eacbf2a010932bf6a05b79344b02ca38095f9b805795dc48",
+    "https://deno.land/std@0.208.0/assert/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
+    "https://deno.land/std@0.208.0/assert/assert.ts": "9a97dad6d98c238938e7540736b826440ad8c1c1e54430ca4c4e623e585607ee",
+    "https://deno.land/std@0.208.0/assert/assert_almost_equals.ts": "e15ca1f34d0d5e0afae63b3f5d975cbd18335a132e42b0c747d282f62ad2cd6c",
+    "https://deno.land/std@0.208.0/assert/assert_array_includes.ts": "6856d7f2c3544bc6e62fb4646dfefa3d1df5ff14744d1bca19f0cbaf3b0d66c9",
+    "https://deno.land/std@0.208.0/assert/assert_equals.ts": "d8ec8a22447fbaf2fc9d7c3ed2e66790fdb74beae3e482855d75782218d68227",
+    "https://deno.land/std@0.208.0/assert/assert_exists.ts": "407cb6b9fb23a835cd8d5ad804e2e2edbbbf3870e322d53f79e1c7a512e2efd7",
+    "https://deno.land/std@0.208.0/assert/assert_false.ts": "0ccbcaae910f52c857192ff16ea08bda40fdc79de80846c206bfc061e8c851c6",
+    "https://deno.land/std@0.208.0/assert/assert_greater.ts": "ae2158a2d19313bf675bf7251d31c6dc52973edb12ac64ac8fc7064152af3e63",
+    "https://deno.land/std@0.208.0/assert/assert_greater_or_equal.ts": "1439da5ebbe20855446cac50097ac78b9742abe8e9a43e7de1ce1426d556e89c",
+    "https://deno.land/std@0.208.0/assert/assert_instance_of.ts": "3aedb3d8186e120812d2b3a5dea66a6e42bf8c57a8bd927645770bd21eea554c",
+    "https://deno.land/std@0.208.0/assert/assert_is_error.ts": "c21113094a51a296ffaf036767d616a78a2ae5f9f7bbd464cd0197476498b94b",
+    "https://deno.land/std@0.208.0/assert/assert_less.ts": "aec695db57db42ec3e2b62e97e1e93db0063f5a6ec133326cc290ff4b71b47e4",
+    "https://deno.land/std@0.208.0/assert/assert_less_or_equal.ts": "5fa8b6a3ffa20fd0a05032fe7257bf985d207b85685fdbcd23651b70f928c848",
+    "https://deno.land/std@0.208.0/assert/assert_match.ts": "c4083f80600bc190309903c95e397a7c9257ff8b5ae5c7ef91e834704e672e9b",
+    "https://deno.land/std@0.208.0/assert/assert_not_equals.ts": "9f1acab95bd1f5fc9a1b17b8027d894509a745d91bac1718fdab51dc76831754",
+    "https://deno.land/std@0.208.0/assert/assert_not_instance_of.ts": "0c14d3dfd9ab7a5276ed8ed0b18c703d79a3d106102077ec437bfe7ed912bd22",
+    "https://deno.land/std@0.208.0/assert/assert_not_match.ts": "3796a5b0c57a1ce6c1c57883dd4286be13a26f715ea662318ab43a8491a13ab0",
+    "https://deno.land/std@0.208.0/assert/assert_not_strict_equals.ts": "4cdef83df17488df555c8aac1f7f5ec2b84ad161b6d0645ccdbcc17654e80c99",
+    "https://deno.land/std@0.208.0/assert/assert_object_match.ts": "d8fc2867cfd92eeacf9cea621e10336b666de1874a6767b5ec48988838370b54",
+    "https://deno.land/std@0.208.0/assert/assert_rejects.ts": "45c59724de2701e3b1f67c391d6c71c392363635aad3f68a1b3408f9efca0057",
+    "https://deno.land/std@0.208.0/assert/assert_strict_equals.ts": "b1f538a7ea5f8348aeca261d4f9ca603127c665e0f2bbfeb91fa272787c87265",
+    "https://deno.land/std@0.208.0/assert/assert_string_includes.ts": "b821d39ebf5cb0200a348863c86d8c4c4b398e02012ce74ad15666fc4b631b0c",
+    "https://deno.land/std@0.208.0/assert/assert_throws.ts": "63784e951475cb7bdfd59878cd25a0931e18f6dc32a6077c454b2cd94f4f4bcd",
+    "https://deno.land/std@0.208.0/assert/assertion_error.ts": "4d0bde9b374dfbcbe8ac23f54f567b77024fb67dbb1906a852d67fe050d42f56",
+    "https://deno.land/std@0.208.0/assert/equal.ts": "9f1a46d5993966d2596c44e5858eec821859b45f783a5ee2f7a695dfc12d8ece",
+    "https://deno.land/std@0.208.0/assert/fail.ts": "c36353d7ae6e1f7933d45f8ea51e358c8c4b67d7e7502028598fe1fea062e278",
+    "https://deno.land/std@0.208.0/assert/mod.ts": "37c49a26aae2b254bbe25723434dc28cd7532e444cf0b481a97c045d110ec085",
+    "https://deno.land/std@0.208.0/assert/unimplemented.ts": "d56fbeecb1f108331a380f72e3e010a1f161baa6956fd0f7cf3e095ae1a4c75a",
+    "https://deno.land/std@0.208.0/assert/unreachable.ts": "4600dc0baf7d9c15a7f7d234f00c23bca8f3eba8b140286aaca7aa998cf9a536",
+    "https://deno.land/std@0.208.0/fmt/colors.ts": "34b3f77432925eb72cf0bfb351616949746768620b8e5ead66da532f93d10ba2",
+    "https://deno.land/std@0.208.0/testing/_test_suite.ts": "30f018feeb3835f12ab198d8a518f9089b1bcb2e8c838a8b615ab10d5005465c",
+    "https://deno.land/std@0.208.0/testing/bdd.ts": "c41f019786c4a9112aadb7e5a7bbcc711f58429ac5904b3855fa248ba5fa0ba6",
+    "https://deno.land/std@0.224.0/assert/_constants.ts": "a271e8ef5a573f1df8e822a6eb9d09df064ad66a4390f21b3e31f820a38e0975",
+    "https://deno.land/std@0.224.0/assert/assert.ts": "09d30564c09de846855b7b071e62b5974b001bb72a4b797958fe0660e7849834",
+    "https://deno.land/std@0.224.0/assert/assert_almost_equals.ts": "9e416114322012c9a21fa68e187637ce2d7df25bcbdbfd957cd639e65d3cf293",
+    "https://deno.land/std@0.224.0/assert/assert_array_includes.ts": "14c5094471bc8e4a7895fc6aa5a184300d8a1879606574cb1cd715ef36a4a3c7",
+    "https://deno.land/std@0.224.0/assert/assert_equals.ts": "3bbca947d85b9d374a108687b1a8ba3785a7850436b5a8930d81f34a32cb8c74",
+    "https://deno.land/std@0.224.0/assert/assert_exists.ts": "43420cf7f956748ae6ed1230646567b3593cb7a36c5a5327269279c870c5ddfd",
+    "https://deno.land/std@0.224.0/assert/assert_false.ts": "3e9be8e33275db00d952e9acb0cd29481a44fa0a4af6d37239ff58d79e8edeff",
+    "https://deno.land/std@0.224.0/assert/assert_greater.ts": "5e57b201fd51b64ced36c828e3dfd773412c1a6120c1a5a99066c9b261974e46",
+    "https://deno.land/std@0.224.0/assert/assert_greater_or_equal.ts": "9870030f997a08361b6f63400273c2fb1856f5db86c0c3852aab2a002e425c5b",
+    "https://deno.land/std@0.224.0/assert/assert_instance_of.ts": "e22343c1fdcacfaea8f37784ad782683ec1cf599ae9b1b618954e9c22f376f2c",
+    "https://deno.land/std@0.224.0/assert/assert_is_error.ts": "f856b3bc978a7aa6a601f3fec6603491ab6255118afa6baa84b04426dd3cc491",
+    "https://deno.land/std@0.224.0/assert/assert_less.ts": "60b61e13a1982865a72726a5fa86c24fad7eb27c3c08b13883fb68882b307f68",
+    "https://deno.land/std@0.224.0/assert/assert_less_or_equal.ts": "d2c84e17faba4afe085e6c9123a63395accf4f9e00150db899c46e67420e0ec3",
+    "https://deno.land/std@0.224.0/assert/assert_match.ts": "ace1710dd3b2811c391946954234b5da910c5665aed817943d086d4d4871a8b7",
+    "https://deno.land/std@0.224.0/assert/assert_not_equals.ts": "78d45dd46133d76ce624b2c6c09392f6110f0df9b73f911d20208a68dee2ef29",
+    "https://deno.land/std@0.224.0/assert/assert_not_instance_of.ts": "3434a669b4d20cdcc5359779301a0588f941ffdc2ad68803c31eabdb4890cf7a",
+    "https://deno.land/std@0.224.0/assert/assert_not_match.ts": "df30417240aa2d35b1ea44df7e541991348a063d9ee823430e0b58079a72242a",
+    "https://deno.land/std@0.224.0/assert/assert_not_strict_equals.ts": "37f73880bd672709373d6dc2c5f148691119bed161f3020fff3548a0496f71b8",
+    "https://deno.land/std@0.224.0/assert/assert_object_match.ts": "411450fd194fdaabc0089ae68f916b545a49d7b7e6d0026e84a54c9e7eed2693",
+    "https://deno.land/std@0.224.0/assert/assert_rejects.ts": "4bee1d6d565a5b623146a14668da8f9eb1f026a4f338bbf92b37e43e0aa53c31",
+    "https://deno.land/std@0.224.0/assert/assert_strict_equals.ts": "b4f45f0fd2e54d9029171876bd0b42dd9ed0efd8f853ab92a3f50127acfa54f5",
+    "https://deno.land/std@0.224.0/assert/assert_string_includes.ts": "496b9ecad84deab72c8718735373feb6cdaa071eb91a98206f6f3cb4285e71b8",
+    "https://deno.land/std@0.224.0/assert/assert_throws.ts": "c6508b2879d465898dab2798009299867e67c570d7d34c90a2d235e4553906eb",
+    "https://deno.land/std@0.224.0/assert/assertion_error.ts": "ba8752bd27ebc51f723702fac2f54d3e94447598f54264a6653d6413738a8917",
+    "https://deno.land/std@0.224.0/assert/equal.ts": "bddf07bb5fc718e10bb72d5dc2c36c1ce5a8bdd3b647069b6319e07af181ac47",
+    "https://deno.land/std@0.224.0/assert/fail.ts": "0eba674ffb47dff083f02ced76d5130460bff1a9a68c6514ebe0cdea4abadb68",
+    "https://deno.land/std@0.224.0/assert/mod.ts": "48b8cb8a619ea0b7958ad7ee9376500fe902284bb36f0e32c598c3dc34cbd6f3",
+    "https://deno.land/std@0.224.0/assert/unimplemented.ts": "8c55a5793e9147b4f1ef68cd66496b7d5ba7a9e7ca30c6da070c1a58da723d73",
+    "https://deno.land/std@0.224.0/assert/unreachable.ts": "5ae3dbf63ef988615b93eb08d395dda771c96546565f9e521ed86f6510c29e19",
+    "https://deno.land/std@0.224.0/fmt/colors.ts": "508563c0659dd7198ba4bbf87e97f654af3c34eb56ba790260f252ad8012e1c5",
+    "https://deno.land/std@0.224.0/internal/diff.ts": "6234a4b493ebe65dc67a18a0eb97ef683626a1166a1906232ce186ae9f65f4e6",
+    "https://deno.land/std@0.224.0/internal/format.ts": "0a98ee226fd3d43450245b1844b47003419d34d210fa989900861c79820d21c2",
+    "https://deno.land/std@0.224.0/internal/mod.ts": "534125398c8e7426183e12dc255bb635d94e06d0f93c60a297723abe69d3b22e"
   },
   "workspace": {
     "dependencies": [

--- a/src/admin/app.ts
+++ b/src/admin/app.ts
@@ -21,16 +21,11 @@ const config: AppConfig = {
   verboseName: "Alexi Admin",
 
   /**
-   * URL configuration module.
+   * Explicit app path using import.meta.url so the path resolves correctly
+   * whether the package is loaded from JSR cache, a local path, or any other
+   * location.
    */
-  urlsModule: "./urls.ts",
-
-  /**
-   * Static files directory.
-   * Uses import.meta.url so the path resolves correctly whether the package
-   * is loaded from JSR cache, a local path, or any other location.
-   */
-  staticDir: new URL("./static/", import.meta.url).href,
+  appPath: new URL("./", import.meta.url).href,
 };
 
 export default config;

--- a/src/auth/app.ts
+++ b/src/auth/app.ts
@@ -12,8 +12,7 @@ import type { AppConfig } from "@alexi/types";
 const config: AppConfig = {
   name: "alexi_auth",
   verboseName: "Alexi Authentication",
-  commandsModule: "./commands/mod.ts",
-  commandsImport: () => import("./commands/mod.ts"),
+  appPath: new URL("./", import.meta.url).href,
 };
 
 export default config;

--- a/src/capacitor/app.ts
+++ b/src/capacitor/app.ts
@@ -20,11 +20,7 @@ const config: AppConfig = {
    */
   verboseName: "Alexi Capacitor",
 
-  /**
-   * Commands module for mobile app management.
-   */
-  commandsModule: "./commands/mod.ts",
-  commandsImport: () => import("./commands/mod.ts"),
+  appPath: new URL("./", import.meta.url).href,
 };
 
 export default config;

--- a/src/core/management/management.ts
+++ b/src/core/management/management.ts
@@ -300,6 +300,7 @@ export class ManagementUtility {
    * Load commands from an import function.
    *
    * The import function is called in user's context, so import maps work correctly.
+   * Commands are discovered by convention from `<appPath>/commands/mod.ts`.
    */
   private async loadCommandsFromImportFn(importFn: AppImportFn): Promise<void> {
     try {
@@ -324,30 +325,39 @@ export class ManagementUtility {
         console.log(`Loading commands from app: ${config.name}`);
       }
 
-      // Check if app has commands
-      if (!config.commandsModule && !config.commandsImport) {
-        if (this.debug) {
-          console.log(
-            `  ${config.name}: no commandsModule or commandsImport defined`,
-          );
-        }
-        return;
+      // Resolve the app's source directory from appPath or convention
+      const appPath = config.appPath ?? `./src/${config.name}`;
+      let commandsUrl: string;
+
+      if (appPath.startsWith("file://")) {
+        // Published package: absolute file:// URL — append commands/mod.ts
+        const base = appPath.endsWith("/") ? appPath : `${appPath}/`;
+        commandsUrl = `${base}commands/mod.ts`;
+      } else {
+        // Relative path — resolve against project root
+        const rel = appPath.replace(/^\.\//, "");
+        commandsUrl = toImportUrl(
+          `${this.projectRoot}/${rel}/commands/mod.ts`,
+        );
       }
 
-      // Check if app provides a commandsImport function
-      if (
-        config.commandsImport && typeof config.commandsImport === "function"
-      ) {
-        // Use the provided import function for commands
-        const commandsModule = await config.commandsImport();
+      // Try to import commands/mod.ts by convention
+      try {
+        const commandsModule = await import(commandsUrl);
         this.registerCommandsFromModule(
           commandsModule as Record<string, unknown>,
           config.name,
         );
-        return;
+      } catch {
+        // No commands/mod.ts — this is normal for most apps
+        if (this.debug) {
+          console.log(
+            `  ${config.name}: no commands/mod.ts found at ${commandsUrl}`,
+          );
+        }
       }
 
-      // Fallback: commands might be exported from the main module
+      // Fallback: commands might be exported from the main module itself
       if (module.commands) {
         this.registerCommandsFromModule(
           module.commands as Record<string, unknown>,

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -429,16 +429,8 @@ export { default as capacitorAppConfig } from "./capacitor/app.ts";
 
 export type {
   AppConfig,
-  BundleConfig,
-  CliTargetConfig,
-  DesktopConfig,
-  DesktopSettings,
-  DesktopTargetConfig,
-  SpaTargetConfig,
-  TargetConfig,
-  TargetOutputConfig,
-  TargetType,
-  WebTargetConfig,
+  AssetfilesDirConfig,
+  TemplatesConfig,
 } from "./types/mod.ts";
 
 // =============================================================================

--- a/src/staticfiles/app.ts
+++ b/src/staticfiles/app.ts
@@ -11,8 +11,7 @@ import type { AppConfig } from "@alexi/types";
 const config: AppConfig = {
   name: "alexi_staticfiles",
   verboseName: "Alexi Static Files",
-  commandsModule: "./commands/mod.ts",
-  commandsImport: () => import("./commands/mod.ts"),
+  appPath: new URL("./", import.meta.url).href,
 };
 
 export default config;

--- a/src/staticfiles/commands/bundle.ts
+++ b/src/staticfiles/commands/bundle.ts
@@ -2,18 +2,16 @@
  * Bundle Command for Alexi Static Files
  *
  * Django-style command that bundles TypeScript frontends to JavaScript.
- * Reads INSTALLED_APPS and finds apps with bundle configuration, and also
- * reads ASSETFILES_DIRS from project settings for the new settings-level
- * bundle configuration.
+ * Reads ASSETFILES_DIRS from project settings to find build targets.
  *
  * Uses esbuild with code-splitting for lazy-loading templates.
  *
  * Template embedding:
- * When bundling a Service Worker (outputName ends with .js and app has
- * bundle config), all installed apps' `templatesDir` directories are scanned
- * recursively and their `.html` files are embedded into the bundle via a
- * virtual esbuild module. This populates `templateRegistry` at runtime so
- * that `templateView` works without filesystem access inside a Service Worker.
+ * When bundling a Service Worker, all installed apps' `templates/` directories
+ * are scanned recursively (via the TEMPLATES setting with APP_DIRS: true) and
+ * their `.html` files are embedded into the bundle via a virtual esbuild
+ * module. This populates `templateRegistry` at runtime so that `templateView`
+ * works without filesystem access inside a Service Worker.
  *
  * @module @alexi/staticfiles/commands/bundle
  */
@@ -33,8 +31,6 @@ import type {
 import type {
   AppConfig,
   AssetfilesDirConfig,
-  BundleConfig,
-  StaticfileConfig,
   TemplatesConfig,
 } from "@alexi/types";
 import type * as esbuild from "esbuild";
@@ -67,8 +63,7 @@ interface BundleResult {
 }
 
 /**
- * A normalised build target derived from either ASSETFILES_DIRS (new) or
- * AppConfig.bundle / AppConfig.staticfiles (legacy).
+ * A normalised build target derived from ASSETFILES_DIRS project settings.
  */
 interface BuildTarget {
   /** Display name shown in progress output */
@@ -201,47 +196,10 @@ export async function scanTemplatesDir(
 }
 
 /**
- * Scan all installed apps' `templatesDir` directories and return the
- * combined list of discovered templates.
- *
- * @param importFunctions - Array of app import functions from INSTALLED_APPS
- * @param projectRoot     - Absolute path to the project root
- *
- * @internal Exported for testing only.
- */
-export async function collectAllTemplates(
-  importFunctions: AppImportFn[],
-  projectRoot: string,
-): Promise<DiscoveredTemplate[]> {
-  const allTemplates: DiscoveredTemplate[] = [];
-
-  for (const importFn of importFunctions) {
-    try {
-      const module = await importFn();
-      const config = module.default as AppConfig | undefined;
-      if (!config?.templatesDir) continue;
-
-      const dir = resolveTemplatesDir(config.templatesDir, projectRoot);
-      if (!dir) continue;
-
-      const templates = await scanTemplatesDir(dir);
-      allTemplates.push(...templates);
-    } catch {
-      // Skip apps that fail to load
-    }
-  }
-
-  return allTemplates;
-}
-
-/**
  * Collect templates using the Django-style TEMPLATES setting.
  *
  * When `APP_DIRS: true`, auto-discovers `<appPath>/templates/` for each
  * installed app.  `DIRS` entries add explicit extra directories.
- *
- * Falls back to `collectAllTemplates()` (legacy `config.templatesDir`) when
- * no TEMPLATES setting is provided.
  *
  * @param templatesConfig - Array from the `TEMPLATES` project setting
  * @param importFunctions - Array of app import functions from INSTALLED_APPS
@@ -471,10 +429,10 @@ export async function rewriteHtmlReferences(
  * Built-in command for bundling TypeScript frontends
  *
  * This command:
- * 1. Reads INSTALLED_APPS from project settings
- * 2. Finds each app's app.ts configuration
- * 3. Bundles apps that have a bundle configuration
- * 4. Writes output to the app's static directory
+ * 1. Reads ASSETFILES_DIRS from project settings
+ * 2. Bundles each entry point with esbuild
+ * 3. Writes output to the configured output directory
+ * 4. Optionally embeds templates into Service Worker bundles
  *
  * @example Command line usage
  * ```bash
@@ -1016,9 +974,7 @@ export class BundleCommand extends BaseCommand {
   // ===========================================================================
 
   /**
-   * Build the list of targets to bundle, combining:
-   * 1. New-style: ASSETFILES_DIRS entries from project settings
-   * 2. Legacy: AppConfig.staticfiles / AppConfig.bundle from INSTALLED_APPS
+   * Build the list of targets to bundle from ASSETFILES_DIRS project settings.
    */
   private async findAppsToBuild(
     settings: {
@@ -1054,66 +1010,6 @@ export class BundleCommand extends BaseCommand {
           templatesDir: entry.templatesDir,
           entryNames: entry.options?.entryNames,
         });
-      }
-    }
-
-    // --- Legacy: INSTALLED_APPS with AppConfig.bundle / AppConfig.staticfiles ---
-    for (const importFn of settings.importFunctions) {
-      try {
-        const module = await importFn();
-        const config = module.default as AppConfig | undefined;
-
-        if (!config) continue;
-
-        // Skip if targeting a specific app
-        if (targetApp && config.name !== targetApp) continue;
-
-        // Check if app has legacy bundle configuration
-        if (
-          !config.bundle &&
-          (!config.staticfiles || config.staticfiles.length === 0)
-        ) {
-          this.debug(`App ${config.name} has no bundle configuration`, true);
-          continue;
-        }
-
-        const appPath = (config.appPath ?? config.bundle?.appPath ??
-          `./src/${config.name}`).replace(/^\.\//, "");
-
-        if (config.bundle) {
-          const entrypoint = config.bundle.entrypoint.replace(/^\.\//, "");
-          const outputDirRel = config.bundle.outputDir.replace(/^\.\//, "");
-          const entryPoint = `./${appPath}/${entrypoint}`;
-          const outputPath =
-            `./${appPath}/${outputDirRel}/${config.bundle.outputName}`;
-
-          targets.push({
-            name: config.name,
-            entryPoint,
-            outputPath,
-            minify: config.bundle.options?.minify,
-            // Legacy bundle: collect templates from all apps via importFunctions
-          });
-        }
-
-        if (config.staticfiles && config.staticfiles.length > 0) {
-          for (const sf of config.staticfiles) {
-            const entrypoint = sf.entrypoint.replace(/^\.\//, "");
-            const outputFile = sf.outputFile.replace(/^\.\//, "");
-            const entryPoint = `./${appPath}/${entrypoint}`;
-            const outputPath = `./${appPath}/${outputFile}`;
-
-            targets.push({
-              name: `${config.name}/${outputFile.split("/").pop()}`,
-              entryPoint,
-              outputPath,
-              minify: sf.options?.minify,
-              // Legacy staticfiles: collect templates from all apps via importFunctions
-            });
-          }
-        }
-      } catch (error) {
-        this.debug(`Failed to load app: ${error}`, true);
       }
     }
 
@@ -1189,19 +1085,6 @@ export class BundleCommand extends BaseCommand {
       ) {
         templates = await collectTemplatesFromConfig(
           options.templatesConfig,
-          options.importFunctions,
-          this.projectRoot,
-        );
-        if (templates.length > 0) {
-          const outputName = outputPath.split("/").pop() ?? outputPath;
-          this.info(
-            `  Embedding ${templates.length} templates into ${outputName}...`,
-          );
-        }
-      } else if (
-        options.importFunctions && options.importFunctions.length > 0
-      ) {
-        templates = await collectAllTemplates(
           options.importFunctions,
           this.projectRoot,
         );

--- a/src/staticfiles/commands/bundle_test.ts
+++ b/src/staticfiles/commands/bundle_test.ts
@@ -10,7 +10,6 @@ import { assertEquals, assertMatch, assertStringIncludes } from "@std/assert";
 import { join, toFileUrl } from "@std/path";
 import {
   buildSWBundle,
-  collectAllTemplates,
   collectTemplatesFromConfig,
   generateTemplatesModule,
   isServiceWorkerFilename,
@@ -216,61 +215,52 @@ Deno.test(
 );
 
 // =============================================================================
-// collectAllTemplates
+// collectTemplatesFromConfig — APP_DIRS multi-app tests
 // =============================================================================
 
 Deno.test(
-  "collectAllTemplates: collects templates from multiple apps",
+  "collectTemplatesFromConfig: APP_DIRS collects templates from multiple apps",
   async () => {
     const tmpDir = await Deno.makeTempDir();
     try {
-      // Set up two apps with template dirs
-      const app1Templates = join(tmpDir, "app1", "templates");
-      const app2Templates = join(tmpDir, "app2", "templates");
-      await Deno.mkdir(join(app1Templates, "app1"), { recursive: true });
-      await Deno.mkdir(join(app2Templates, "app2"), { recursive: true });
+      // Set up two apps each with a convention-based templates/ directory
+      const app1Dir = join(tmpDir, "src", "app1");
+      const app2Dir = join(tmpDir, "src", "app2");
+      await Deno.mkdir(join(app1Dir, "templates", "app1"), {
+        recursive: true,
+      });
+      await Deno.mkdir(join(app2Dir, "templates", "app2"), {
+        recursive: true,
+      });
 
       await Deno.writeTextFile(
-        join(app1Templates, "app1", "page.html"),
+        join(app1Dir, "templates", "app1", "page.html"),
         "<p>App1</p>",
       );
       await Deno.writeTextFile(
-        join(app2Templates, "app2", "home.html"),
+        join(app2Dir, "templates", "app2", "home.html"),
         "<p>App2</p>",
       );
-
-      // Create mock import functions that return AppConfig-like objects.
-      // Use file:// URLs so resolveTemplatesDir handles them as absolute paths
-      // on all platforms (avoids the relative-path branch).
-      const app1Url =
-        new URL(`file://${app1Templates.replace(/\\/g, "/")}`).href;
-      const app2Url =
-        new URL(`file://${app2Templates.replace(/\\/g, "/")}`).href;
 
       const importFunctions = [
         () =>
           Promise.resolve({
-            default: {
-              name: "app1",
-              templatesDir: app1Url,
-            },
+            default: { name: "app1", appPath: "src/app1" },
           }),
         () =>
           Promise.resolve({
-            default: {
-              name: "app2",
-              templatesDir: app2Url,
-            },
+            default: { name: "app2", appPath: "src/app2" },
           }),
       ];
 
-      const results = await collectAllTemplates(
+      const results = await collectTemplatesFromConfig(
+        [{ APP_DIRS: true, DIRS: [] }],
         importFunctions as never,
         tmpDir,
       );
 
       assertEquals(results.length, 2);
-      const names = results.map((r) => r.name).sort();
+      const names = results.map((r: { name: string }) => r.name).sort();
       assertEquals(names, ["app1/page.html", "app2/home.html"]);
     } finally {
       await Deno.remove(tmpDir, { recursive: true });
@@ -279,18 +269,19 @@ Deno.test(
 );
 
 Deno.test(
-  "collectAllTemplates: skips apps without templatesDir",
+  "collectTemplatesFromConfig: APP_DIRS skips apps without templates/ dir",
   async () => {
     const tmpDir = await Deno.makeTempDir();
     try {
       const importFunctions = [
         () =>
           Promise.resolve({
-            default: { name: "no-templates" }, // no templatesDir
+            default: { name: "no-templates", appPath: "src/no-templates" },
           }),
       ];
 
-      const results = await collectAllTemplates(
+      const results = await collectTemplatesFromConfig(
+        [{ APP_DIRS: true, DIRS: [] }],
         importFunctions as never,
         tmpDir,
       );
@@ -302,7 +293,7 @@ Deno.test(
 );
 
 Deno.test(
-  "collectAllTemplates: skips apps that fail to import",
+  "collectTemplatesFromConfig: APP_DIRS skips apps that fail to import",
   async () => {
     const tmpDir = await Deno.makeTempDir();
     try {
@@ -310,7 +301,8 @@ Deno.test(
         () => Promise.reject(new Error("import failed")),
       ];
 
-      const results = await collectAllTemplates(
+      const results = await collectTemplatesFromConfig(
+        [{ APP_DIRS: true, DIRS: [] }],
         importFunctions as never,
         tmpDir,
       );

--- a/src/staticfiles/commands/collectstatic.ts
+++ b/src/staticfiles/commands/collectstatic.ts
@@ -352,33 +352,29 @@ export class CollectStaticCommand extends BaseCommand {
           continue;
         }
 
-        // Resolve static directory path
+        // Resolve app directory from appPath or convention
         let staticDir: string;
         let appPath: string;
 
-        if (config.staticDir?.startsWith("file://")) {
-          // Package uses import.meta.url-based path (e.g. @alexi/admin).
-          // Convert file:// URL to a filesystem path directly.
-          const url = new URL(config.staticDir);
+        const rawAppPath = config.appPath ?? `./src/${config.name}`;
+
+        if (rawAppPath.startsWith("file://")) {
+          // Published package: absolute file:// URL — static/ is a subdirectory
+          const url = new URL(rawAppPath);
+          let pathname = url.pathname.replace(/\/$/, "");
           // On Windows, url.pathname is /C:/..., strip leading slash
-          let pathname = url.pathname;
           if (/^\/[a-zA-Z]:\//.test(pathname)) {
             pathname = pathname.slice(1);
           }
-          staticDir = pathname;
-          appPath = config.appPath ?? `./src/${config.name}`;
-        } else if (config.staticDir) {
-          // Legacy: explicit relative staticDir on AppConfig
-          const staticDirRel = config.staticDir.replace(/^\.\//, "");
-          appPath = config.appPath ?? `./src/${config.name}`;
-          const appPathNormalized = appPath.replace(/^\.\//, "");
-          const appDir = `${this.projectRoot}/${appPathNormalized}`;
-          staticDir = `${appDir}/${staticDirRel}`;
+          appPath = rawAppPath;
+          staticDir = `${pathname}/static`;
         } else {
-          // Convention: <appPath>/static/
-          appPath = config.appPath ?? `./src/${config.name}`;
+          // Relative or absolute path
+          appPath = rawAppPath;
           const appPathNormalized = appPath.replace(/^\.\//, "");
-          const appDir = `${this.projectRoot}/${appPathNormalized}`;
+          const appDir = appPath.startsWith("/")
+            ? appPath
+            : `${this.projectRoot}/${appPathNormalized}`;
           staticDir = `${appDir}/static`;
         }
 

--- a/src/staticfiles/commands/collectstatic_test.ts
+++ b/src/staticfiles/commands/collectstatic_test.ts
@@ -2,8 +2,8 @@
  * CollectStatic Command Tests
  *
  * Tests for the collectstatic command, including support for
- * file:// URL-based staticDir values (e.g. from @alexi/admin using
- * `new URL("./static/", import.meta.url).href`).
+ * file:// URL-based appPath values (e.g. from @alexi/admin using
+ * `new URL("./", import.meta.url).href`).
  */
 
 import { assertEquals } from "@std/assert";
@@ -77,7 +77,7 @@ function toFileUrl(absPath: string): string {
 // =============================================================================
 
 Deno.test({
-  name: "collectstatic: copies files from traditional relative staticDir",
+  name: "collectstatic: copies files from traditional relative appPath",
   async fn() {
     const tmpDir = await Deno.makeTempDir({
       prefix: "alexi_collectstatic_test_",
@@ -88,7 +88,7 @@ Deno.test({
       const appConfig: AppConfig = {
         name: "myapp",
         verboseName: "My App",
-        staticDir: "./static",
+        appPath: "./src/myapp",
       };
 
       const { staticRoot } = await createTempProject({
@@ -128,21 +128,22 @@ Deno.test({
 });
 
 Deno.test({
-  name: "collectstatic: copies files from file:// URL-based staticDir",
+  name: "collectstatic: copies files from file:// URL-based appPath",
   async fn() {
     const tmpDir = await Deno.makeTempDir({
       prefix: "alexi_collectstatic_test_",
     });
 
     try {
-      // Simulate a package's static dir resolved via import.meta.url
-      const appStaticDir = join(tmpDir, "pkg_cache", "alexi_admin", "static");
-      const fileUrl = toFileUrl(appStaticDir);
+      // Simulate a package's app dir resolved via import.meta.url
+      const appDir = join(tmpDir, "pkg_cache", "alexi_admin");
+      const appStaticDir = join(appDir, "static");
+      const fileUrl = toFileUrl(appDir);
 
       const appConfig: AppConfig = {
         name: "alexi_admin",
         verboseName: "Alexi Admin",
-        staticDir: fileUrl,
+        appPath: fileUrl,
       };
 
       const { staticRoot } = await createTempProject({
@@ -186,20 +187,21 @@ Deno.test({
 });
 
 Deno.test({
-  name: "collectstatic: skips app when file:// staticDir does not exist",
+  name:
+    "collectstatic: skips app when file:// appPath static dir does not exist",
   async fn() {
     const tmpDir = await Deno.makeTempDir({
       prefix: "alexi_collectstatic_test_",
     });
 
     try {
-      const nonExistentDir = join(tmpDir, "does_not_exist", "static");
-      const fileUrl = toFileUrl(nonExistentDir);
+      const nonExistentAppDir = join(tmpDir, "does_not_exist");
+      const fileUrl = toFileUrl(nonExistentAppDir);
 
       const appConfig: AppConfig = {
         name: "ghost_app",
         verboseName: "Ghost",
-        staticDir: fileUrl,
+        appPath: fileUrl,
       };
 
       const staticRoot = join(tmpDir, "static");

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -319,53 +319,6 @@ export interface TargetConfig {
 // =============================================================================
 
 /**
- * Static file bundle configuration for a single entry point.
- *
- * Used in `AppConfig.staticfiles` to declare multiple bundles per app
- * (e.g. a `worker.ts` Service Worker bundle and a `document.ts` DOM bundle).
- *
- * @deprecated Use `ASSETFILES_DIRS` in project settings instead.
- */
-export interface StaticfileConfig {
-  /**
-   * Entrypoint file for bundling.
-   * Path is relative to the app's directory.
-   *
-   * @example "./worker.ts"
-   * @example "./document.ts"
-   */
-  entrypoint: string;
-
-  /**
-   * Output file path (including filename), relative to the app's directory.
-   *
-   * @example "./static/myapp/worker.js"
-   * @example "./static/myapp/document.js"
-   */
-  outputFile: string;
-
-  /**
-   * Additional options for the bundler.
-   */
-  options?: {
-    /**
-     * Enable minification for production builds.
-     */
-    minify?: boolean;
-
-    /**
-     * Enable source maps.
-     */
-    sourceMaps?: boolean;
-
-    /**
-     * External modules that should not be bundled.
-     */
-    external?: string[];
-  };
-}
-
-/**
  * Configuration for a single asset files directory entry.
  *
  * Replaces `AppConfig.staticfiles` — bundle configuration now lives in
@@ -507,245 +460,33 @@ export interface TemplatesConfig {
 }
 
 /**
- * Bundle configuration for frontend apps.
- */
-export interface BundleConfig {
-  /**
-   * Path to the app directory.
-   * If not specified, derived from app name as `./src/${name}`.
-   *
-   * @example "./src/myapp-ui"
-   */
-  appPath?: string;
-
-  /**
-   * Entrypoint file for bundling.
-   * Path is relative to the app's directory.
-   *
-   * @example "./src/main.ts"
-   */
-  entrypoint: string;
-
-  /**
-   * Output directory for bundled files.
-   * Path is relative to the app's directory.
-   * This is typically the app's static directory.
-   *
-   * @example "./static/comachine"
-   */
-  outputDir: string;
-
-  /**
-   * Output filename for the bundled JavaScript.
-   *
-   * @example "bundle.js"
-   */
-  outputName: string;
-
-  /**
-   * Output filename for CSS (if bundler produces CSS).
-   *
-   * @example "bundle.css"
-   */
-  cssOutputName?: string;
-
-  /**
-   * Additional options for the bundler.
-   */
-  options?: {
-    /**
-     * Enable minification for production builds.
-     */
-    minify?: boolean;
-
-    /**
-     * Enable source maps.
-     */
-    sourceMaps?: boolean;
-
-    /**
-     * External modules that should not be bundled.
-     */
-    external?: string[];
-  };
-}
-
-/**
- * Project-level desktop settings.
- *
- * These settings are defined in project/desktop.settings.ts and apply
- * when running with `--settings desktop`.
- */
-export interface DesktopSettings {
-  /**
-   * Whether desktop mode is enabled.
-   * Set to true in desktop.settings.ts, false/null in web.settings.ts.
-   */
-  enabled?: boolean;
-
-  /**
-   * Window title shown in the title bar.
-   *
-   * @default Project name from settings
-   */
-  title?: string;
-
-  /**
-   * Window width in pixels.
-   *
-   * @default 1280
-   */
-  width?: number;
-
-  /**
-   * Window height in pixels.
-   *
-   * @default 800
-   */
-  height?: number;
-
-  /**
-   * Preferred browser to use.
-   *
-   * @default "any"
-   */
-  browser?: "chrome" | "firefox" | "edge" | "safari" | "chromium" | "any";
-
-  /**
-   * Whether to start in kiosk/fullscreen mode.
-   *
-   * @default false
-   */
-  kiosk?: boolean;
-
-  /**
-   * Whether to show DevTools on startup.
-   *
-   * @default false
-   */
-  devTools?: boolean;
-
-  /**
-   * Custom icon path (relative to project root).
-   *
-   * @example "./assets/icon.png"
-   */
-  icon?: string;
-}
-
-/**
- * Desktop app configuration using WebUI.
- *
- * When an app has this configuration, the `desktop` command
- * can launch it as a native-like desktop application using
- * the user's web browser.
- */
-export interface DesktopConfig {
-  /**
-   * Window title shown in the title bar.
-   *
-   * @example "CoMachine"
-   */
-  title: string;
-
-  /**
-   * Window width in pixels.
-   *
-   * @default 1280
-   */
-  width?: number;
-
-  /**
-   * Window height in pixels.
-   *
-   * @default 800
-   */
-  height?: number;
-
-  /**
-   * Preferred browser to use.
-   * If not specified, WebUI will use any available browser.
-   *
-   * @example "chrome" | "firefox" | "edge" | "any"
-   */
-  browser?: "chrome" | "firefox" | "edge" | "safari" | "chromium" | "any";
-
-  /**
-   * Whether to start the browser in kiosk/fullscreen mode.
-   *
-   * @default false
-   */
-  kiosk?: boolean;
-
-  /**
-   * Custom icon path (relative to app directory).
-   * Used when the app is compiled.
-   *
-   * @example "./assets/icon.png"
-   */
-  icon?: string;
-
-  /**
-   * Whether to hide the browser's URL bar and navigation.
-   * WebUI does this by default in app mode.
-   *
-   * @default true
-   */
-  hideNavigation?: boolean;
-
-  /**
-   * The SPA app name to serve.
-   * This should match an app in INSTALLED_APPS that has bundle config.
-   * If not specified, defaults to the first app with bundle config.
-   *
-   * @example "comachine"
-   */
-  serveApp?: string;
-
-  /**
-   * Port for the embedded HTTP server.
-   * If not specified, uses a random available port.
-   *
-   * @example 8000
-   */
-  port?: number;
-
-  /**
-   * Whether to show DevTools on startup (development only).
-   *
-   * @default false
-   */
-  devTools?: boolean;
-}
-
-/**
  * App configuration.
  *
- * Django-style app configuration that tells the framework
- * what the app contains and how to handle it.
+ * Django-style app configuration that tells the framework what the app is.
+ * Mirrors Django's `AppConfig` — only app identity metadata lives here.
  *
- * Following Django conventions, `AppConfig` contains only app identity
- * metadata (`name`, `verboseName`, `appPath`).  Build and file-serving
- * configuration now lives in project settings:
+ * Build and file-serving configuration belongs in project settings:
  * - `ASSETFILES_DIRS` — TypeScript source directories for the bundler
  * - `STATICFILES_DIRS` — additional static file directories for collectstatic
+ * - `TEMPLATES` — template discovery configuration
  *
- * Per-app static files are auto-discovered by convention from
- * `<appPath>/static/` (like Django's `AppDirectoriesFinder`), and templates
- * from `<appPath>/templates/` at `runserver` time.
+ * Static files are auto-discovered by convention from `<appPath>/static/`
+ * (like Django's `AppDirectoriesFinder`), templates from
+ * `<appPath>/templates/`, and management commands from
+ * `<appPath>/commands/mod.ts`.
  */
 export interface AppConfig {
   /**
-   * App name. Must match the name in INSTALLED_APPS.
+   * App name. Must match the import map key / name in INSTALLED_APPS.
    *
-   * @example "comachine"
+   * @example "my-app"
    */
   name: string;
 
   /**
    * Human-readable name for the app.
    *
-   * @example "CoMachine Frontend"
+   * @example "My App"
    */
   verboseName?: string;
 
@@ -759,119 +500,8 @@ export interface AppConfig {
    * Can be a relative path (resolved against the project root) or an
    * absolute `file://` URL (recommended for published packages).
    *
-   * Path is relative to the project root.
-   *
    * @example "./src/myapp"
-   * @example "file:///path/to/package"
+   * @example "file:///path/to/package"  // new URL("./", import.meta.url).href
    */
   appPath?: string;
-
-  /**
-   * Frontend bundle configuration.
-   * If defined, the `bundle` command will compile TypeScript → JavaScript.
-   *
-   * @deprecated Use `ASSETFILES_DIRS` in project settings instead.
-   */
-  bundle?: BundleConfig;
-
-  /**
-   * Multiple frontend bundle entry points.
-   *
-   * Use this instead of `bundle` when an app produces more than one JS output
-   * (e.g. a browser app with a `worker.ts` Service Worker entry and a
-   * `document.ts` DOM entry).  Each item is bundled independently.
-   *
-   * @deprecated Use `ASSETFILES_DIRS` in project settings instead.
-   *
-   * @example
-   * staticfiles: [
-   *   { entrypoint: "./worker.ts",   outputFile: "./static/myapp/worker.js" },
-   *   { entrypoint: "./document.ts", outputFile: "./static/myapp/document.js" },
-   * ]
-   */
-  staticfiles?: StaticfileConfig[];
-
-  /**
-   * Static files directory.
-   * These files are copied to STATIC_ROOT by the collectstatic command.
-   *
-   * @deprecated Static file discovery is now convention-based (`<appPath>/static/`).
-   * Extra directories can be registered via `STATICFILES_DIRS` in project settings.
-   *
-   * Can be either:
-   * - A path relative to the app's `src/<name>/` directory: `"static"`
-   * - An absolute `file://` URL derived from `import.meta.url` (recommended
-   *   for published packages so the path resolves correctly regardless of
-   *   whether the package is installed from JSR, npm, or a local path):
-   *
-   * @example
-   * // Absolute URL (published packages — works in JSR cache, local dev, etc.)
-   * staticDir: new URL("./static/", import.meta.url).href
-   */
-  staticDir?: string;
-
-  /**
-   * URL patterns module.
-   * Path to a module that exports URL patterns.
-   * Path is relative to the app's directory.
-   *
-   * @example "./urls.ts"
-   */
-  urlsModule?: string;
-
-  /**
-   * Models module.
-   * Path to a module that exports database models.
-   * Path is relative to the app's directory.
-   *
-   * @example "./models/mod.ts"
-   */
-  modelsModule?: string;
-
-  /**
-   * Desktop app configuration.
-   * If defined, the `desktop` command can launch this app
-   * as a desktop application using WebUI.
-   */
-  desktop?: DesktopConfig;
-
-  /**
-   * Management commands provided by this app.
-   * Path to a module that exports command classes.
-   * Path is relative to the app's directory.
-   *
-   * @example "./commands/mod.ts"
-   */
-  commandsModule?: string;
-
-  /**
-   * Import function for loading commands module.
-   *
-   * This is the preferred way to load commands - it runs in the app's
-   * context so import maps work correctly.
-   *
-   * @example () => import("./commands/mod.ts")
-   */
-  commandsImport?: () => Promise<Record<string, unknown>>;
-
-  /**
-   * Template directory for this app.
-   *
-   * @deprecated Template discovery is now convention-based (`<appPath>/templates/`)
-   * at `runserver` time, and `templatesDir` in `ASSETFILES_DIRS` is used for
-   * bundle-time SW template embedding.
-   *
-   * Django-style namespacing: a template named `"my-app/note_list.html"`
-   * should live at `<templatesDir>/my-app/note_list.html`.
-   *
-   * Can be either:
-   * - A path relative to the project root: `"src/my-app/templates"`
-   * - An absolute `file://` URL (recommended for published packages):
-   *   `new URL("./templates/", import.meta.url).href`
-   *
-   * @example
-   * // Absolute URL (published packages)
-   * templatesDir: new URL("./templates/", import.meta.url).href
-   */
-  templatesDir?: string;
 }

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -12,8 +12,7 @@ import type { AppConfig } from "@alexi/types";
 const config: AppConfig = {
   name: "alexi_web",
   verboseName: "Alexi Web Server",
-  commandsModule: "./commands/mod.ts",
-  commandsImport: () => import("./commands/mod.ts"),
+  appPath: new URL("./", import.meta.url).href,
 };
 
 export default config;

--- a/src/web/commands/runserver.ts
+++ b/src/web/commands/runserver.ts
@@ -321,8 +321,7 @@ export class RunServerCommand extends BaseCommand {
         }
       }
     } else {
-      // Legacy fallback: explicit `config.templatesDir` on AppConfig or
-      // convention-based `<appPath>/templates/` auto-discovery
+      // Convention-based: `<appPath>/templates/` auto-discovery
       for (const importFn of installedApps) {
         if (typeof importFn !== "function") continue;
 
@@ -332,30 +331,20 @@ export class RunServerCommand extends BaseCommand {
           if (!config?.name) continue;
 
           const appPath = appPathMap[config.name];
+          if (!appPath) continue;
 
-          let templatesDir: string | null = null;
-          if (config.templatesDir) {
-            // 1. Legacy: explicit `config.templatesDir` on AppConfig
-            templatesDir = this.resolveTemplatesDir(config.templatesDir);
-          } else if (appPath) {
-            // 2. Convention: `<appPath>/templates/` auto-discovery
-            const absAppDir = appPath.startsWith("/")
-              ? appPath
-              : `${this.projectRoot}/${appPath.replace(/^\.\//, "")}`;
-            const conventionDir = `${absAppDir}/templates`;
-            try {
-              const stat = await Deno.stat(conventionDir);
-              if (stat.isDirectory) {
-                templatesDir = conventionDir;
-              }
-            } catch {
-              // No templates dir by convention, skip
+          const absAppDir = appPath.startsWith("/")
+            ? appPath
+            : `${this.projectRoot}/${appPath.replace(/^\.\//, "")}`;
+          const conventionDir = `${absAppDir}/templates`;
+          try {
+            const stat = await Deno.stat(conventionDir);
+            if (stat.isDirectory) {
+              await this.scanAndRegisterTemplates(conventionDir);
+              templatesRegistered++;
             }
-          }
-
-          if (templatesDir) {
-            await this.scanAndRegisterTemplates(templatesDir);
-            templatesRegistered++;
+          } catch {
+            // No templates dir by convention, skip
           }
         } catch {
           // Skip apps that fail to load or have unreadable template dirs
@@ -424,48 +413,38 @@ export class RunServerCommand extends BaseCommand {
    * relative paths against `projectRoot`).
    *
    * Supports two strategies:
-   * - `staticDir` with `file://` URL → derive absolute parent directory
+   * - `appPath` with `file://` URL → return absolute directory path
+   * - `appPath` relative path → return as-is (resolved by the finder)
    * - Convention: `./src/${config.name}` (relative, resolved by the finder)
    *
    * Returns the app's source directory path, or null if not resolvable.
    */
   private resolveAppPath(config: AppConfig): string | null {
-    // Strategy 0: explicit appPath on config (e.g. worker apps whose name
-    // doesn't match their directory)
-    if (config.appPath) {
-      return config.appPath;
+    if (!config.appPath) {
+      // Convention-based relative path from app name
+      return `./src/${config.name}`;
     }
 
-    // Strategy 1: derive from file:// staticDir (published packages)
-    if (config.staticDir?.startsWith("file://")) {
+    if (config.appPath.startsWith("file://")) {
+      // Published package: absolute file:// URL
       try {
-        const url = new URL(config.staticDir);
+        const url = new URL(config.appPath);
         let pathname = url.pathname.replace(/\/$/, "");
         // Remove leading slash on Windows absolute paths (/C:/...)
         if (/^\/[a-zA-Z]:\//.test(pathname)) {
           pathname = pathname.slice(1);
         }
-        // staticDir points to e.g. /path/to/src/admin/static
-        // The app dir is the parent of the static dir
-        const lastSlash = pathname.lastIndexOf("/");
-        if (lastSlash > 0) {
-          // Return absolute path — starts with / (Unix) or C:/ (Windows)
-          // The finder recognises / as absolute; for Windows, we prefix with /
-          const absPath = pathname.slice(0, lastSlash);
-          if (/^[a-zA-Z]:\//.test(absPath)) {
-            return `/${absPath}`;
-          }
-          return absPath;
+        if (/^[a-zA-Z]:\//.test(pathname)) {
+          return `/${pathname}`;
         }
-        return null;
+        return pathname;
       } catch {
         return null;
       }
     }
 
-    // Strategy 2: convention-based relative path from app name
-    // The finder resolves this against projectRoot
-    return `./src/${config.name}`;
+    // Explicit relative path (e.g. "./src/myapp")
+    return config.appPath;
   }
 
   /**

--- a/src/webui/app.ts
+++ b/src/webui/app.ts
@@ -20,11 +20,7 @@ const config: AppConfig = {
    */
   verboseName: "Alexi WebUI",
 
-  /**
-   * Commands module for desktop app management.
-   */
-  commandsModule: "./commands/mod.ts",
-  commandsImport: () => import("./commands/mod.ts"),
+  appPath: new URL("./", import.meta.url).href,
 };
 
 export default config;


### PR DESCRIPTION
## Summary

- Removes all non-identity fields from `AppConfig`: `staticDir`, `templatesDir`, `commandsModule`, `urlsModule`, `modelsModule`, `bundle`, `staticfiles`, `desktop`
- `AppConfig` now mirrors Django's `AppConfig` — only `name`, `verboseName`, `appPath`
- Removes `BundleConfig`, `StaticfileConfig`, `DesktopConfig`, `DesktopSettings` types from `src/types/mod.ts` and `src/mod.ts`
- Framework code updated to use convention-based discovery (`<appPath>/commands/mod.ts`, `<appPath>/static/`, `<appPath>/templates/`)
- All framework `app.ts` files now set `appPath: new URL("./", import.meta.url).href`
- All tests updated and passing (1,190 passed, 0 failed)

Closes #222