### PR TITLE
fix(db): fix selectRelated silently dropped by _clone() cache propagation and fetch() fast-path

### DIFF
--- a/src/db/query/queryset.ts
+++ b/src/db/query/queryset.ts
@@ -119,18 +119,30 @@ export class QuerySet<T extends Model> implements AsyncIterable<T> {
 
   /**
    * Clone this QuerySet with a modified state
+   *
+   * Clones intentionally do NOT inherit `_isFetched` or `_cache` from the
+   * parent. Propagating those flags caused a subtle bug: clones created by
+   * chaining methods (e.g. `limit()`, `selectRelated()`) would appear already
+   * fetched, so a subsequent `fetch()` call would hit the early-return path
+   * and never call `_loadRelatedObjects`, silently dropping `selectRelated`.
+   *
+   * The only place that deliberately preserves cache state is `filter()` when
+   * applied to an already-fetched QuerySet — that path uses `_fromState`
+   * directly with explicit cache/isFetched arguments.
    */
   private _clone(modifier?: (state: QueryState<T>) => void): QuerySet<T> {
     const newState = cloneQueryState(this._state);
     if (modifier) {
       modifier(newState);
     }
-    // Clone preserves fetched state, cache, and isEmpty flag
+    // Do NOT propagate _isFetched / _cache — clones always start unfetched.
+    // isEmpty is preserved because none() QuerySets must stay empty through
+    // all chaining (no database query should ever run on them).
     return QuerySet._fromState(
       newState,
       this._backend,
-      this._cache,
-      this._isFetched,
+      undefined,
+      undefined,
       this._isEmpty,
     );
   }
@@ -760,7 +772,20 @@ export class QuerySet<T extends Model> implements AsyncIterable<T> {
    * ```
    */
   async fetch(): Promise<this> {
+    // none() QuerySets must always return empty — never hit the database.
+    if (this._isEmpty) {
+      this._cache = [];
+      this._isFetched = true;
+      return this;
+    }
+
     if (this._isFetched && this._cache !== null) {
+      // Even in the cache fast-path, selectRelated fields must be loaded.
+      // A QuerySet can be re-fetched with new selectRelated entries added after
+      // the original fetch(), so we always ensure related objects are resolved.
+      if (this._state.selectRelated.length > 0) {
+        await this._loadRelatedObjects(this._cache);
+      }
       return this;
     }
 
@@ -1263,7 +1288,17 @@ export class QuerySet<T extends Model> implements AsyncIterable<T> {
    * ```
    */
   using(backend: DatabaseBackend | string): QuerySet<T> {
+    // _clone() deliberately does not propagate _isFetched/_cache (to prevent
+    // the selectRelated bug), but using() is the one place where we DO want
+    // to carry the cache across — the primary use-case is cross-backend sync:
+    //   const qs = await Model.objects.fetch();
+    //   await qs.using(otherBackend).save();
+    // Without cache propagation, save() would throw "QuerySet not fetched".
     const qs = this._clone();
+    // deno-lint-ignore no-explicit-any
+    (qs as any)._cache = this._cache;
+    // deno-lint-ignore no-explicit-any
+    (qs as any)._isFetched = this._isFetched;
 
     if (typeof backend === "string") {
       const namedBackend = getBackendByName(backend);

--- a/src/db/tests/foreignkey_test.ts
+++ b/src/db/tests/foreignkey_test.ts
@@ -1511,3 +1511,285 @@ Deno.test({
     }
   },
 });
+
+// ============================================================================
+// Issue #251 / #252: fetch() cache fast-path skips selectRelated;
+// _clone() must not propagate _isFetched/_cache
+// ============================================================================
+
+Deno.test({
+  name:
+    "selectRelated() + fetch() — direct fetch() respects selectRelated (Issue #251)",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = new DenoKVBackend({
+      name: "sr251-fetch-direct",
+      path: ":memory:",
+    });
+    await backend.connect();
+    registerBackend("default", backend);
+
+    try {
+      const org = await Organisation.objects.create({
+        name: "Direct Fetch Org",
+        country: "Finland",
+      });
+      await Project.objects.create({
+        name: "Direct Fetch Project",
+        organisation: org,
+      });
+
+      // Plain fetch() with selectRelated — must load related objects
+      const projects = await Project.objects
+        .selectRelated("organisation")
+        .fetch();
+
+      assertEquals(projects.array().length, 1);
+      const project = projects.array()[0];
+      assertEquals(
+        project.organisation.isLoaded(),
+        true,
+        "organisation should be loaded by selectRelated + fetch()",
+      );
+      assertEquals(project.organisation.get().name.get(), "Direct Fetch Org");
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "selectRelated() + fetch() — cache fast-path still loads related (Issue #251)",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    // Scenario: fetch() is called on a QuerySet that already has _isFetched=true.
+    // The old code returned immediately without calling _loadRelatedObjects.
+    const backend = new DenoKVBackend({
+      name: "sr251-fetch-cache",
+      path: ":memory:",
+    });
+    await backend.connect();
+    registerBackend("default", backend);
+
+    try {
+      const org = await Organisation.objects.create({
+        name: "Cache Fast-path Org",
+        country: "Sweden",
+      });
+      await Project.objects.create({
+        name: "Cache Fast-path Project",
+        organisation: org,
+      });
+
+      // Pre-fetch without selectRelated
+      const baseQs = await Project.objects.all().fetch();
+
+      // Now chain selectRelated + fetch() on the already-fetched QuerySet.
+      // With the old _clone() bug this created a clone with _isFetched=true,
+      // causing fetch() to return before _loadRelatedObjects ran.
+      const projects = await baseQs.selectRelated("organisation").fetch();
+
+      assertEquals(projects.array().length, 1);
+      const project = projects.array()[0];
+      assertEquals(
+        project.organisation.isLoaded(),
+        true,
+        "organisation should be loaded even when chained from an already-fetched QS",
+      );
+      assertEquals(
+        project.organisation.get().name.get(),
+        "Cache Fast-path Org",
+      );
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "selectRelated() + first() — chained from already-fetched QS (Issue #251)",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    // Scenario from issue #251:
+    //   Ticket.objects.filter({ id }).selectRelated("unit").first()
+    // first() calls this.limit(1) which clones the QS.
+    // Old _clone() propagated _isFetched=true, so the clone's fetch() returned
+    // immediately, silently skipping _loadRelatedObjects.
+    const backend = new DenoKVBackend({
+      name: "sr251-first-chained",
+      path: ":memory:",
+    });
+    await backend.connect();
+    registerBackend("default", backend);
+
+    try {
+      const org = await Organisation.objects.create({
+        name: "Chained First Org",
+        country: "Norway",
+      });
+      await Project.objects.create({
+        name: "Chained First Project",
+        organisation: org,
+      });
+
+      // This is the exact pattern from the issue report
+      const project = await Project.objects
+        .filter({ name: "Chained First Project" })
+        .selectRelated("organisation")
+        .first();
+
+      assertExists(project);
+      assertEquals(
+        project.organisation.isLoaded(),
+        true,
+        "organisation should be loaded — this was the bug reported in #251",
+      );
+      assertEquals(
+        project.organisation.get().name.get(),
+        "Chained First Org",
+      );
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "selectRelated() + last() — chained from already-fetched QS (Issue #251)",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = new DenoKVBackend({
+      name: "sr251-last-chained",
+      path: ":memory:",
+    });
+    await backend.connect();
+    registerBackend("default", backend);
+
+    try {
+      const org = await Organisation.objects.create({
+        name: "Chained Last Org",
+        country: "Denmark",
+      });
+      await Project.objects.create({
+        name: "Chained Last Project",
+        organisation: org,
+      });
+
+      const project = await Project.objects
+        .filter({ name: "Chained Last Project" })
+        .selectRelated("organisation")
+        .last();
+
+      assertExists(project);
+      assertEquals(project.organisation.isLoaded(), true);
+      assertEquals(
+        project.organisation.get().name.get(),
+        "Chained Last Org",
+      );
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "selectRelated() + get() — chained from already-fetched QS (Issue #251)",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = new DenoKVBackend({
+      name: "sr251-get-chained",
+      path: ":memory:",
+    });
+    await backend.connect();
+    registerBackend("default", backend);
+
+    try {
+      const org = await Organisation.objects.create({
+        name: "Chained Get Org",
+        country: "Iceland",
+      });
+      const created = await Project.objects.create({
+        name: "Chained Get Project",
+        organisation: org,
+      });
+
+      const project = await Project.objects
+        .filter({ id: created.id.get() })
+        .selectRelated("organisation")
+        .get();
+
+      assertEquals(project.organisation.isLoaded(), true);
+      assertEquals(
+        project.organisation.get().name.get(),
+        "Chained Get Org",
+      );
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "selectRelated() nested + fetch() — chained from already-fetched QS (Issue #251)",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = new DenoKVBackend({
+      name: "sr251-nested-fetch-chained",
+      path: ":memory:",
+    });
+    await backend.connect();
+    registerBackend("default", backend);
+
+    try {
+      const org = await Organisation.objects.create({
+        name: "Nested Fetch Org",
+        country: "Finland",
+      });
+      const project = await Project.objects.create({
+        name: "Nested Fetch Project",
+        organisation: org,
+      });
+      const role = await ProjectRole.objects.create({
+        name: "Nested Fetch Role",
+        project: project,
+      });
+      await ProjectRoleCompetence.objects.create({
+        level: 2,
+        projectRole: role,
+      });
+
+      // Chain nested selectRelated + fetch() on a fresh QuerySet
+      const comps = await ProjectRoleCompetence.objects
+        .selectRelated("projectRole__project")
+        .fetch();
+
+      assertEquals(comps.array().length, 1);
+      const comp = comps.array()[0];
+      assertEquals(comp.projectRole.isLoaded(), true);
+      assertEquals(comp.projectRole.get().project.isLoaded(), true);
+      assertEquals(
+        comp.projectRole.get().project.get().name.get(),
+        "Nested Fetch Project",
+      );
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});


### PR DESCRIPTION
## Summary

- `_clone()` no longer propagates `_isFetched`/`_cache` to clones — chained QuerySets (`limit()`, `selectRelated()`, `filter()`, etc.) always start unfetched, so `fetch()` runs a real query and calls `_loadRelatedObjects`
- `fetch()` cache fast-path now runs `_loadRelatedObjects` when `selectRelated` fields are present, mirroring the fix from PR #250 for `first()`/`last()`/`get()`
- `fetch()` handles `_isEmpty` explicitly so `none()` chains (`none().exclude().orderBy().fetch()`) stay empty without hitting the database
- `using()` explicitly copies `_isFetched`/`_cache` after cloning to preserve cross-backend sync behaviour (`qs.using(otherBackend).save()`)
- 6 new regression tests covering: `fetch()` direct, `fetch()` cache fast-path, `first()`/`last()`/`get()` chained from an already-fetched QS, and nested `selectRelated` with `fetch()`

Closes #251
Closes #252