### PR TITLE
fix(db): add index signature to Model class to satisfy ModelLike structural type check

### DIFF
--- a/src/db/models/model.ts
+++ b/src/db/models/model.ts
@@ -316,6 +316,13 @@ export class ModelRegistry {
  */
 export abstract class Model {
   /**
+   * Index signature so Model instances satisfy structural type checks that
+   * require `{ [key: string]: unknown }` (e.g. `ModelLike` in restframework).
+   * At runtime this is backed by the Proxy returned from the constructor.
+   */
+  [key: string]: unknown;
+
+  /**
    * Model metadata
    */
   static meta: ModelMeta = {};


### PR DESCRIPTION
## Summary

- Adds `[key: string]: unknown` index signature to the `Model` base class
- `ModelLike` (in `@alexi/restframework`) requires this index signature, but `Model` lacked it — causing a TypeScript error when setting a concrete Model subclass as `Meta.model` in a `ModelSerializer`
- At runtime the Proxy returned from `Model`'s constructor already supports dynamic property access; this change makes TypeScript aware of it

Closes #242