### PR TITLE
fix(admin): changeform respects readonlyFields and fieldsets/fields

### DIFF
--- a/src/admin/tests/changeform_test.ts
+++ b/src/admin/tests/changeform_test.ts
@@ -813,3 +813,187 @@ Deno.test({
     }
   },
 });
+
+// =============================================================================
+// readonlyFields support (#162)
+// =============================================================================
+
+class AuditedModel extends Model {
+  id = new AutoField({ primaryKey: true });
+  name = new CharField({ maxLength: 100 });
+  secret = new CharField({ maxLength: 100, blank: true, default: "" });
+  createdBy = new ForeignKey<CategoryModel>("CategoryModel", {
+    onDelete: OnDelete.SET_NULL,
+    blank: true,
+  });
+
+  static objects = new Manager(AuditedModel);
+  static override meta = {
+    dbTable: "cf_audited",
+    verboseName: "Audited",
+    verboseNamePlural: "Auditeds",
+  };
+}
+
+class AuditedAdmin extends ModelAdmin {
+  override readonlyFields = ["id", "createdBy"];
+}
+
+Deno.test({
+  name:
+    "renderChangeForm: GET form does not render readonlyFields as editable inputs",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const site = makeSite();
+      site.register(AuditedModel, AuditedAdmin);
+      const req = makeGetRequest("/admin/auditedmodel/add/", makeValidToken());
+      const res = await renderChangeForm(
+        { request: req, params: {}, adminSite: site, backend },
+        "auditedmodel",
+      );
+      assertEquals(res.status, 200);
+      const html = await res.text();
+      // 'name' should appear as an input
+      assertStringIncludes(html, 'name="name"');
+      // 'createdBy' is readonly — must NOT appear as an editable input
+      assertEquals(html.includes('name="createdBy"'), false);
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "renderChangeForm: POST change succeeds when readonlyFields are absent from form data",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const instance = await AuditedModel.objects.create({
+        name: "Before",
+        secret: "",
+      });
+      const id = String(instance.id.get());
+
+      const site = makeSite();
+      site.register(AuditedModel, AuditedAdmin);
+      // POST without createdBy — it is readonly and must not be required
+      const req = makePostRequest(
+        `/admin/auditedmodel/${id}/`,
+        { name: "After", secret: "mysecret" },
+        makeValidToken(),
+      );
+      const res = await renderChangeForm(
+        { request: req, params: { id }, adminSite: site, backend },
+        "auditedmodel",
+        id,
+      );
+      // Should redirect (302), not fail with 500
+      assertEquals(res.status, 302);
+
+      const updated = await AuditedModel.objects.get({ id: parseInt(id, 10) });
+      assertEquals(updated.name.get(), "After");
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+// =============================================================================
+// fieldsets support (#162)
+// =============================================================================
+
+class FieldsetModel extends Model {
+  id = new AutoField({ primaryKey: true });
+  title = new CharField({ maxLength: 100 });
+  internal = new CharField({ maxLength: 100, blank: true, default: "" });
+  hidden = new CharField({ maxLength: 100, blank: true, default: "" });
+
+  static objects = new Manager(FieldsetModel);
+  static override meta = {
+    dbTable: "cf_fieldset",
+    verboseName: "Fieldset",
+    verboseNamePlural: "Fieldsets",
+  };
+}
+
+class FieldsetAdmin extends ModelAdmin {
+  override fieldsets = [
+    { name: "Main", fields: ["title"] },
+  ];
+}
+
+Deno.test({
+  name: "renderChangeForm: GET form only renders fields listed in fieldsets",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const site = makeSite();
+      site.register(FieldsetModel, FieldsetAdmin);
+      const req = makeGetRequest("/admin/fieldsetmodel/add/", makeValidToken());
+      const res = await renderChangeForm(
+        { request: req, params: {}, adminSite: site, backend },
+        "fieldsetmodel",
+      );
+      assertEquals(res.status, 200);
+      const html = await res.text();
+      // 'title' is in fieldsets — must appear
+      assertStringIncludes(html, 'name="title"');
+      // 'internal' and 'hidden' are NOT in fieldsets — must NOT appear
+      assertEquals(html.includes('name="internal"'), false);
+      assertEquals(html.includes('name="hidden"'), false);
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
+Deno.test({
+  name: "renderChangeForm: POST change with fieldsets only saves listed fields",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const instance = await FieldsetModel.objects.create({
+        title: "Old",
+        internal: "keep-me",
+        hidden: "also-keep",
+      });
+      const id = String(instance.id.get());
+
+      const site = makeSite();
+      site.register(FieldsetModel, FieldsetAdmin);
+      // POST only sends 'title' (the only fieldset field)
+      const req = makePostRequest(
+        `/admin/fieldsetmodel/${id}/`,
+        { title: "New Title" },
+        makeValidToken(),
+      );
+      const res = await renderChangeForm(
+        { request: req, params: { id }, adminSite: site, backend },
+        "fieldsetmodel",
+        id,
+      );
+      // Should succeed with redirect, not 500
+      assertEquals(res.status, 302);
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});

--- a/src/admin/views/changeform_views.ts
+++ b/src/admin/views/changeform_views.ts
@@ -262,12 +262,14 @@ interface ValidationResult {
 function validateFormData(
   fields: FieldInfo[],
   formData: Record<string, string>,
+  readonlyFields: string[] = [],
 ): ValidationResult {
   const data: Record<string, unknown> = {};
   const errors: Record<string, string[]> = {};
 
   for (const field of fields) {
     if (!field.isEditable || field.isPrimaryKey) continue;
+    if (readonlyFields.includes(field.name)) continue;
 
     const raw = formData[field.name];
     const fieldErrors: string[] = [];
@@ -477,9 +479,10 @@ function renderFormHtml(
   fields: FieldInfo[],
   values: Record<string, unknown>,
   errors: Record<string, string[]>,
+  readonlyFields: string[] = [],
 ): string {
   return fields
-    .filter((f) => f.isEditable)
+    .filter((f) => f.isEditable && !readonlyFields.includes(f.name))
     .map((f) => renderWidget(f, values[f.name], errors[f.name] ?? []))
     .join("\n");
 }
@@ -524,7 +527,27 @@ export async function renderChangeForm(
 
   const meta = getModelMeta(modelAdmin.model);
   const allFields = getModelFields(modelAdmin.model);
-  const editableFields = getEditableFields(modelAdmin.model);
+  const readonlyFields = modelAdmin.readonlyFields ?? [];
+
+  // Determine which fields to show in the form:
+  // If ModelAdmin has `fieldsets`, collect fields from all fieldsets.
+  // If ModelAdmin has `fields`, use that list.
+  // Otherwise fall back to all editable fields.
+  let formFieldNames: string[] | null = null;
+  if (modelAdmin.fieldsets && modelAdmin.fieldsets.length > 0) {
+    formFieldNames = modelAdmin.fieldsets.flatMap((fs) => fs.fields);
+  } else if (modelAdmin.fields && modelAdmin.fields.length > 0) {
+    formFieldNames = modelAdmin.fields;
+  }
+
+  const editableFields = getEditableFields(modelAdmin.model).filter((f) => {
+    // If an explicit field list is configured, only include those fields
+    if (formFieldNames !== null) {
+      return formFieldNames.includes(f.name);
+    }
+    // Otherwise include all editable fields that are not readonly
+    return true;
+  });
 
   const isAdd = !objectId;
   const listUrl = modelAdmin.getListUrl();
@@ -568,7 +591,7 @@ export async function renderChangeForm(
       }
     }
 
-    const formHtml = renderFormHtml(editableFields, values, {});
+    const formHtml = renderFormHtml(editableFields, values, {}, readonlyFields);
     const title = isAdd
       ? `Add ${meta.verboseName}`
       : `Change ${meta.verboseName}`;
@@ -606,7 +629,11 @@ export async function renderChangeForm(
 
   if (request.method === "POST") {
     const formData = await parseFormData(request);
-    const validation = validateFormData(editableFields, formData);
+    const validation = validateFormData(
+      editableFields,
+      formData,
+      readonlyFields,
+    );
 
     if (!validation.isValid) {
       // Re-render form with errors
@@ -615,6 +642,7 @@ export async function renderChangeForm(
         editableFields,
         displayValues,
         validation.errors,
+        readonlyFields,
       );
       const title = isAdd
         ? `Add ${meta.verboseName}`
@@ -657,7 +685,12 @@ export async function renderChangeForm(
 
     if (!result.success) {
       const displayValues: Record<string, unknown> = { ...formData };
-      const formHtml = renderFormHtml(editableFields, displayValues, {});
+      const formHtml = renderFormHtml(
+        editableFields,
+        displayValues,
+        {},
+        readonlyFields,
+      );
       const title = isAdd
         ? `Add ${meta.verboseName}`
         : `Change ${meta.verboseName}`;


### PR DESCRIPTION
## Summary

- `renderChangeForm` previously called `getEditableFields()` unconditionally, ignoring `ModelAdmin.readonlyFields`, `fields`, and `fieldsets` — causing HTTP 500 when POSTing to the change form for models with audit FK fields not in the fieldset
- Now builds `formFieldNames` from `fieldsets.fields` or `fields` when configured, falling back to all editable fields only when neither is set
- Passes `readonlyFields` to `validateFormData` and `renderFormHtml` so those functions skip fields not present on the form

## Tests added

- GET form does not render `readonlyFields` as editable inputs
- POST change succeeds when `readonlyFields` are absent from submitted form data (main regression test)
- GET form only renders fields listed in `fieldsets`
- POST change with `fieldsets` only validates listed fields (no 500)