### PR TITLE
feat(@alexi/views): class-based views

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1660,8 +1660,180 @@ class HeaderVersioning extends BaseVersioning {
 
 ## Views & Template Engine
 
-`@alexi/views` provides a full Django-style template engine and the
-`templateView` helper for serving HTML pages.
+`@alexi/views` provides a full Django-style template engine, the `templateView`
+function-based helper, and a complete set of **class-based views (CBVs)**
+mirroring Django's `django.views.generic`.
+
+### Class-Based Views (CBVs)
+
+CBVs provide reusable, composable view logic with a Django-compatible API. All
+CBVs are exported from `@alexi/views`.
+
+#### `View` — Base Class
+
+```typescript
+import { View } from "@alexi/views";
+import { path } from "@alexi/urls";
+
+class MyView extends View {
+  async get(
+    request: Request,
+    params: Record<string, string>,
+  ): Promise<Response> {
+    return new Response("Hello!");
+  }
+  async post(
+    request: Request,
+    params: Record<string, string>,
+  ): Promise<Response> {
+    return new Response("Created", { status: 201 });
+  }
+}
+
+// In urls.ts:
+path("my-view/", MyView.as_view());
+// Pass initkwargs to set class properties before dispatch:
+path("my-view/", MyView.as_view({ extraData: "foo" }));
+```
+
+- `as_view(initkwargs?)` — returns a plain
+  `(request, params) => Promise<Response>` handler compatible with `path()`
+- A **fresh instance** is created per request (no shared state)
+- Unknown methods return `405 Method Not Allowed`
+- `OPTIONS` returns an `Allow` header listing implemented HTTP methods
+
+#### `TemplateView`
+
+Renders a named template with context. Equivalent to Django's `TemplateView`.
+
+```typescript
+import { TemplateView } from "@alexi/views";
+
+class HomeView extends TemplateView {
+  templateName = "myapp/home.html";
+
+  override async getContextData(
+    request: Request,
+    params: Record<string, string>,
+    extra: Record<string, unknown> = {},
+  ): Promise<Record<string, unknown>> {
+    const base = await super.getContextData(request, params, extra);
+    return { ...base, title: "Home" };
+  }
+}
+
+// Inline via initkwargs:
+path("home/", TemplateView.as_view({ templateName: "myapp/home.html" }));
+```
+
+#### `RedirectView`
+
+Issues redirects (permanent or temporary) with optional URL interpolation.
+
+```typescript
+import { RedirectView } from "@alexi/views";
+
+// Permanent redirect
+path("old/", RedirectView.as_view({ url: "/new/", permanent: true }));
+
+// Dynamic redirect with URL params
+class ArticleRedirectView extends RedirectView {
+  override getRedirectUrl(
+    request: Request,
+    params: Record<string, string>,
+  ): string | null {
+    return `/articles/${params.slug}/`;
+  }
+}
+```
+
+| Property          | Default | Description                                   |
+| ----------------- | ------- | --------------------------------------------- |
+| `url`             | `null`  | Target URL (static)                           |
+| `permanent`       | `false` | `true` → 301, `false` → 302                   |
+| `queryStringPass` | `true`  | Forward original query string to redirect URL |
+
+Returns `410 Gone` when `getRedirectUrl()` returns `null`.
+
+#### `ListView`
+
+Fetches a queryset and renders it in a template. Equivalent to Django's
+`ListView`.
+
+```typescript
+import { ListView } from "@alexi/views";
+import { ArticleModel } from "./models.ts";
+
+class ArticleListView extends ListView<typeof ArticleModel.prototype> {
+  model = ArticleModel;
+  templateName = "blog/article_list.html";
+  paginateBy = 20; // optional pagination
+
+  // Optional: customise the queryset
+  override getQueryset() {
+    return ArticleModel.objects.filter({ published: true });
+  }
+}
+
+path("articles/", ArticleListView.as_view());
+```
+
+Template context:
+
+| Variable       | Description                                   |
+| -------------- | --------------------------------------------- |
+| `object_list`  | Array of plain objects (from `toJSON()`)      |
+| `<model>_list` | Same array, keyed by lowercase model name     |
+| `is_paginated` | `true` when more than one page exists         |
+| `page_obj`     | `Page` object (only when `paginateBy` is set) |
+
+`Page` object properties: `objectList`, `number`, `numPages`, `count`,
+`hasNext`, `hasPrevious`, `nextPageNumber`, `previousPageNumber`.
+
+#### `DetailView`
+
+Fetches a single object by PK (or slug) and renders it. Equivalent to Django's
+`DetailView`.
+
+```typescript
+import { DetailView } from "@alexi/views";
+import { ArticleModel } from "./models.ts";
+
+class ArticleDetailView extends DetailView<typeof ArticleModel.prototype> {
+  model = ArticleModel;
+  templateName = "blog/article_detail.html";
+  // pkUrlKwarg = "id";      // default — matches path("articles/:id/", ...)
+  // slugUrlKwarg = "slug";  // set to look up by slug instead
+}
+
+path("articles/:id/", ArticleDetailView.as_view());
+```
+
+Template context:
+
+| Variable          | Description                                |
+| ----------------- | ------------------------------------------ |
+| `object`          | Plain object from `toJSON()`               |
+| `<model>`         | Same object, keyed by lowercase model name |
+| `object_instance` | Raw model instance (for programmatic use)  |
+
+Returns `404 Not Found` automatically when the object does not exist.
+
+#### CBV Imports
+
+```typescript
+import {
+  ContextMixin,
+  DetailView,
+  ListView,
+  MultipleObjectMixin,
+  RedirectView,
+  SingleObjectMixin,
+  TemplateResponseMixin,
+  TemplateView,
+  View,
+} from "@alexi/views";
+```
 
 ### Template Engine Features
 

--- a/deno.lock
+++ b/deno.lock
@@ -1,22 +1,44 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@luca/esbuild-deno-loader@~0.11.1": "0.11.1",
     "jsr:@std/assert@*": "1.0.19",
+    "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/bytes@^1.0.2": "1.0.6",
+    "jsr:@std/encoding@^1.0.5": "1.0.10",
     "jsr:@std/fs@^1.0.19": "1.0.23",
     "jsr:@std/internal@^1.0.12": "1.0.12",
+    "jsr:@std/path@1": "1.1.4",
+    "jsr:@std/path@^1.0.6": "1.1.4",
     "jsr:@std/path@^1.1.2": "1.1.4",
     "jsr:@std/path@^1.1.4": "1.1.4",
     "jsr:@webui/deno-webui@^2.5.13": "2.5.13",
     "jsr:@zip-js/zip-js@^2.8.7": "2.8.22",
+    "npm:esbuild@0.24": "0.24.2",
     "npm:fake-indexeddb@6": "6.2.5",
-    "npm:pg@8": "8.19.0"
+    "npm:pg@8": "8.19.0",
+    "npm:playwright@^1.48.0": "1.58.2"
   },
   "jsr": {
+    "@luca/esbuild-deno-loader@0.11.1": {
+      "integrity": "dc020d16d75b591f679f6b9288b10f38bdb4f24345edb2f5732affa1d9885267",
+      "dependencies": [
+        "jsr:@std/bytes",
+        "jsr:@std/encoding",
+        "jsr:@std/path@^1.0.6"
+      ]
+    },
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [
         "jsr:@std/internal"
       ]
+    },
+    "@std/bytes@1.0.6": {
+      "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
+    },
+    "@std/encoding@1.0.10": {
+      "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
     },
     "@std/fs@1.0.23": {
       "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
@@ -47,8 +69,170 @@
     }
   },
   "npm": {
+    "@esbuild/aix-ppc64@0.24.2": {
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "os": ["aix"],
+      "cpu": ["ppc64"]
+    },
+    "@esbuild/android-arm64@0.24.2": {
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "os": ["android"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/android-arm@0.24.2": {
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "os": ["android"],
+      "cpu": ["arm"]
+    },
+    "@esbuild/android-x64@0.24.2": {
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "os": ["android"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/darwin-arm64@0.24.2": {
+      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/darwin-x64@0.24.2": {
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/freebsd-arm64@0.24.2": {
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "os": ["freebsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/freebsd-x64@0.24.2": {
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/linux-arm64@0.24.2": {
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/linux-arm@0.24.2": {
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@esbuild/linux-ia32@0.24.2": {
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "os": ["linux"],
+      "cpu": ["ia32"]
+    },
+    "@esbuild/linux-loong64@0.24.2": {
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "os": ["linux"],
+      "cpu": ["loong64"]
+    },
+    "@esbuild/linux-mips64el@0.24.2": {
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "os": ["linux"],
+      "cpu": ["mips64el"]
+    },
+    "@esbuild/linux-ppc64@0.24.2": {
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "os": ["linux"],
+      "cpu": ["ppc64"]
+    },
+    "@esbuild/linux-riscv64@0.24.2": {
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
+    },
+    "@esbuild/linux-s390x@0.24.2": {
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "os": ["linux"],
+      "cpu": ["s390x"]
+    },
+    "@esbuild/linux-x64@0.24.2": {
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/netbsd-arm64@0.24.2": {
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "os": ["netbsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/netbsd-x64@0.24.2": {
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "os": ["netbsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/openbsd-arm64@0.24.2": {
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "os": ["openbsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/openbsd-x64@0.24.2": {
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "os": ["openbsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/sunos-x64@0.24.2": {
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "os": ["sunos"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/win32-arm64@0.24.2": {
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/win32-ia32@0.24.2": {
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
+    },
+    "@esbuild/win32-x64@0.24.2": {
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "esbuild@0.24.2": {
+      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+      "optionalDependencies": [
+        "@esbuild/aix-ppc64",
+        "@esbuild/android-arm",
+        "@esbuild/android-arm64",
+        "@esbuild/android-x64",
+        "@esbuild/darwin-arm64",
+        "@esbuild/darwin-x64",
+        "@esbuild/freebsd-arm64",
+        "@esbuild/freebsd-x64",
+        "@esbuild/linux-arm",
+        "@esbuild/linux-arm64",
+        "@esbuild/linux-ia32",
+        "@esbuild/linux-loong64",
+        "@esbuild/linux-mips64el",
+        "@esbuild/linux-ppc64",
+        "@esbuild/linux-riscv64",
+        "@esbuild/linux-s390x",
+        "@esbuild/linux-x64",
+        "@esbuild/netbsd-arm64",
+        "@esbuild/netbsd-x64",
+        "@esbuild/openbsd-arm64",
+        "@esbuild/openbsd-x64",
+        "@esbuild/sunos-x64",
+        "@esbuild/win32-arm64",
+        "@esbuild/win32-ia32",
+        "@esbuild/win32-x64"
+      ],
+      "scripts": true,
+      "bin": true
+    },
     "fake-indexeddb@6.2.5": {
       "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w=="
+    },
+    "fsevents@2.3.2": {
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "os": ["darwin"],
+      "scripts": true
     },
     "pg-cloudflare@1.3.0": {
       "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ=="
@@ -97,6 +281,20 @@
         "split2"
       ]
     },
+    "playwright-core@1.58.2": {
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "bin": true
+    },
+    "playwright@1.58.2": {
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dependencies": [
+        "playwright-core"
+      ],
+      "optionalDependencies": [
+        "fsevents"
+      ],
+      "bin": true
+    },
     "postgres-array@2.0.0": {
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
     },
@@ -118,6 +316,75 @@
     "xtend@4.0.2": {
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     }
+  },
+  "remote": {
+    "https://deno.land/std@0.208.0/assert/_constants.ts": "8a9da298c26750b28b326b297316cdde860bc237533b07e1337c021379e6b2a9",
+    "https://deno.land/std@0.208.0/assert/_diff.ts": "58e1461cc61d8eb1eacbf2a010932bf6a05b79344b02ca38095f9b805795dc48",
+    "https://deno.land/std@0.208.0/assert/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
+    "https://deno.land/std@0.208.0/assert/assert.ts": "9a97dad6d98c238938e7540736b826440ad8c1c1e54430ca4c4e623e585607ee",
+    "https://deno.land/std@0.208.0/assert/assert_almost_equals.ts": "e15ca1f34d0d5e0afae63b3f5d975cbd18335a132e42b0c747d282f62ad2cd6c",
+    "https://deno.land/std@0.208.0/assert/assert_array_includes.ts": "6856d7f2c3544bc6e62fb4646dfefa3d1df5ff14744d1bca19f0cbaf3b0d66c9",
+    "https://deno.land/std@0.208.0/assert/assert_equals.ts": "d8ec8a22447fbaf2fc9d7c3ed2e66790fdb74beae3e482855d75782218d68227",
+    "https://deno.land/std@0.208.0/assert/assert_exists.ts": "407cb6b9fb23a835cd8d5ad804e2e2edbbbf3870e322d53f79e1c7a512e2efd7",
+    "https://deno.land/std@0.208.0/assert/assert_false.ts": "0ccbcaae910f52c857192ff16ea08bda40fdc79de80846c206bfc061e8c851c6",
+    "https://deno.land/std@0.208.0/assert/assert_greater.ts": "ae2158a2d19313bf675bf7251d31c6dc52973edb12ac64ac8fc7064152af3e63",
+    "https://deno.land/std@0.208.0/assert/assert_greater_or_equal.ts": "1439da5ebbe20855446cac50097ac78b9742abe8e9a43e7de1ce1426d556e89c",
+    "https://deno.land/std@0.208.0/assert/assert_instance_of.ts": "3aedb3d8186e120812d2b3a5dea66a6e42bf8c57a8bd927645770bd21eea554c",
+    "https://deno.land/std@0.208.0/assert/assert_is_error.ts": "c21113094a51a296ffaf036767d616a78a2ae5f9f7bbd464cd0197476498b94b",
+    "https://deno.land/std@0.208.0/assert/assert_less.ts": "aec695db57db42ec3e2b62e97e1e93db0063f5a6ec133326cc290ff4b71b47e4",
+    "https://deno.land/std@0.208.0/assert/assert_less_or_equal.ts": "5fa8b6a3ffa20fd0a05032fe7257bf985d207b85685fdbcd23651b70f928c848",
+    "https://deno.land/std@0.208.0/assert/assert_match.ts": "c4083f80600bc190309903c95e397a7c9257ff8b5ae5c7ef91e834704e672e9b",
+    "https://deno.land/std@0.208.0/assert/assert_not_equals.ts": "9f1acab95bd1f5fc9a1b17b8027d894509a745d91bac1718fdab51dc76831754",
+    "https://deno.land/std@0.208.0/assert/assert_not_instance_of.ts": "0c14d3dfd9ab7a5276ed8ed0b18c703d79a3d106102077ec437bfe7ed912bd22",
+    "https://deno.land/std@0.208.0/assert/assert_not_match.ts": "3796a5b0c57a1ce6c1c57883dd4286be13a26f715ea662318ab43a8491a13ab0",
+    "https://deno.land/std@0.208.0/assert/assert_not_strict_equals.ts": "4cdef83df17488df555c8aac1f7f5ec2b84ad161b6d0645ccdbcc17654e80c99",
+    "https://deno.land/std@0.208.0/assert/assert_object_match.ts": "d8fc2867cfd92eeacf9cea621e10336b666de1874a6767b5ec48988838370b54",
+    "https://deno.land/std@0.208.0/assert/assert_rejects.ts": "45c59724de2701e3b1f67c391d6c71c392363635aad3f68a1b3408f9efca0057",
+    "https://deno.land/std@0.208.0/assert/assert_strict_equals.ts": "b1f538a7ea5f8348aeca261d4f9ca603127c665e0f2bbfeb91fa272787c87265",
+    "https://deno.land/std@0.208.0/assert/assert_string_includes.ts": "b821d39ebf5cb0200a348863c86d8c4c4b398e02012ce74ad15666fc4b631b0c",
+    "https://deno.land/std@0.208.0/assert/assert_throws.ts": "63784e951475cb7bdfd59878cd25a0931e18f6dc32a6077c454b2cd94f4f4bcd",
+    "https://deno.land/std@0.208.0/assert/assertion_error.ts": "4d0bde9b374dfbcbe8ac23f54f567b77024fb67dbb1906a852d67fe050d42f56",
+    "https://deno.land/std@0.208.0/assert/equal.ts": "9f1a46d5993966d2596c44e5858eec821859b45f783a5ee2f7a695dfc12d8ece",
+    "https://deno.land/std@0.208.0/assert/fail.ts": "c36353d7ae6e1f7933d45f8ea51e358c8c4b67d7e7502028598fe1fea062e278",
+    "https://deno.land/std@0.208.0/assert/mod.ts": "37c49a26aae2b254bbe25723434dc28cd7532e444cf0b481a97c045d110ec085",
+    "https://deno.land/std@0.208.0/assert/unimplemented.ts": "d56fbeecb1f108331a380f72e3e010a1f161baa6956fd0f7cf3e095ae1a4c75a",
+    "https://deno.land/std@0.208.0/assert/unreachable.ts": "4600dc0baf7d9c15a7f7d234f00c23bca8f3eba8b140286aaca7aa998cf9a536",
+    "https://deno.land/std@0.208.0/fmt/colors.ts": "34b3f77432925eb72cf0bfb351616949746768620b8e5ead66da532f93d10ba2",
+    "https://deno.land/std@0.208.0/testing/_test_suite.ts": "30f018feeb3835f12ab198d8a518f9089b1bcb2e8c838a8b615ab10d5005465c",
+    "https://deno.land/std@0.208.0/testing/bdd.ts": "c41f019786c4a9112aadb7e5a7bbcc711f58429ac5904b3855fa248ba5fa0ba6",
+    "https://deno.land/std@0.224.0/assert/_constants.ts": "a271e8ef5a573f1df8e822a6eb9d09df064ad66a4390f21b3e31f820a38e0975",
+    "https://deno.land/std@0.224.0/assert/assert.ts": "09d30564c09de846855b7b071e62b5974b001bb72a4b797958fe0660e7849834",
+    "https://deno.land/std@0.224.0/assert/assert_almost_equals.ts": "9e416114322012c9a21fa68e187637ce2d7df25bcbdbfd957cd639e65d3cf293",
+    "https://deno.land/std@0.224.0/assert/assert_array_includes.ts": "14c5094471bc8e4a7895fc6aa5a184300d8a1879606574cb1cd715ef36a4a3c7",
+    "https://deno.land/std@0.224.0/assert/assert_equals.ts": "3bbca947d85b9d374a108687b1a8ba3785a7850436b5a8930d81f34a32cb8c74",
+    "https://deno.land/std@0.224.0/assert/assert_exists.ts": "43420cf7f956748ae6ed1230646567b3593cb7a36c5a5327269279c870c5ddfd",
+    "https://deno.land/std@0.224.0/assert/assert_false.ts": "3e9be8e33275db00d952e9acb0cd29481a44fa0a4af6d37239ff58d79e8edeff",
+    "https://deno.land/std@0.224.0/assert/assert_greater.ts": "5e57b201fd51b64ced36c828e3dfd773412c1a6120c1a5a99066c9b261974e46",
+    "https://deno.land/std@0.224.0/assert/assert_greater_or_equal.ts": "9870030f997a08361b6f63400273c2fb1856f5db86c0c3852aab2a002e425c5b",
+    "https://deno.land/std@0.224.0/assert/assert_instance_of.ts": "e22343c1fdcacfaea8f37784ad782683ec1cf599ae9b1b618954e9c22f376f2c",
+    "https://deno.land/std@0.224.0/assert/assert_is_error.ts": "f856b3bc978a7aa6a601f3fec6603491ab6255118afa6baa84b04426dd3cc491",
+    "https://deno.land/std@0.224.0/assert/assert_less.ts": "60b61e13a1982865a72726a5fa86c24fad7eb27c3c08b13883fb68882b307f68",
+    "https://deno.land/std@0.224.0/assert/assert_less_or_equal.ts": "d2c84e17faba4afe085e6c9123a63395accf4f9e00150db899c46e67420e0ec3",
+    "https://deno.land/std@0.224.0/assert/assert_match.ts": "ace1710dd3b2811c391946954234b5da910c5665aed817943d086d4d4871a8b7",
+    "https://deno.land/std@0.224.0/assert/assert_not_equals.ts": "78d45dd46133d76ce624b2c6c09392f6110f0df9b73f911d20208a68dee2ef29",
+    "https://deno.land/std@0.224.0/assert/assert_not_instance_of.ts": "3434a669b4d20cdcc5359779301a0588f941ffdc2ad68803c31eabdb4890cf7a",
+    "https://deno.land/std@0.224.0/assert/assert_not_match.ts": "df30417240aa2d35b1ea44df7e541991348a063d9ee823430e0b58079a72242a",
+    "https://deno.land/std@0.224.0/assert/assert_not_strict_equals.ts": "37f73880bd672709373d6dc2c5f148691119bed161f3020fff3548a0496f71b8",
+    "https://deno.land/std@0.224.0/assert/assert_object_match.ts": "411450fd194fdaabc0089ae68f916b545a49d7b7e6d0026e84a54c9e7eed2693",
+    "https://deno.land/std@0.224.0/assert/assert_rejects.ts": "4bee1d6d565a5b623146a14668da8f9eb1f026a4f338bbf92b37e43e0aa53c31",
+    "https://deno.land/std@0.224.0/assert/assert_strict_equals.ts": "b4f45f0fd2e54d9029171876bd0b42dd9ed0efd8f853ab92a3f50127acfa54f5",
+    "https://deno.land/std@0.224.0/assert/assert_string_includes.ts": "496b9ecad84deab72c8718735373feb6cdaa071eb91a98206f6f3cb4285e71b8",
+    "https://deno.land/std@0.224.0/assert/assert_throws.ts": "c6508b2879d465898dab2798009299867e67c570d7d34c90a2d235e4553906eb",
+    "https://deno.land/std@0.224.0/assert/assertion_error.ts": "ba8752bd27ebc51f723702fac2f54d3e94447598f54264a6653d6413738a8917",
+    "https://deno.land/std@0.224.0/assert/equal.ts": "bddf07bb5fc718e10bb72d5dc2c36c1ce5a8bdd3b647069b6319e07af181ac47",
+    "https://deno.land/std@0.224.0/assert/fail.ts": "0eba674ffb47dff083f02ced76d5130460bff1a9a68c6514ebe0cdea4abadb68",
+    "https://deno.land/std@0.224.0/assert/mod.ts": "48b8cb8a619ea0b7958ad7ee9376500fe902284bb36f0e32c598c3dc34cbd6f3",
+    "https://deno.land/std@0.224.0/assert/unimplemented.ts": "8c55a5793e9147b4f1ef68cd66496b7d5ba7a9e7ca30c6da070c1a58da723d73",
+    "https://deno.land/std@0.224.0/assert/unreachable.ts": "5ae3dbf63ef988615b93eb08d395dda771c96546565f9e521ed86f6510c29e19",
+    "https://deno.land/std@0.224.0/fmt/colors.ts": "508563c0659dd7198ba4bbf87e97f654af3c34eb56ba790260f252ad8012e1c5",
+    "https://deno.land/std@0.224.0/internal/diff.ts": "6234a4b493ebe65dc67a18a0eb97ef683626a1166a1906232ce186ae9f65f4e6",
+    "https://deno.land/std@0.224.0/internal/format.ts": "0a98ee226fd3d43450245b1844b47003419d34d210fa989900861c79820d21c2",
+    "https://deno.land/std@0.224.0/internal/mod.ts": "534125398c8e7426183e12dc255bb635d94e06d0f93c60a297723abe69d3b22e"
   },
   "workspace": {
     "dependencies": [
@@ -219,6 +486,7 @@
       },
       "src/views": {
         "dependencies": [
+          "jsr:@alexi/db@0.37.5",
           "jsr:@alexi/types@0.37.5"
         ]
       },

--- a/src/views/deno.jsonc
+++ b/src/views/deno.jsonc
@@ -7,6 +7,7 @@
     "./config": "./app.ts"
   },
   "imports": {
+    "@alexi/db": "jsr:@alexi/db@0.37.5",
     "@alexi/types": "jsr:@alexi/types@0.37.5"
   }
 }

--- a/src/views/mod.ts
+++ b/src/views/mod.ts
@@ -95,3 +95,21 @@ export type {
   NewTemplateViewOptions,
   TemplateViewOptions,
 } from "./template.ts";
+
+// ============================================================================
+// Class-Based Views
+// ============================================================================
+
+export {
+  ContextMixin,
+  DetailView,
+  ListView,
+  MultipleObjectMixin,
+  RedirectView,
+  SingleObjectMixin,
+  TemplateResponseMixin,
+  TemplateView,
+  View,
+} from "./views/mod.ts";
+
+export type { Page, ViewFunction } from "./views/mod.ts";

--- a/src/views/views/base.ts
+++ b/src/views/views/base.ts
@@ -1,0 +1,302 @@
+/**
+ * Alexi Views - Class-Based Views: Base
+ *
+ * Provides the base `View` class and core mixins that mirror Django's
+ * `django.views.generic.base` module.
+ *
+ * - `View` — base class with `dispatch()` routing and `as_view()` factory
+ * - `ContextMixin` — adds `getContextData()` for building template context
+ * - `TemplateResponseMixin` — adds `templateName`, `getTemplateName()`,
+ *   and `renderToResponse()`
+ *
+ * @module @alexi/views/views/base
+ */
+
+import { render, templateRegistry } from "../engine/mod.ts";
+import type { TemplateContext, TemplateLoader } from "../engine/mod.ts";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Standard Alexi view function signature.
+ */
+export type ViewFunction = (
+  request: Request,
+  params: Record<string, string>,
+) => Promise<Response>;
+
+// =============================================================================
+// View
+// =============================================================================
+
+/**
+ * Base class for all class-based views.
+ *
+ * Mirrors Django's `django.views.generic.base.View`.
+ *
+ * @example
+ * ```ts
+ * import { View } from "@alexi/views";
+ *
+ * class MyView extends View {
+ *   async get(request: Request, params: Record<string, string>): Promise<Response> {
+ *     return Response.json({ hello: "world" });
+ *   }
+ * }
+ *
+ * // In urls.ts:
+ * path("my/", MyView.as_view());
+ * ```
+ */
+export class View {
+  /** HTTP methods handled by this view (lower-case). */
+  protected httpMethodNames: string[] = [
+    "get",
+    "post",
+    "put",
+    "patch",
+    "delete",
+    "head",
+    "options",
+    "trace",
+  ];
+
+  /**
+   * The current request (set per-call by `setup()`).
+   * Do not store state between requests on the class instance —
+   * `as_view()` creates a fresh instance for every request.
+   */
+  protected request!: Request;
+
+  /**
+   * The URL parameters for the current request (set per-call by `setup()`).
+   */
+  protected params!: Record<string, string>;
+
+  /**
+   * Constructor-time overrides passed via `as_view({ key: value })`.
+   * Each key/value pair is applied to the instance before `setup()` is called.
+   */
+  [key: string]: unknown;
+
+  /**
+   * Per-request initialisation.
+   * Called by `as_view()` before `dispatch()`.
+   */
+  protected setup(
+    request: Request,
+    params: Record<string, string>,
+  ): void {
+    this.request = request;
+    this.params = params;
+  }
+
+  /**
+   * Route the request to the appropriate HTTP method handler.
+   * Returns `405 Method Not Allowed` if the method is not implemented.
+   */
+  async dispatch(
+    request: Request,
+    params: Record<string, string>,
+  ): Promise<Response> {
+    const method = request.method.toLowerCase();
+
+    if (this.httpMethodNames.includes(method)) {
+      const handler = (this as Record<string, unknown>)[method];
+      if (typeof handler === "function") {
+        return await (handler as (
+          req: Request,
+          params: Record<string, string>,
+        ) => Promise<Response>).call(this, request, params);
+      }
+    }
+
+    return this.httpMethodNotAllowed(request);
+  }
+
+  /**
+   * Called when the request method is not implemented by this view.
+   */
+  protected httpMethodNotAllowed(_request: Request): Response {
+    const allowed = this.httpMethodNames
+      .filter((m) => typeof (this as Record<string, unknown>)[m] === "function")
+      .map((m) => m.toUpperCase())
+      .join(", ");
+
+    return new Response("Method Not Allowed", {
+      status: 405,
+      headers: { Allow: allowed },
+    });
+  }
+
+  /**
+   * Handle `OPTIONS` requests by returning the `Allow` header.
+   */
+  options(_request: Request, _params: Record<string, string>): Response {
+    const allowed = this.httpMethodNames
+      .filter((m) => typeof (this as Record<string, unknown>)[m] === "function")
+      .map((m) => m.toUpperCase())
+      .join(", ");
+
+    return new Response(null, {
+      status: 200,
+      headers: { Allow: allowed },
+    });
+  }
+
+  /**
+   * Factory method that returns a plain view function compatible with `path()`.
+   *
+   * Any kwargs passed here are set as instance attributes before each request,
+   * mirroring Django's `as_view(**initkwargs)` pattern.
+   *
+   * @example
+   * ```ts
+   * path("about/", MyView.as_view({ title: "About Us" }));
+   * ```
+   */
+  static as_view(
+    initkwargs: Record<string, unknown> = {},
+  ): ViewFunction {
+    // Capture `this` (the class) for use inside the closure.
+    // deno-lint-ignore no-this-alias
+    const ViewClass = this;
+
+    return async function view(
+      request: Request,
+      params: Record<string, string>,
+    ): Promise<Response> {
+      // Create a fresh instance per request (no shared state).
+      const self = new ViewClass() as View;
+
+      // Apply initkwargs to the instance.
+      for (const [key, value] of Object.entries(initkwargs)) {
+        (self as Record<string, unknown>)[key] = value;
+      }
+
+      self.setup(request, params);
+      return self.dispatch(request, params);
+    };
+  }
+}
+
+// =============================================================================
+// ContextMixin
+// =============================================================================
+
+/**
+ * Mixin that provides a `getContextData()` method for building template context.
+ *
+ * Mirrors Django's `django.views.generic.base.ContextMixin`.
+ *
+ * @example
+ * ```ts
+ * class MyView extends ContextMixin(View) {
+ *   override async getContextData(
+ *     request: Request,
+ *     params: Record<string, string>,
+ *     extra: TemplateContext = {},
+ *   ): Promise<TemplateContext> {
+ *     return {
+ *       ...(await super.getContextData(request, params, extra)),
+ *       greeting: "Hello!",
+ *     };
+ *   }
+ * }
+ * ```
+ */
+export class ContextMixin extends View {
+  /**
+   * Build and return the context dict for the template.
+   * Override in subclasses to add extra context variables.
+   */
+  async getContextData(
+    _request: Request,
+    _params: Record<string, string>,
+    extra: TemplateContext = {},
+  ): Promise<TemplateContext> {
+    return { ...extra };
+  }
+}
+
+// =============================================================================
+// TemplateResponseMixin
+// =============================================================================
+
+/**
+ * Mixin that provides template rendering capabilities.
+ *
+ * Mirrors Django's `django.views.generic.base.TemplateResponseMixin`.
+ */
+export class TemplateResponseMixin extends ContextMixin {
+  /**
+   * The name of the template to render, e.g. `"myapp/index.html"`.
+   * Must be set either on the class or passed via `as_view()`.
+   */
+  templateName: string | null = null;
+
+  /**
+   * Custom template loader.
+   * Defaults to the global `templateRegistry`.
+   */
+  templateLoader: TemplateLoader | null = null;
+
+  /**
+   * Content-Type header value for the rendered response.
+   * @default "text/html; charset=utf-8"
+   */
+  contentType = "text/html; charset=utf-8";
+
+  /**
+   * Cache-Control header value.
+   * @default "no-cache"
+   */
+  cacheControl = "no-cache";
+
+  /**
+   * Return the template name to use for rendering.
+   * Override to generate the name dynamically.
+   *
+   * @throws {Error} if `templateName` is not set
+   */
+  getTemplateName(): string {
+    if (!this.templateName) {
+      const name = this.constructor.name;
+      throw new Error(
+        `${name} requires either a definition of 'templateName' or an ` +
+          `implementation of 'getTemplateName()'`,
+      );
+    }
+    return this.templateName;
+  }
+
+  /**
+   * Render the template with the given context and return an HTTP Response.
+   */
+  async renderToResponse(context: TemplateContext): Promise<Response> {
+    const templateName = this.getTemplateName();
+    const loader = this.templateLoader ?? templateRegistry;
+
+    try {
+      const html = await render(templateName, context, loader);
+      return new Response(html, {
+        status: 200,
+        headers: {
+          "Content-Type": this.contentType,
+          "Cache-Control": this.cacheControl,
+        },
+      });
+    } catch (error) {
+      console.error(
+        `[${this.constructor.name}] Failed to render template: ${templateName}`,
+        error,
+      );
+      return new Response(`Template error: ${templateName}\n${error}`, {
+        status: 500,
+        headers: { "Content-Type": "text/plain; charset=utf-8" },
+      });
+    }
+  }
+}

--- a/src/views/views/detail_view.ts
+++ b/src/views/views/detail_view.ts
@@ -1,0 +1,200 @@
+/**
+ * Alexi Views - Class-Based Views: DetailView
+ *
+ * Mirrors Django's `django.views.generic.detail` module.
+ *
+ * - `SingleObjectMixin` — fetches a single model instance by PK or slug
+ * - `DetailView` — renders a single object in a template
+ *
+ * @module @alexi/views/views/detail_view
+ */
+
+import type { Model, QuerySet } from "@alexi/db";
+import { TemplateResponseMixin } from "./base.ts";
+
+// Helper type for a Model class with a static `objects` Manager
+type ModelClass<TModel extends Model> = (new () => TModel) & {
+  objects: {
+    all(): QuerySet<TModel>;
+    filter(conditions: Record<string, unknown>): QuerySet<TModel>;
+  };
+};
+
+// =============================================================================
+// SingleObjectMixin
+// =============================================================================
+
+/**
+ * Mixin that provides `getObject()` and `getQueryset()` for views that
+ * operate on a single model instance.
+ *
+ * Mirrors Django's `django.views.generic.detail.SingleObjectMixin`.
+ */
+export class SingleObjectMixin<
+  TModel extends Model,
+> extends TemplateResponseMixin {
+  /**
+   * The model class to use. Required unless `getQueryset()` is overridden.
+   */
+  model: ModelClass<TModel> | null = null;
+
+  /**
+   * The URL parameter name used to look up the object.
+   * @default "id"
+   */
+  pkUrlKwarg = "id";
+
+  /**
+   * The URL parameter name used to look up the object by slug.
+   * Used only if `pkUrlKwarg` is not present in `params`.
+   * @default null
+   */
+  slugUrlKwarg: string | null = null;
+
+  /**
+   * The model field name for slug lookups.
+   * @default "slug"
+   */
+  slugField = "slug";
+
+  /**
+   * Return the base QuerySet for fetching the object.
+   * Override to customise the queryset (e.g., add `select_related`).
+   */
+  getQueryset(): QuerySet<TModel> {
+    if (!this.model) {
+      throw new Error(
+        `${this.constructor.name} requires either a definition of 'model' ` +
+          `or an implementation of 'getQueryset()'`,
+      );
+    }
+    return this.model.objects.all();
+  }
+
+  /**
+   * Fetch and return the single object that this view operates on.
+   *
+   * Looks up the object using the URL params (by `pkUrlKwarg` or
+   * `slugUrlKwarg`).
+   *
+   * @throws {Response} 404 response if the object is not found
+   */
+  async getObject(): Promise<TModel> {
+    const params = this.params;
+    const qs = this.getQueryset();
+
+    const pk = params[this.pkUrlKwarg];
+    if (pk !== undefined) {
+      // Coerce to number if it looks like an integer (ORM PKs are typically numbers)
+      const pkValue: string | number = /^\d+$/.test(pk) ? parseInt(pk, 10) : pk;
+      const obj = await qs.filter({ id: pkValue }).first();
+      if (!obj) {
+        return Promise.reject(
+          new Response(`No object found with id=${pk}`, { status: 404 }),
+        );
+      }
+      return obj;
+    }
+
+    if (this.slugUrlKwarg) {
+      const slug = params[this.slugUrlKwarg];
+      if (slug !== undefined) {
+        const obj = await qs
+          .filter({ [this.slugField]: slug })
+          .first();
+        if (!obj) {
+          return Promise.reject(
+            new Response(
+              `No object found with ${this.slugField}=${slug}`,
+              { status: 404 },
+            ),
+          );
+        }
+        return obj;
+      }
+    }
+
+    throw new Error(
+      `${this.constructor.name}: URL params must include '${this.pkUrlKwarg}'` +
+        (this.slugUrlKwarg ? ` or '${this.slugUrlKwarg}'` : ""),
+    );
+  }
+
+  /**
+   * Build context data including the retrieved object.
+   * Adds `object` (plain data from `toJSON()`) and an optional model-named key
+   * (`article`, `user`, etc.) for convenience.
+   * The raw model instance is available as `object_instance`.
+   */
+  override async getContextData(
+    request: Request,
+    params: Record<string, string>,
+    extra: Record<string, unknown> = {},
+  ): Promise<Record<string, unknown>> {
+    const obj = await this.getObject();
+    const base = await super.getContextData(request, params, extra);
+
+    // Use toJSON() so template variables like {{ object.title }} work
+    const objData = (obj as unknown as { toJSON(): Record<string, unknown> })
+      .toJSON();
+
+    const context: Record<string, unknown> = {
+      ...base,
+      object: objData,
+      object_instance: obj,
+    };
+
+    // Add a convenience key using the model name in lower-case
+    if (this.model) {
+      const modelName = this.model.name.replace(/Model$/, "").toLowerCase();
+      context[modelName] = objData;
+    }
+
+    return context;
+  }
+}
+
+// =============================================================================
+// DetailView
+// =============================================================================
+
+/**
+ * A view that renders a single model instance in a template.
+ *
+ * Mirrors Django's `django.views.generic.DetailView`.
+ *
+ * @example
+ * ```ts
+ * import { DetailView } from "@alexi/views";
+ * import { ArticleModel } from "./models.ts";
+ *
+ * class ArticleDetailView extends DetailView<typeof ArticleModel.prototype> {
+ *   model = ArticleModel;
+ *   templateName = "blog/article_detail.html";
+ *   // Template context: `object` (the article) and `article` (same object)
+ * }
+ *
+ * // In urls.ts:
+ * path("articles/:id/", ArticleDetailView.as_view());
+ * ```
+ */
+export class DetailView<TModel extends Model>
+  extends SingleObjectMixin<TModel> {
+  /**
+   * Handle GET requests by fetching the object and rendering the template.
+   */
+  async get(
+    request: Request,
+    params: Record<string, string>,
+  ): Promise<Response> {
+    let context: Record<string, unknown>;
+    try {
+      context = await this.getContextData(request, params);
+    } catch (e) {
+      // Re-raise 404/other Response objects directly
+      if (e instanceof Response) return e;
+      throw e;
+    }
+    return this.renderToResponse(context);
+  }
+}

--- a/src/views/views/list_view.ts
+++ b/src/views/views/list_view.ts
@@ -1,0 +1,241 @@
+/**
+ * Alexi Views - Class-Based Views: ListView
+ *
+ * Mirrors Django's `django.views.generic.list` module.
+ *
+ * - `MultipleObjectMixin` — fetches a queryset of model instances
+ * - `ListView` — renders a list of objects in a template with optional pagination
+ *
+ * @module @alexi/views/views/list_view
+ */
+
+import type { Model, QuerySet } from "@alexi/db";
+import { TemplateResponseMixin } from "./base.ts";
+
+// Helper type for a Model class with a static `objects` Manager
+type ModelClass<TModel extends Model> = (new () => TModel) & {
+  objects: {
+    all(): QuerySet<TModel>;
+    filter(conditions: Record<string, unknown>): QuerySet<TModel>;
+  };
+};
+
+// =============================================================================
+// Paginator (lightweight)
+// =============================================================================
+
+/**
+ * A simple paginator for use with ListView.
+ */
+export interface Page<TModel extends Model> {
+  /** Objects on this page. */
+  objectList: TModel[];
+  /** Page number (1-indexed). */
+  number: number;
+  /** Total number of pages. */
+  numPages: number;
+  /** Total number of objects. */
+  count: number;
+  /** Whether there is a next page. */
+  hasNext: boolean;
+  /** Whether there is a previous page. */
+  hasPrevious: boolean;
+  /** Next page number, or null. */
+  nextPageNumber: number | null;
+  /** Previous page number, or null. */
+  previousPageNumber: number | null;
+}
+
+function paginate<TModel extends Model>(
+  objects: TModel[],
+  pageNumber: number,
+  pageSize: number,
+): Page<TModel> {
+  const count = objects.length;
+  const numPages = Math.max(1, Math.ceil(count / pageSize));
+  const safePage = Math.min(Math.max(1, pageNumber), numPages);
+  const start = (safePage - 1) * pageSize;
+  const end = start + pageSize;
+
+  return {
+    objectList: objects.slice(start, end),
+    number: safePage,
+    numPages,
+    count,
+    hasNext: safePage < numPages,
+    hasPrevious: safePage > 1,
+    nextPageNumber: safePage < numPages ? safePage + 1 : null,
+    previousPageNumber: safePage > 1 ? safePage - 1 : null,
+  };
+}
+
+// =============================================================================
+// MultipleObjectMixin
+// =============================================================================
+
+/**
+ * Mixin that provides `getQueryset()` and optional pagination for views that
+ * operate on a list of model instances.
+ *
+ * Mirrors Django's `django.views.generic.list.MultipleObjectMixin`.
+ */
+export class MultipleObjectMixin<
+  TModel extends Model,
+> extends TemplateResponseMixin {
+  /**
+   * The model class to use. Required unless `getQueryset()` is overridden.
+   */
+  model: ModelClass<TModel> | null = null;
+
+  /**
+   * Number of objects per page.
+   * Set to `null` to disable pagination.
+   * @default null
+   */
+  paginateBy: number | null = null;
+
+  /**
+   * The name of the URL query parameter for the page number.
+   * @default "page"
+   */
+  pageKwarg = "page";
+
+  /**
+   * The name of the context variable that holds the object list.
+   * @default "object_list"
+   */
+  contextObjectName = "object_list";
+
+  /**
+   * Return the QuerySet for this view.
+   * Override to customise (e.g., filter by user, add ordering, etc.).
+   */
+  getQueryset(): QuerySet<TModel> {
+    if (!this.model) {
+      throw new Error(
+        `${this.constructor.name} requires either a definition of 'model' ` +
+          `or an implementation of 'getQueryset()'`,
+      );
+    }
+    return this.model.objects.all();
+  }
+
+  /**
+   * Return the page number from the request's query string.
+   */
+  protected getPageNumber(request: Request): number {
+    const url = new URL(request.url);
+    const page = parseInt(url.searchParams.get(this.pageKwarg) ?? "1", 10);
+    return isNaN(page) ? 1 : page;
+  }
+
+  /**
+   * Build context data including the object list and pagination info.
+   *
+   * Context variables:
+   * - `object_list` (or `contextObjectName`) — array of model instances
+   * - `page_obj` — `Page` object (if `paginateBy` is set)
+   * - `is_paginated` — boolean
+   */
+  override async getContextData(
+    request: Request,
+    params: Record<string, string>,
+    extra: Record<string, unknown> = {},
+  ): Promise<Record<string, unknown>> {
+    const qs = this.getQueryset();
+    const allObjects = (await qs.fetch()).array();
+
+    const base = await super.getContextData(request, params, extra);
+
+    let objectList: TModel[];
+    let isPaginated = false;
+    let pageObj: Page<TModel> | null = null;
+
+    if (this.paginateBy !== null) {
+      const pageNumber = this.getPageNumber(request);
+      pageObj = paginate(allObjects, pageNumber, this.paginateBy);
+      objectList = pageObj.objectList;
+      isPaginated = pageObj.numPages > 1;
+    } else {
+      objectList = allObjects;
+    }
+
+    // Convert model instances to plain objects so template variables like
+    // {{ item.title }} work correctly (Field objects don't stringify as values).
+    type WithToJSON = { toJSON(): Record<string, unknown> };
+    const objectListData = objectList.map((obj) =>
+      (obj as unknown as WithToJSON).toJSON()
+    );
+
+    // Also patch page_obj.objectList for consistency when pagination is active
+    if (pageObj) {
+      (pageObj as unknown as { objectList: unknown[] }).objectList =
+        objectListData;
+    }
+
+    const context: Record<string, unknown> = {
+      ...base,
+      [this.contextObjectName]: objectListData,
+      is_paginated: isPaginated,
+      page_obj: pageObj,
+    };
+
+    // Add a convenience key using the model name in lower-case + "_list"
+    if (this.model) {
+      const modelName = this.model.name.replace(/Model$/, "").toLowerCase();
+      context[`${modelName}_list`] = objectListData;
+    }
+
+    return context;
+  }
+}
+
+// =============================================================================
+// ListView
+// =============================================================================
+
+/**
+ * A view that renders a list of model instances in a template.
+ *
+ * Mirrors Django's `django.views.generic.ListView`.
+ *
+ * @example
+ * ```ts
+ * import { ListView } from "@alexi/views";
+ * import { ArticleModel } from "./models.ts";
+ *
+ * class ArticleListView extends ListView<typeof ArticleModel.prototype> {
+ *   model = ArticleModel;
+ *   templateName = "blog/article_list.html";
+ *   paginateBy = 20;
+ *
+ *   override getQueryset() {
+ *     return ArticleModel.objects
+ *       .filter({ published: true })
+ *       .orderBy("-createdAt");
+ *   }
+ * }
+ *
+ * // In urls.ts:
+ * path("articles/", ArticleListView.as_view());
+ * ```
+ *
+ * Template context:
+ * - `object_list` — array of model instances
+ * - `article_list` — same, using model name (convenience)
+ * - `is_paginated` — boolean
+ * - `page_obj` — Page object (if paginateBy is set)
+ */
+export class ListView<TModel extends Model>
+  extends MultipleObjectMixin<TModel> {
+  /**
+   * Handle GET requests by fetching the queryset and rendering the template.
+   */
+  async get(
+    request: Request,
+    params: Record<string, string>,
+  ): Promise<Response> {
+    const context = await this.getContextData(request, params);
+    return this.renderToResponse(context);
+  }
+}

--- a/src/views/views/mod.ts
+++ b/src/views/views/mod.ts
@@ -1,0 +1,18 @@
+/**
+ * Alexi Views - Class-Based Views
+ *
+ * Re-exports all class-based view classes and types.
+ *
+ * @module @alexi/views/views
+ */
+
+// Base infrastructure
+export { ContextMixin, TemplateResponseMixin, View } from "./base.ts";
+export type { ViewFunction } from "./base.ts";
+
+// Concrete views
+export { TemplateView } from "./template_view.ts";
+export { RedirectView } from "./redirect_view.ts";
+export { DetailView, SingleObjectMixin } from "./detail_view.ts";
+export { ListView, MultipleObjectMixin } from "./list_view.ts";
+export type { Page } from "./list_view.ts";

--- a/src/views/views/redirect_view.ts
+++ b/src/views/views/redirect_view.ts
@@ -1,0 +1,138 @@
+/**
+ * Alexi Views - Class-Based Views: RedirectView
+ *
+ * Mirrors Django's `django.views.generic.base.RedirectView`.
+ *
+ * @module @alexi/views/views/redirect_view
+ */
+
+import { View } from "./base.ts";
+
+// =============================================================================
+// RedirectView
+// =============================================================================
+
+/**
+ * A view that redirects to a given URL.
+ *
+ * Mirrors Django's `django.views.generic.RedirectView`.
+ *
+ * @example Permanent static redirect
+ * ```ts
+ * import { RedirectView } from "@alexi/views";
+ *
+ * path("old/", RedirectView.as_view({ url: "/new/", permanent: true }));
+ * ```
+ *
+ * @example Dynamic redirect
+ * ```ts
+ * class ProfileRedirectView extends RedirectView {
+ *   override getRedirectUrl(
+ *     request: Request,
+ *     params: Record<string, string>,
+ *   ): string | null {
+ *     return `/users/${params.username}/profile/`;
+ *   }
+ * }
+ * path("profile/:username/", ProfileRedirectView.as_view());
+ * ```
+ */
+export class RedirectView extends View {
+  /**
+   * The URL to redirect to.
+   * URL parameters from `params` are substituted using `:param` syntax.
+   * If `null`, `getRedirectUrl()` must be overridden.
+   */
+  url: string | null = null;
+
+  /**
+   * Whether to use a permanent redirect (301) instead of a temporary one (302).
+   * @default false
+   */
+  permanent = false;
+
+  /**
+   * Whether to pass GET query parameters to the redirect URL.
+   * @default true
+   */
+  queryStringForward = true;
+
+  /**
+   * Return the URL to redirect to, or `null` to return 410 Gone.
+   *
+   * The default implementation substitutes `:param` placeholders in `this.url`
+   * with the matched URL parameters.
+   *
+   * Override to generate the URL dynamically.
+   */
+  getRedirectUrl(
+    _request: Request,
+    params: Record<string, string>,
+  ): string | null {
+    if (!this.url) {
+      return null;
+    }
+
+    // Substitute :param placeholders with URL parameters
+    let redirectUrl = this.url;
+    for (const [key, value] of Object.entries(params)) {
+      redirectUrl = redirectUrl.replaceAll(`:${key}`, value);
+    }
+
+    return redirectUrl;
+  }
+
+  /**
+   * Handle any HTTP method by redirecting.
+   */
+  private redirect(
+    request: Request,
+    params: Record<string, string>,
+  ): Response {
+    let redirectUrl = this.getRedirectUrl(request, params);
+
+    if (!redirectUrl) {
+      return new Response("Gone", { status: 410 });
+    }
+
+    // Forward query string if configured
+    if (this.queryStringForward) {
+      const requestUrl = new URL(request.url);
+      if (requestUrl.search) {
+        // Append existing query string (avoid duplicating if already present)
+        const separator = redirectUrl.includes("?") ? "&" : "?";
+        redirectUrl = `${redirectUrl}${separator}${requestUrl.search.slice(1)}`;
+      }
+    }
+
+    const status = this.permanent ? 301 : 302;
+    return new Response(null, {
+      status,
+      headers: { Location: redirectUrl },
+    });
+  }
+
+  get(request: Request, params: Record<string, string>): Response {
+    return this.redirect(request, params);
+  }
+
+  post(request: Request, params: Record<string, string>): Response {
+    return this.redirect(request, params);
+  }
+
+  put(request: Request, params: Record<string, string>): Response {
+    return this.redirect(request, params);
+  }
+
+  patch(request: Request, params: Record<string, string>): Response {
+    return this.redirect(request, params);
+  }
+
+  delete(request: Request, params: Record<string, string>): Response {
+    return this.redirect(request, params);
+  }
+
+  head(request: Request, params: Record<string, string>): Response {
+    return this.redirect(request, params);
+  }
+}

--- a/src/views/views/template_view.ts
+++ b/src/views/views/template_view.ts
@@ -1,0 +1,60 @@
+/**
+ * Alexi Views - Class-Based Views: TemplateView
+ *
+ * Mirrors Django's `django.views.generic.base.TemplateView`.
+ *
+ * @module @alexi/views/views/template_view
+ */
+
+import type { TemplateContext } from "../engine/mod.ts";
+import { TemplateResponseMixin } from "./base.ts";
+
+// =============================================================================
+// TemplateView
+// =============================================================================
+
+/**
+ * A view that renders a template.
+ *
+ * Mirrors Django's `django.views.generic.TemplateView`.
+ *
+ * @example
+ * ```ts
+ * import { TemplateView } from "@alexi/views";
+ *
+ * class HomeView extends TemplateView {
+ *   templateName = "myapp/home.html";
+ *
+ *   override async getContextData(
+ *     request: Request,
+ *     params: Record<string, string>,
+ *   ): Promise<Record<string, unknown>> {
+ *     return {
+ *       ...(await super.getContextData(request, params)),
+ *       greeting: "Hello!",
+ *     };
+ *   }
+ * }
+ *
+ * // In urls.ts:
+ * path("", HomeView.as_view());
+ *
+ * // Or pass options directly to as_view():
+ * path("about/", TemplateView.as_view({ templateName: "myapp/about.html" }));
+ * ```
+ */
+export class TemplateView extends TemplateResponseMixin {
+  /**
+   * Handle GET requests by rendering the template with context data.
+   */
+  async get(
+    request: Request,
+    params: Record<string, string>,
+  ): Promise<Response> {
+    const context: TemplateContext = await this.getContextData(
+      request,
+      params,
+    );
+    return this.renderToResponse(context);
+  }
+}

--- a/src/views/views/views_test.ts
+++ b/src/views/views/views_test.ts
@@ -1,0 +1,533 @@
+/**
+ * Tests for Alexi class-based views.
+ *
+ * Covers: View dispatch, TemplateView, RedirectView, ListView, DetailView.
+ *
+ * ORM-backed tests (ListView, DetailView) use DenoKVBackend with :memory:.
+ */
+
+import {
+  assertEquals,
+  assertMatch,
+  assertStringIncludes,
+} from "jsr:@std/assert@1";
+
+import { AutoField, CharField, IntegerField, Manager, Model } from "@alexi/db";
+import { DenoKVBackend } from "@alexi/db/backends/denokv";
+import { registerBackend, reset } from "../../db/setup.ts";
+
+import {
+  ContextMixin,
+  DetailView,
+  ListView,
+  RedirectView,
+  TemplateResponseMixin,
+  TemplateView,
+  View,
+} from "./mod.ts";
+import { MemoryTemplateLoader, templateRegistry } from "../engine/mod.ts";
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function makeRequest(
+  url = "http://localhost/",
+  method = "GET",
+): Request {
+  // Ensure absolute URL (Deno's Request requires it)
+  const absUrl = url.startsWith("http") ? url : `http://localhost${url}`;
+  return new Request(absUrl, { method });
+}
+
+// =============================================================================
+// Test Model
+// =============================================================================
+
+class NoteModel extends Model {
+  id = new AutoField({ primaryKey: true });
+  title = new CharField({ maxLength: 200 });
+  priority = new IntegerField({ default: 0 });
+
+  static objects = new Manager(NoteModel);
+  static override meta = { dbTable: "notes" };
+}
+
+// =============================================================================
+// View — base dispatch
+// =============================================================================
+
+Deno.test("View: GET dispatches to get()", async () => {
+  class MyView extends View {
+    get(_req: Request, _params: Record<string, string>): Response {
+      return new Response("hello", { status: 200 });
+    }
+  }
+
+  const handler = MyView.as_view();
+  const res = await handler(makeRequest(), {});
+  assertEquals(res.status, 200);
+  assertEquals(await res.text(), "hello");
+});
+
+Deno.test("View: unknown method returns 405", async () => {
+  class MyView extends View {
+    get(_req: Request, _params: Record<string, string>): Response {
+      return new Response("ok");
+    }
+  }
+
+  const handler = MyView.as_view();
+  const res = await handler(makeRequest("/", "POST"), {});
+  assertEquals(res.status, 405);
+});
+
+Deno.test("View: as_view() applies initkwargs", async () => {
+  class MyView extends View {
+    message = "default";
+
+    get(_req: Request, _params: Record<string, string>): Response {
+      return new Response(this.message);
+    }
+  }
+
+  const handler = MyView.as_view({ message: "overridden" });
+  const res = await handler(makeRequest(), {});
+  assertEquals(await res.text(), "overridden");
+});
+
+Deno.test("View: OPTIONS returns Allow header", async () => {
+  class MyView extends View {
+    get(_req: Request, _params: Record<string, string>): Response {
+      return new Response("ok");
+    }
+  }
+
+  const handler = MyView.as_view();
+  const res = await handler(makeRequest("/", "OPTIONS"), {});
+  assertEquals(res.status, 200);
+  assertStringIncludes(res.headers.get("Allow") ?? "", "GET");
+  assertStringIncludes(res.headers.get("Allow") ?? "", "OPTIONS");
+});
+
+Deno.test("View: fresh instance per request (no shared state)", async () => {
+  let callCount = 0;
+
+  class CountingView extends View {
+    count = 0;
+
+    get(_req: Request, _params: Record<string, string>): Response {
+      callCount++;
+      this.count++;
+      return new Response(String(this.count));
+    }
+  }
+
+  const handler = CountingView.as_view();
+  const r1 = await handler(makeRequest(), {});
+  const r2 = await handler(makeRequest(), {});
+  // Each call gets a fresh instance, so count is always 1
+  assertEquals(await r1.text(), "1");
+  assertEquals(await r2.text(), "1");
+  assertEquals(callCount, 2);
+});
+
+// =============================================================================
+// ContextMixin
+// =============================================================================
+
+Deno.test("ContextMixin: getContextData returns empty object by default", async () => {
+  const mixin = new ContextMixin();
+  const ctx = await mixin.getContextData(makeRequest(), {});
+  assertEquals(ctx, {});
+});
+
+Deno.test("ContextMixin: getContextData merges extra", async () => {
+  const mixin = new ContextMixin();
+  const ctx = await mixin.getContextData(makeRequest(), {}, {
+    foo: "bar",
+  });
+  assertEquals(ctx, { foo: "bar" });
+});
+
+// =============================================================================
+// TemplateResponseMixin
+// =============================================================================
+
+Deno.test("TemplateResponseMixin: getTemplateName throws without templateName", () => {
+  const mixin = new TemplateResponseMixin();
+  let threw = false;
+  try {
+    mixin.getTemplateName();
+  } catch {
+    threw = true;
+  }
+  assertEquals(threw, true);
+});
+
+Deno.test("TemplateResponseMixin: getTemplateName returns templateName", () => {
+  const mixin = new TemplateResponseMixin();
+  mixin.templateName = "myapp/index.html";
+  assertEquals(mixin.getTemplateName(), "myapp/index.html");
+});
+
+// =============================================================================
+// TemplateView
+// =============================================================================
+
+Deno.test("TemplateView: renders template", async () => {
+  const loader = new MemoryTemplateLoader();
+  loader.register("test/hello.html", "<p>Hello {{ name }}</p>");
+
+  class HelloView extends TemplateView {
+    override templateName = "test/hello.html";
+    override templateLoader = loader;
+
+    override async getContextData(
+      request: Request,
+      params: Record<string, string>,
+    ) {
+      return {
+        ...(await super.getContextData(request, params)),
+        name: "World",
+      };
+    }
+  }
+
+  const handler = HelloView.as_view();
+  const res = await handler(makeRequest(), {});
+  assertEquals(res.status, 200);
+  assertStringIncludes(await res.text(), "Hello World");
+  assertStringIncludes(
+    res.headers.get("Content-Type") ?? "",
+    "text/html",
+  );
+});
+
+Deno.test("TemplateView: as_view with templateName initkwarg", async () => {
+  const loader = new MemoryTemplateLoader();
+  loader.register("test/simple.html", "<h1>Simple</h1>");
+
+  // Temporarily set in registry for this test
+  templateRegistry.register("test/simple.html", "<h1>Simple</h1>");
+
+  const handler = TemplateView.as_view({ templateName: "test/simple.html" });
+  const res = await handler(makeRequest(), {});
+  assertEquals(res.status, 200);
+  assertStringIncludes(await res.text(), "Simple");
+});
+
+Deno.test("TemplateView: 500 for missing template", async () => {
+  class MissingView extends TemplateView {
+    override templateName = "does/not/exist.html";
+  }
+
+  const handler = MissingView.as_view();
+  const res = await handler(makeRequest(), {});
+  assertEquals(res.status, 500);
+});
+
+// =============================================================================
+// RedirectView
+// =============================================================================
+
+Deno.test("RedirectView: temporary redirect (302)", async () => {
+  const handler = RedirectView.as_view({ url: "/new/" });
+  const res = await handler(makeRequest(), {});
+  assertEquals(res.status, 302);
+  assertEquals(res.headers.get("Location"), "/new/");
+});
+
+Deno.test("RedirectView: permanent redirect (301)", async () => {
+  const handler = RedirectView.as_view({ url: "/new/", permanent: true });
+  const res = await handler(makeRequest(), {});
+  assertEquals(res.status, 301);
+});
+
+Deno.test("RedirectView: substitutes URL params", async () => {
+  const handler = RedirectView.as_view({ url: "/users/:username/profile/" });
+  const res = await handler(makeRequest(), { username: "alice" });
+  assertEquals(res.headers.get("Location"), "/users/alice/profile/");
+});
+
+Deno.test("RedirectView: forwards query string", async () => {
+  const handler = RedirectView.as_view({
+    url: "/new/",
+    queryStringForward: true,
+  });
+  const res = await handler(makeRequest("http://localhost/old/?foo=bar"), {});
+  assertEquals(res.headers.get("Location"), "/new/?foo=bar");
+});
+
+Deno.test("RedirectView: does not forward query string when disabled", async () => {
+  const handler = RedirectView.as_view({
+    url: "/new/",
+    queryStringForward: false,
+  });
+  const res = await handler(makeRequest("http://localhost/old/?foo=bar"), {});
+  assertEquals(res.headers.get("Location"), "/new/");
+});
+
+Deno.test("RedirectView: 410 when url is null and getRedirectUrl returns null", async () => {
+  class NullRedirect extends RedirectView {
+    override getRedirectUrl() {
+      return null;
+    }
+  }
+
+  const handler = NullRedirect.as_view();
+  const res = await handler(makeRequest(), {});
+  assertEquals(res.status, 410);
+});
+
+Deno.test("RedirectView: dynamic override via getRedirectUrl", async () => {
+  class DynamicRedirect extends RedirectView {
+    override getRedirectUrl(
+      _req: Request,
+      params: Record<string, string>,
+    ): string {
+      return `/profile/${params.id}/`;
+    }
+  }
+
+  const handler = DynamicRedirect.as_view();
+  const res = await handler(makeRequest(), { id: "42" });
+  assertEquals(res.headers.get("Location"), "/profile/42/");
+});
+
+// =============================================================================
+// ListView
+// =============================================================================
+
+Deno.test({
+  name: "ListView: renders object_list in template",
+  async fn() {
+    const backend = new DenoKVBackend({ name: "test_list", path: ":memory:" });
+    await backend.connect();
+    registerBackend("default", backend);
+
+    try {
+      await NoteModel.objects.create({ title: "Note A", priority: 1 });
+      await NoteModel.objects.create({ title: "Note B", priority: 2 });
+
+      const loader = new MemoryTemplateLoader();
+      loader.register(
+        "test/note_list.html",
+        "{% for note in object_list %}{{ note.title }}{% endfor %}",
+      );
+
+      class NoteListView extends ListView<NoteModel> {
+        override model = NoteModel;
+        override templateName = "test/note_list.html";
+        override templateLoader = loader;
+      }
+
+      const handler = NoteListView.as_view();
+      const res = await handler(makeRequest(), {});
+      assertEquals(res.status, 200);
+      const body = await res.text();
+      assertStringIncludes(body, "Note A");
+      assertStringIncludes(body, "Note B");
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});
+
+Deno.test({
+  name: "ListView: paginates object_list",
+  async fn() {
+    const backend = new DenoKVBackend({
+      name: "test_list_page",
+      path: ":memory:",
+    });
+    await backend.connect();
+    registerBackend("default", backend);
+
+    try {
+      for (let i = 1; i <= 5; i++) {
+        await NoteModel.objects.create({ title: `Note ${i}`, priority: i });
+      }
+
+      const loader = new MemoryTemplateLoader();
+      loader.register(
+        "test/note_page.html",
+        "count:{{ page_obj.count }} page:{{ page_obj.number }} pages:{{ page_obj.numPages }}",
+      );
+
+      class PagedListView extends ListView<NoteModel> {
+        override model = NoteModel;
+        override templateName = "test/note_page.html";
+        override templateLoader = loader;
+        override paginateBy = 2;
+      }
+
+      const handler = PagedListView.as_view();
+      // Page 1
+      const res1 = await handler(makeRequest("http://localhost/?page=1"), {});
+      const body1 = await res1.text();
+      assertStringIncludes(body1, "count:5");
+      assertStringIncludes(body1, "page:1");
+      assertStringIncludes(body1, "pages:3");
+
+      // Page 2
+      const res2 = await handler(makeRequest("http://localhost/?page=2"), {});
+      assertStringIncludes(await res2.text(), "page:2");
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});
+
+Deno.test({
+  name: "ListView: custom queryset via getQueryset()",
+  async fn() {
+    const backend = new DenoKVBackend({
+      name: "test_list_qs",
+      path: ":memory:",
+    });
+    await backend.connect();
+    registerBackend("default", backend);
+
+    try {
+      await NoteModel.objects.create({ title: "Low", priority: 1 });
+      await NoteModel.objects.create({ title: "High", priority: 10 });
+
+      const loader = new MemoryTemplateLoader();
+      loader.register(
+        "test/note_filtered.html",
+        "{% for note in object_list %}{{ note.title }}{% endfor %}",
+      );
+
+      class HighPriorityListView extends ListView<NoteModel> {
+        override model = NoteModel;
+        override templateName = "test/note_filtered.html";
+        override templateLoader = loader;
+
+        override getQueryset() {
+          return NoteModel.objects.filter({ priority__gte: 5 });
+        }
+      }
+
+      const handler = HighPriorityListView.as_view();
+      const res = await handler(makeRequest(), {});
+      const body = await res.text();
+      assertStringIncludes(body, "High");
+      assertEquals(body.includes("Low"), false);
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});
+
+// =============================================================================
+// DetailView
+// =============================================================================
+
+Deno.test({
+  name: "DetailView: renders single object by id",
+  async fn() {
+    const backend = new DenoKVBackend({
+      name: "test_detail",
+      path: ":memory:",
+    });
+    await backend.connect();
+    registerBackend("default", backend);
+
+    try {
+      const note = await NoteModel.objects.create({
+        title: "My Note",
+        priority: 5,
+      });
+      const noteId = String(note.id.get());
+
+      const loader = new MemoryTemplateLoader();
+      loader.register("test/note_detail.html", "{{ object.title }}");
+
+      class NoteDetailView extends DetailView<NoteModel> {
+        override model = NoteModel;
+        override templateName = "test/note_detail.html";
+        override templateLoader = loader;
+      }
+
+      const handler = NoteDetailView.as_view();
+      const res = await handler(makeRequest(), { id: noteId });
+      assertEquals(res.status, 200);
+      assertStringIncludes(await res.text(), "My Note");
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});
+
+Deno.test({
+  name: "DetailView: 404 for missing object",
+  async fn() {
+    const backend = new DenoKVBackend({
+      name: "test_detail_404",
+      path: ":memory:",
+    });
+    await backend.connect();
+    registerBackend("default", backend);
+
+    try {
+      const loader = new MemoryTemplateLoader();
+      loader.register("test/note_detail.html", "{{ object.title }}");
+
+      class NoteDetailView extends DetailView<NoteModel> {
+        override model = NoteModel;
+        override templateName = "test/note_detail.html";
+        override templateLoader = loader;
+      }
+
+      const handler = NoteDetailView.as_view();
+      const res = await handler(makeRequest(), { id: "9999" });
+      assertEquals(res.status, 404);
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});
+
+Deno.test({
+  name: "DetailView: adds model-name convenience context key",
+  async fn() {
+    const backend = new DenoKVBackend({
+      name: "test_detail_ctx",
+      path: ":memory:",
+    });
+    await backend.connect();
+    registerBackend("default", backend);
+
+    try {
+      const note = await NoteModel.objects.create({
+        title: "Context Note",
+        priority: 1,
+      });
+      const noteId = String(note.id.get());
+
+      const loader = new MemoryTemplateLoader();
+      // Access via model-name key "note" (NoteModel → note)
+      loader.register("test/note_ctx.html", "{{ note.title }}");
+
+      class NoteDetailView extends DetailView<NoteModel> {
+        override model = NoteModel;
+        override templateName = "test/note_ctx.html";
+        override templateLoader = loader;
+      }
+
+      const handler = NoteDetailView.as_view();
+      const res = await handler(makeRequest(), { id: noteId });
+      assertEquals(res.status, 200);
+      assertStringIncludes(await res.text(), "Context Note");
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});


### PR DESCRIPTION
## Summary

- Implements Django-style class-based views mirroring `django.views.generic`
- `View` — base class with `as_view()`, fresh instance per request, 405/OPTIONS handling
- `TemplateView` — renders a named template with context via `getContextData()`
- `RedirectView` — permanent/temporary redirects with query string forwarding and URL param substitution
- `ListView` — fetches a queryset, converts instances to plain objects, optional pagination
- `DetailView` — fetches a single object by PK or slug, 404 on not found
- `ContextMixin`, `TemplateResponseMixin`, `SingleObjectMixin`, `MultipleObjectMixin` mixins exported for composition
- 25 tests covering all classes and edge cases
- `AGENTS.md` updated with full CBV documentation and examples

Closes #230