### PR TITLE
fix(db): add index signature to FieldOptions to fix ModelSerializer subclass type error

### DIFF
--- a/src/db/fields/field.ts
+++ b/src/db/fields/field.ts
@@ -25,6 +25,8 @@ export type Validator<T> = (value: T | null) => {
  * Field options interface
  */
 export interface FieldOptions<T> {
+  /** Index signature to satisfy structural type checks (e.g. ModelFieldLike). */
+  [key: string]: unknown;
   /** Allow NULL values in database */
   null?: boolean;
   /** Allow blank/empty values (validation only) */


### PR DESCRIPTION
## Summary

- Adds `[key: string]: unknown` index signature to `FieldOptions<T>` interface
- This makes `FieldOptions<T>` structurally compatible with `ModelFieldLike.options` which requires an index signature
- Fixes TypeScript error when extending `ModelSerializer` with a custom `Meta.model`

Closes #242