### PR TITLE
fix(db): SQLiteSchemaEditor FK REFERENCES respects meta.dbTable

### DIFF
--- a/src/db/backends/sqlite/backend_test.ts
+++ b/src/db/backends/sqlite/backend_test.ts
@@ -23,9 +23,11 @@ import {
   BooleanField,
   CharField,
   DateTimeField,
+  ForeignKey,
   IntegerField,
   Manager,
   Model,
+  OnDelete,
   TextField,
 } from "../../mod.ts";
 import { registerBackend, reset } from "../../setup.ts";
@@ -52,6 +54,35 @@ class SqliteTestArticle extends Model {
   static objects = new Manager(SqliteTestArticle);
   static override meta = {
     dbTable: "sqlite_test_articles",
+  };
+}
+
+// ----------------------------------------------------------------------------
+// FK test models — used for issue #280 regression test.
+// SqliteFkAuthor has a custom dbTable that differs from the lowercased class
+// name, so naive `modelName.toLowerCase()` would produce the wrong table name.
+// ----------------------------------------------------------------------------
+
+class SqliteFkAuthor extends Model {
+  id = new AutoField({ primaryKey: true });
+  name = new CharField({ maxLength: 100 });
+
+  static objects = new Manager(SqliteFkAuthor);
+  static override meta = {
+    dbTable: "sqlite_fk_authors", // differs from "sqliteFkauthor" / "sqliteFkauthors"
+  };
+}
+
+class SqliteFkPost extends Model {
+  id = new AutoField({ primaryKey: true });
+  title = new CharField({ maxLength: 200 });
+  author = new ForeignKey<SqliteFkAuthor>("SqliteFkAuthor", {
+    onDelete: OnDelete.CASCADE,
+  });
+
+  static objects = new Manager(SqliteFkPost);
+  static override meta = {
+    dbTable: "sqlite_fk_posts",
   };
 }
 
@@ -539,6 +570,42 @@ Deno.test({
         await backend.disconnect();
       }
     });
+
+    // Regression test for https://github.com/atzufuki/alexi/issues/280:
+    // getRelatedTableName() must use meta.dbTable via ModelRegistry instead of
+    // lowercasing the raw class name.
+    await t.step(
+      "SQLiteSchemaEditor - FK REFERENCES uses meta.dbTable (issue #280)",
+      async () => {
+        const backend = new SQLiteBackend({ path: ":memory:" });
+        await backend.connect();
+
+        try {
+          const editor = backend.getSchemaEditor() as SQLiteSchemaEditor;
+
+          // Create the referenced table first so SQLite FK checks can resolve it.
+          await editor.createTable(SqliteFkAuthor);
+          // This must NOT throw "no such table: main.sqliteFkauthor" or similar.
+          await editor.createTable(SqliteFkPost);
+
+          // Verify the REFERENCES clause in the DDL points at the correct table.
+          // backend.db is typed as `any` so we cast the prepare result explicitly.
+          const rows = backend.db.prepare(
+            `SELECT sql FROM sqlite_master WHERE type='table' AND name='sqlite_fk_posts'`,
+          ).all() as Array<{ sql: string }>;
+          assertExists(rows[0]);
+          const ddl: string = rows[0].sql;
+          // Must reference the table defined in meta.dbTable, not the raw class name.
+          assertEquals(
+            ddl.includes('"sqlite_fk_authors"'),
+            true,
+            `Expected DDL to reference "sqlite_fk_authors" but got: ${ddl}`,
+          );
+        } finally {
+          await backend.disconnect();
+        }
+      },
+    );
 
     // ============================================================================
     // compile() Tests

--- a/src/db/backends/sqlite/schema_editor.ts
+++ b/src/db/backends/sqlite/schema_editor.ts
@@ -12,7 +12,7 @@
  * @module
  */
 
-import type { Model } from "../../models/model.ts";
+import { Model, ModelRegistry } from "../../models/model.ts";
 import type { SchemaEditor } from "../backend.ts";
 import { FIELD_TYPE_MAP } from "./types.ts";
 
@@ -225,9 +225,21 @@ export class SQLiteSchemaEditor implements SchemaEditor {
   }
 
   /**
-   * Derive a related table name from a model name string.
+   * Derive the related table name for a FK `REFERENCES` clause.
+   *
+   * Looks up the model class from {@link ModelRegistry} so that
+   * `meta.dbTable` is respected. Falls back to the legacy lowercased
+   * class-name heuristic when the model has not been registered yet
+   * (e.g. during early bootstrap or in unit tests that bypass the registry).
+   *
+   * @param modelName - The model class name string stored on the ForeignKey field.
    */
   private getRelatedTableName(modelName: string): string {
+    const modelClass = ModelRegistry.instance.get(modelName);
+    if (modelClass) {
+      return modelClass.getTableName();
+    }
+    // Fallback: strip trailing "Model" suffix and lowercase.
     return modelName.replace(/Model$/, "").toLowerCase();
   }
 


### PR DESCRIPTION
## Summary

- `getRelatedTableName()` in `SQLiteSchemaEditor` now resolves the model class from `ModelRegistry` and calls `getTableName()` on it, so `meta.dbTable` is respected when generating `REFERENCES` clauses
- The old implementation naively lowercased the raw class name string, producing the wrong table name for every model whose `dbTable` differs from the class name (e.g. `User` → `"user"` instead of `"users"`)
- Adds regression test `SQLiteSchemaEditor - FK REFERENCES uses meta.dbTable (issue #280)` with FK models whose `dbTable` intentionally differs from the lowercased class name

Closes #280