### PR TITLE
fix(core): add explicit CLI application API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,11 @@ alexi/
 └── README.md
 ```
 
+`ManagementUtility` defaults to a generic CLI runner, so help output stays
+neutral and only explicitly registered commands are shown. For user-facing CLI
+tools, prefer `getCliApplication()`. Alexi's own `manage.ts` should use the same
+API with explicit command registration.
+
 ---
 
 ## Naming Conventions

--- a/docs/core/management.md
+++ b/docs/core/management.md
@@ -351,11 +351,12 @@ You can also register commands manually in `manage.ts`:
 
 ```ts
 // manage.ts
-import { ManagementUtility } from "@alexi/core/management";
+import { getCliApplication } from "@alexi/core/management";
 import { MyCommand } from "./src/myapp/commands/mycommand.ts";
 
-const cli = new ManagementUtility({
+const cli = await getCliApplication({
   commands: [MyCommand],
+  programName: "myapp",
 });
 
 await cli.execute(Deno.args);
@@ -363,34 +364,55 @@ await cli.execute(Deno.args);
 
 ---
 
-## ManagementUtility
+## `getCliApplication()`
 
-The `ManagementUtility` class is the main entry point for the CLI:
+`getCliApplication()` is the recommended entry point for building a CLI:
 
 ```ts
-import { ManagementUtility } from "@alexi/core/management";
+import {
+  alexi_management_commands,
+  getCliApplication,
+} from "@alexi/core/management";
 
-// Basic usage
-const cli = new ManagementUtility();
+// Basic usage for a custom CLI
+const cli = await getCliApplication({ programName: "myapp" });
 await cli.execute(Deno.args);
 
+// Alexi/Django-style manage.ts behavior via explicit commands
+const manage = await getCliApplication({
+  programName: "manage.ts",
+  title: "Alexi Management Commands",
+  commands: alexi_management_commands,
+});
+await manage.execute(Deno.args);
+
 // With options
-const cli = new ManagementUtility({
+const configured = await getCliApplication({
   debug: true,
   projectRoot: "./myproject",
   commands: [MyCommand, AnotherCommand],
+  programName: "myapp",
 });
 
-await cli.execute(Deno.args);
+await configured.execute(Deno.args);
 ```
 
 ### Configuration
 
-| Option        | Type                   | Description            |
-| ------------- | ---------------------- | ---------------------- |
-| `debug`       | `boolean`              | Enable debug mode      |
-| `projectRoot` | `string`               | Project root directory |
-| `commands`    | `CommandConstructor[]` | Commands to register   |
+| Option        | Type                   | Description                       |
+| ------------- | ---------------------- | --------------------------------- |
+| `debug`       | `boolean`              | Enable debug mode                 |
+| `projectRoot` | `string`               | Project root directory            |
+| `commands`    | `CommandConstructor[]` | Commands to register              |
+| `programName` | `string`               | Program name shown in usage/help  |
+| `title`       | `string`               | Help title shown in general help  |
+| `usage`       | `string \| string[]`   | Override help usage text          |
+| `version`     | `string`               | Version text shown by `--version` |
+
+## `ManagementUtility`
+
+`ManagementUtility` remains available as the lower-level CLI runner used by
+`getCliApplication()`.
 
 ### Methods
 

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -31,9 +31,9 @@ await setup({
 ## Management Commands
 
 ```typescript
-import { BaseCommand, ManagementUtility } from "@alexi/core/management";
+import { BaseCommand, getCliApplication } from "@alexi/core/management";
 
-const cli = new ManagementUtility();
+const cli = await getCliApplication({ programName: "my-cli" });
 await cli.execute(Deno.args);
 ```
 

--- a/src/core/management/base_command.ts
+++ b/src/core/management/base_command.ts
@@ -99,11 +99,23 @@ export abstract class BaseCommand implements ICommand {
   protected stderr: IConsole = console;
 
   /**
+   * Program name used in help output.
+   */
+  protected programName = "manage.ts";
+
+  /**
    * Set the console implementations (useful for testing)
    */
   setConsole(stdout: IConsole, stderr?: IConsole): void {
     this.stdout = stdout;
     this.stderr = stderr ?? stdout;
+  }
+
+  /**
+   * Set the displayed program name for help examples.
+   */
+  setProgramName(programName: string): void {
+    this.programName = programName;
   }
 
   // ===========================================================================
@@ -224,7 +236,7 @@ export abstract class BaseCommand implements ICommand {
     const lines: string[] = [];
 
     // Header
-    lines.push(`Usage: manage.ts ${this.name} [options]`);
+    lines.push(`Usage: ${this.programName} ${this.name} [options]`);
     lines.push("");
 
     // Description

--- a/src/core/management/commands/help.ts
+++ b/src/core/management/commands/help.ts
@@ -11,6 +11,7 @@ import type {
   CommandOptions,
   CommandResult,
   IArgumentParser,
+  UsageConfig,
 } from "../types.ts";
 import type { CommandRegistry } from "../registry.ts";
 
@@ -39,6 +40,9 @@ export class HelpCommand extends BaseCommand {
   override readonly description = "Shows a list of all available commands, " +
     "or detailed help for a specific command.";
 
+  private title = "Available Commands";
+  private usage: string[] = ["Usage: cli <command> [arguments]"];
+
   override readonly examples = [
     "manage.ts help              - List all commands",
     "manage.ts help runserver    - Show help for runserver command",
@@ -54,6 +58,18 @@ export class HelpCommand extends BaseCommand {
    */
   setRegistry(registry: CommandRegistry): void {
     this.registry = registry;
+  }
+
+  setDisplayOptions(options: { title?: string; usage?: UsageConfig }): void {
+    if (options.title) {
+      this.title = options.title;
+    }
+
+    if (options.usage) {
+      this.usage = Array.isArray(options.usage)
+        ? options.usage
+        : [options.usage];
+    }
   }
 
   // ===========================================================================
@@ -104,6 +120,9 @@ export class HelpCommand extends BaseCommand {
 
     // Use the command's own help printing if it's a BaseCommand
     if ("printHelp" in command && typeof command.printHelp === "function") {
+      if (command instanceof BaseCommand) {
+        command.setProgramName(this.programName);
+      }
       (command as BaseCommand).printHelp();
     } else {
       this.stdout.log(`${command.name}: ${command.help}`);
@@ -118,11 +137,12 @@ export class HelpCommand extends BaseCommand {
   private showGeneralHelp(): CommandResult {
     const lines: string[] = [];
 
-    lines.push("┌─────────────────────────────────────────────┐");
-    lines.push("│         Alexi Management Commands           │");
-    lines.push("└─────────────────────────────────────────────┘");
-    lines.push("");
-    lines.push("Usage: deno run -A manage.ts <command> [arguments]");
+    if (this.title.length > 0) {
+      lines.push(this.title);
+      lines.push("");
+    }
+
+    lines.push(...this.usage);
     lines.push("");
 
     if (this.registry) {

--- a/src/core/management/management.ts
+++ b/src/core/management/management.ts
@@ -17,9 +17,11 @@ import { MigrateCommand } from "./commands/migrate.ts";
 import { ShowmigrationsCommand } from "./commands/showmigrations.ts";
 import { SqlmigrateCommand } from "./commands/sqlmigrate.ts";
 import type {
+  CliApplicationConfig,
   CommandConstructor,
   IConsole,
   ManagementConfig,
+  UsageConfig,
 } from "./types.ts";
 import type { AppConfig } from "@alexi/types";
 
@@ -67,16 +69,16 @@ type AppImportFn = () => Promise<
  *
  * @example Basic usage
  * ```ts
- * // manage.ts
- * import { ManagementUtility } from "@alexi/management";
+ * // cli.ts
+ * import { getCliApplication } from "@alexi/core/management";
  *
- * const cli = new ManagementUtility();
+ * const cli = await getCliApplication({ programName: "my-cli" });
  * await cli.execute(Deno.args);
  * ```
  *
  * @example With custom commands
  * ```ts
- * import { ManagementUtility, BaseCommand } from "@alexi/management";
+ * import { getCliApplication, BaseCommand } from "@alexi/core/management";
  *
  * class MyCommand extends BaseCommand {
  *   name = "mycommand";
@@ -84,8 +86,10 @@ type AppImportFn = () => Promise<
  *   async handle() { ... }
  * }
  *
- * const cli = new ManagementUtility();
- * cli.registerCommand(MyCommand);
+ * const cli = await getCliApplication({
+ *   programName: "my-cli",
+ *   commands: [MyCommand],
+ * });
  * await cli.execute(Deno.args);
  * ```
  */
@@ -93,6 +97,10 @@ export class ManagementUtility {
   private readonly registry: CommandRegistry;
   private readonly debug: boolean;
   private readonly projectRoot: string;
+  private readonly programName: string;
+  private readonly title: string;
+  private readonly usage: string[];
+  private readonly version: string;
   private stdout: IConsole = console;
   private stderr: IConsole = console;
 
@@ -111,6 +119,13 @@ export class ManagementUtility {
     this.registry = new CommandRegistry();
     this.debug = config.debug ?? Deno.env.get("DEBUG") === "true";
     this.projectRoot = config.projectRoot ?? Deno.cwd();
+    this.programName = config.programName ?? "cli";
+    this.title = config.title ?? "Available Commands";
+    this.usage = this.normalizeUsage(
+      config.usage,
+      this.programName,
+    );
+    this.version = config.version ?? this.programName;
 
     // Register built-in commands
     this.registerBuiltinCommands();
@@ -138,38 +153,25 @@ export class ManagementUtility {
    */
   private registerBuiltinCommands(): void {
     // Register help command and set registry reference
-    const helpCommand = new HelpCommand();
+    const helpCommand = this.registry.register(HelpCommand) as HelpCommand;
     helpCommand.setRegistry(this.registry);
-    this.registry.register(
-      class extends HelpCommand {
-        constructor() {
-          super();
-          this.setRegistry(helpCommand["registry"]!);
-        }
-      },
-    );
-    // Replace with the configured instance
-    (this.registry as unknown as { commands: Map<string, unknown> }).commands
-      .set("help", helpCommand);
+    helpCommand.setDisplayOptions({
+      title: this.title,
+      usage: this.usage,
+    });
 
-    // Register test command
-    this.registry.register(TestCommand);
+    // Framework commands are opt-in and can be registered explicitly.
+  }
 
-    // Register startapp command
-    this.registry.register(StartAppCommand);
+  private normalizeUsage(
+    usage: UsageConfig | undefined,
+    programName: string,
+  ): string[] {
+    if (usage) {
+      return Array.isArray(usage) ? usage : [usage];
+    }
 
-    // Register flush command (core command, like Django's flush)
-    this.registry.register(FlushCommand);
-
-    // Register migration commands (live in @alexi/core/management to avoid
-    // circular dependency with @alexi/db)
-    this.registry.register(MakemigrationsCommand);
-    this.registry.register(MigrateCommand);
-    this.registry.register(ShowmigrationsCommand);
-    this.registry.register(SqlmigrateCommand);
-
-    // Note: Other commands (createsuperuser, bundle, collectstatic, runserver)
-    // are loaded dynamically from INSTALLED_APPS via loadAppCommands()
+    return [`Usage: ${programName} <command> [arguments]`];
   }
 
   /**
@@ -508,6 +510,7 @@ export class ManagementUtility {
     // Configure command output if it's a BaseCommand
     if (command instanceof BaseCommand) {
       command.setConsole(this.stdout, this.stderr);
+      command.setProgramName(this.programName);
     }
 
     try {
@@ -552,11 +555,11 @@ export class ManagementUtility {
    */
   private showUsage(): void {
     this.stdout.log("");
-    this.stdout.log("Alexi Management Utility");
+    this.stdout.log(this.title);
     this.stdout.log("");
-    this.stdout.log("Usage:");
-    this.stdout.log("  deno task <command> [options]");
-    this.stdout.log("  deno run -A manage.ts <command> [options]");
+    for (const line of this.usage) {
+      this.stdout.log(line);
+    }
     this.stdout.log("");
     this.stdout.log("Available commands:");
 
@@ -573,7 +576,7 @@ export class ManagementUtility {
    * Show version information
    */
   private showVersion(): void {
-    this.stdout.log("Alexi Framework v0.8.0");
+    this.stdout.log(this.version);
   }
 
   // ===========================================================================
@@ -615,6 +618,29 @@ export class ManagementUtility {
  * @returns Exit code
  */
 export async function execute(args: string[] = Deno.args): Promise<number> {
-  const cli = new ManagementUtility();
+  const cli = await getCliApplication();
   return await cli.execute(args);
 }
+
+/**
+ * Create a CLI application with explicit command configuration.
+ */
+export async function getCliApplication(
+  config: CliApplicationConfig = {},
+): Promise<ManagementUtility> {
+  return new ManagementUtility(config);
+}
+
+/**
+ * Alexi framework management commands.
+ */
+export const alexi_management_commands: CommandConstructor[] = [
+  HelpCommand,
+  TestCommand,
+  StartAppCommand,
+  FlushCommand,
+  MakemigrationsCommand,
+  MigrateCommand,
+  ShowmigrationsCommand,
+  SqlmigrateCommand,
+];

--- a/src/core/management/mod.ts
+++ b/src/core/management/mod.ts
@@ -9,9 +9,9 @@
  *
  * @example manage.ts
  * ```ts
- * import { ManagementUtility } from "@alexi/core/management";
+ * import { getCliApplication } from "@alexi/core/management";
  *
- * const cli = new ManagementUtility();
+ * const cli = await getCliApplication({ programName: "my-cli" });
  * const exitCode = await cli.execute(Deno.args);
  * Deno.exit(exitCode);
  * ```
@@ -21,7 +21,12 @@
 // CLI
 // =============================================================================
 
-export { execute, ManagementUtility } from "./management.ts";
+export {
+  alexi_management_commands,
+  execute,
+  getCliApplication,
+  ManagementUtility,
+} from "./management.ts";
 
 /** @deprecated Use import functions in INSTALLED_APPS instead. */
 export { pathToFileUrl } from "./management.ts";
@@ -84,6 +89,7 @@ export {
 export type {
   ArgumentConfig,
   ArgumentType,
+  CliApplicationConfig,
   CommandConstructor,
   CommandMeta,
   CommandOptions,

--- a/src/core/management/registry.ts
+++ b/src/core/management/registry.ts
@@ -68,7 +68,7 @@ export class CommandRegistry implements ICommandRegistry {
   register(
     CommandClass: CommandConstructor,
     options: { override?: boolean } = {},
-  ): void {
+  ): ICommand {
     const { override = true } = options;
     const command = new CommandClass();
     const name = command.name;
@@ -81,6 +81,7 @@ export class CommandRegistry implements ICommandRegistry {
     }
 
     this.commands.set(name, command);
+    return command;
   }
 
   /**

--- a/src/core/management/types.ts
+++ b/src/core/management/types.ts
@@ -154,13 +154,18 @@ export interface ICommand {
 export type CommandConstructor = new () => ICommand;
 
 /**
+ * Usage text shown in help output.
+ */
+export type UsageConfig = string | string[];
+
+/**
  * Registry of available commands
  */
 export interface ICommandRegistry {
   /**
    * Register a command
    */
-  register(command: CommandConstructor): void;
+  register(command: CommandConstructor): ICommand;
 
   /**
    * Get a command by name
@@ -192,9 +197,26 @@ export interface ManagementConfig {
   /** Project root directory */
   projectRoot?: string;
 
+  /** Optional help title */
+  title?: string;
+
+  /** Program name shown in usage text */
+  programName?: string;
+
+  /** Override help usage text */
+  usage?: UsageConfig;
+
+  /** Version text shown by --version */
+  version?: string;
+
   /** Custom commands to register */
   commands?: CommandConstructor[];
 }
+
+/**
+ * Configuration for high-level CLI application creation.
+ */
+export type CliApplicationConfig = ManagementConfig;
 
 /**
  * Console output interface for testability

--- a/src/core/tests/management.test.ts
+++ b/src/core/tests/management.test.ts
@@ -5,7 +5,11 @@
  */
 
 import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
-import { ManagementUtility } from "../management/management.ts";
+import {
+  alexi_management_commands,
+  getCliApplication,
+  ManagementUtility,
+} from "../management/management.ts";
 import { BaseCommand, success } from "../management/base_command.ts";
 import type {
   CommandOptions,
@@ -56,7 +60,7 @@ class GreetCommand extends BaseCommand {
   readonly name = "greet";
   readonly help = "Greet someone";
 
-  addArguments(parser: IArgumentParser): void {
+  override addArguments(parser: IArgumentParser): void {
     parser.addArgument("--name", {
       type: "string",
       default: "World",
@@ -75,7 +79,7 @@ class EchoCommand extends BaseCommand {
   readonly name = "echo";
   readonly help = "Echo a message";
 
-  addArguments(parser: IArgumentParser): void {
+  override addArguments(parser: IArgumentParser): void {
     parser.addArgument("message", {
       required: true,
       help: "Message to echo",
@@ -140,7 +144,7 @@ Deno.test("ManagementUtility - shows version with --version", async () => {
 
   assertEquals(exitCode, 0);
   assertEquals(
-    mockConsole.logs.some((log) => log.includes("Alexi Management")),
+    mockConsole.logs.some((log) => log.includes("cli")),
     true,
   );
 });
@@ -171,15 +175,38 @@ Deno.test("ManagementUtility - has built-in help command", async () => {
   // The important thing is that exitCode is 0 (success)
 });
 
-Deno.test("ManagementUtility - has built-in help and test commands", () => {
+Deno.test("ManagementUtility - has only minimal built-in commands by default", () => {
   const cli = new ManagementUtility();
 
   const registry = cli.getRegistry();
 
-  // Only help and test are built-in core commands
-  // runserver comes from INSTALLED_APPS (alexi_web, alexi_staticfiles, alexi_webui)
+  assertEquals(registry.has("help"), true);
+  assertEquals(registry.has("test"), false);
+  assertEquals(registry.has("flush"), false);
+  assertEquals(registry.has("startapp"), false);
+});
+
+Deno.test("ManagementUtility - framework commands are opt-in", () => {
+  const cli = new ManagementUtility({ commands: alexi_management_commands });
+
+  const registry = cli.getRegistry();
+
   assertEquals(registry.has("help"), true);
   assertEquals(registry.has("test"), true);
+  assertEquals(registry.has("flush"), true);
+  assertEquals(registry.has("startapp"), true);
+});
+
+Deno.test("getCliApplication - creates configured CLI application", async () => {
+  const cli = await getCliApplication({
+    programName: "asr",
+    title: "ASR Commands",
+    commands: [GreetCommand],
+  });
+
+  assertEquals(cli.getRegistry().has("help"), true);
+  assertEquals(cli.getRegistry().has("greet"), true);
+  assertEquals(cli.getRegistry().has("test"), false);
 });
 
 // =============================================================================
@@ -245,6 +272,44 @@ Deno.test("ManagementUtility - accepts commands via config", async () => {
   assertEquals(exitCode, 0);
   assertEquals(cli.getRegistry().has("greet"), true);
   assertEquals(cli.getRegistry().has("echo"), true);
+});
+
+Deno.test("ManagementUtility - uses custom title and usage in help output", async () => {
+  const mockConsole = new MockConsole();
+  const cli = new ManagementUtility({
+    title: "ASR Commands",
+    programName: "asr",
+  });
+  cli.setConsole(mockConsole);
+
+  const exitCode = await cli.execute(["help"]);
+
+  assertEquals(exitCode, 0);
+  assertEquals(
+    mockConsole.logs.some((log) => log.includes("ASR Commands")),
+    true,
+  );
+  assertEquals(
+    mockConsole.logs.some((log) =>
+      log.includes("Usage: asr <command> [arguments]")
+    ),
+    true,
+  );
+});
+
+Deno.test("ManagementUtility - uses program name for command help", async () => {
+  const mockConsole = new MockConsole();
+  const cli = new ManagementUtility({ programName: "asr" });
+  cli.setConsole(mockConsole);
+  cli.registerCommand(GreetCommand);
+
+  const exitCode = await cli.execute(["greet", "--help"]);
+
+  assertEquals(exitCode, 0);
+  assertEquals(
+    mockConsole.logs.some((log) => log.includes("Usage: asr greet [options]")),
+    true,
+  );
 });
 
 // =============================================================================

--- a/src/create/templates/root/manage_ts.ts
+++ b/src/create/templates/root/manage_ts.ts
@@ -17,9 +17,22 @@ export function generateManageTs(): string {
  *   deno task test    # Run tests
  */
 
-import { ManagementUtility } from "@alexi/core/management";
+import {
+  alexi_management_commands,
+  getCliApplication,
+} from "@alexi/core/management";
 
-const management = new ManagementUtility();
+const management = await getCliApplication({
+  programName: "manage.ts",
+  title: "Alexi Management Commands",
+  usage: [
+    "Usage:",
+    "  deno task <command> [options]",
+    "  deno run -A manage.ts <command> [options]",
+  ],
+  version: "Alexi Framework v0.8.0",
+  commands: alexi_management_commands,
+});
 await management.execute(Deno.args);
 `;
 }


### PR DESCRIPTION
## Summary

- add `getCliApplication()` as the recommended public API for CLI apps and keep `ManagementUtility` as the lower-level runner
- make framework management commands opt-in via explicit registration so custom CLIs no longer inherit Alexi branding or commands by default
- update the scaffolded `manage.ts`, tests, and docs to use the same explicit CLI configuration model

Closes #232