### PR TITLE
feat(core): process INSTALLED_APPS in _buildApplication()

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -467,6 +467,7 @@
           "jsr:@alexi/middleware@0.43.1",
           "jsr:@alexi/types@0.43.1",
           "jsr:@alexi/urls@0.43.1",
+          "jsr:@alexi/views@0.43.1",
           "jsr:@std/path@1"
         ]
       },

--- a/src/core/deno.jsonc
+++ b/src/core/deno.jsonc
@@ -13,6 +13,7 @@
     "@alexi/db/migrations/schema": "jsr:@alexi/db@0.43.1/migrations/schema",
     "@alexi/urls": "jsr:@alexi/urls@0.43.1",
     "@alexi/middleware": "jsr:@alexi/middleware@0.43.1",
+    "@alexi/views": "jsr:@alexi/views@0.43.1",
     "@std/path": "jsr:@std/path@1"
   },
   "compilerOptions": {

--- a/src/core/get_application.ts
+++ b/src/core/get_application.ts
@@ -21,11 +21,13 @@ import { setup } from "./setup.ts";
 import type { DatabasesConfig } from "./setup.ts";
 import type { URLPattern } from "@alexi/urls";
 import type { Middleware, MiddlewareClass } from "@alexi/middleware";
-import type { TemplatesConfig } from "@alexi/types";
+import type { AppConfig, TemplatesConfig } from "@alexi/types";
+import { appRegistrationHooks } from "@alexi/types";
+import { registerTemplateDir } from "@alexi/views";
 
 export type { Middleware, MiddlewareClass } from "@alexi/middleware";
 export type { URLPattern } from "@alexi/urls";
-export type { TemplatesConfig } from "@alexi/types";
+export type { AppConfig, TemplatesConfig } from "@alexi/types";
 
 // =============================================================================
 // Types
@@ -123,6 +125,29 @@ export interface GetApplicationSettings {
    * ];
    */
   TEMPLATES?: TemplatesConfig[];
+
+  /**
+   * List of installed application configurations.
+   *
+   * Mirrors Django's `INSTALLED_APPS`. Each entry is a plain `AppConfig`
+   * object (not an import function). The framework calls `appConfig.ready()`
+   * on each entry during application startup, after databases are initialised.
+   *
+   * When `TEMPLATES[0].APP_DIRS` is `true`, each app's `<appPath>/templates/`
+   * directory is automatically registered as a template search directory.
+   *
+   * @example
+   * ```ts
+   * import { StaticfilesConfig } from "@alexi/staticfiles";
+   * import { AuthConfig } from "@alexi/auth";
+   *
+   * export const INSTALLED_APPS = [
+   *   StaticfilesConfig,
+   *   AuthConfig,
+   * ];
+   * ```
+   */
+  INSTALLED_APPS?: AppConfig[];
 }
 
 // =============================================================================
@@ -234,14 +259,22 @@ async function _buildApplication(
     await setup({ DATABASES: settings.DATABASES });
   }
 
-  // 2. Resolve URL patterns
+  // 2. Process INSTALLED_APPS and TEMPLATES
+  if (settings.INSTALLED_APPS || settings.TEMPLATES) {
+    await _processInstalledApps(
+      settings.INSTALLED_APPS ?? [],
+      settings.TEMPLATES,
+    );
+  }
+
+  // 3. Resolve URL patterns
   const urls = await _resolveUrlPatterns(settings);
 
-  // 3. Build middleware
+  // 4. Build middleware
   const debug = settings.DEBUG ?? false;
   const middleware = _resolveMiddleware(settings, debug);
 
-  // 4. Create and return Application
+  // 5. Create and return Application
   const options: ApplicationOptions = {
     urls,
     middleware,
@@ -249,6 +282,59 @@ async function _buildApplication(
   };
 
   return new Application(options);
+}
+
+/**
+ * Process INSTALLED_APPS: call ready(), register template dirs, and notify
+ * app-registration hooks (e.g. static file registration).
+ *
+ * For each app:
+ * 1. All registered `appRegistrationHooks` are called with the app name and
+ *    resolved path (e.g. `@alexi/staticfiles` uses this to populate the
+ *    global `AppDirectoriesFinder`).
+ * 2. When `TEMPLATES[0].APP_DIRS` is `true`, the app's `<appPath>/templates/`
+ *    directory is registered with the global filesystem template loader.
+ * 3. `app.ready()` is called (if defined).
+ */
+async function _processInstalledApps(
+  installedApps: AppConfig[],
+  templates?: TemplatesConfig[],
+): Promise<void> {
+  const appDirs = templates?.[0]?.APP_DIRS === true;
+  const extraDirs = templates?.[0]?.DIRS ?? [];
+
+  // Register explicit TEMPLATES[0].DIRS entries first
+  for (const dir of extraDirs) {
+    registerTemplateDir(dir);
+  }
+
+  for (const app of installedApps) {
+    const appPath = app.appPath;
+
+    // 1. Notify all app-registration hooks (e.g. static file registration)
+    for (const hook of appRegistrationHooks) {
+      await hook(app.name, appPath);
+    }
+
+    // 2. Register template directory when APP_DIRS is true
+    if (appDirs && appPath) {
+      // Normalise: convert file:// URL to path and strip trailing slash
+      let resolvedPath = appPath;
+      if (appPath.startsWith("file://")) {
+        try {
+          resolvedPath = new URL(appPath).pathname.replace(/\/$/, "");
+        } catch {
+          // keep original
+        }
+      }
+      registerTemplateDir(`${resolvedPath}/templates`);
+    }
+
+    // 3. Call ready() hook
+    if (typeof app.ready === "function") {
+      await app.ready();
+    }
+  }
 }
 
 /**

--- a/src/core/management/management.ts
+++ b/src/core/management/management.ts
@@ -221,8 +221,9 @@ export class ManagementUtility {
       const settingsArg = this.parseSettingsArg(args) ??
         Deno.env.get("ALEXI_SETTINGS_MODULE");
 
-      // Collect import functions from settings
+      // Collect import functions and direct AppConfig objects from settings
       const importFunctions: AppImportFn[] = [];
+      const directConfigs: AppConfig[] = [];
 
       if (settingsArg) {
         // Load from specified settings file
@@ -245,6 +246,9 @@ export class ManagementUtility {
           for (const app of installedApps) {
             if (typeof app === "function") {
               importFunctions.push(app as AppImportFn);
+            } else if (app && typeof app === "object" && "name" in app) {
+              // Direct AppConfig object
+              directConfigs.push(app as AppConfig);
             }
           }
         } catch (error) {
@@ -274,6 +278,12 @@ export class ManagementUtility {
                     if (!importFunctions.includes(app as AppImportFn)) {
                       importFunctions.push(app as AppImportFn);
                     }
+                  } else if (app && typeof app === "object" && "name" in app) {
+                    // Direct AppConfig object — deduplicate by name
+                    const config = app as AppConfig;
+                    if (!directConfigs.some((c) => c.name === config.name)) {
+                      directConfigs.push(config);
+                    }
                   }
                 }
               } catch {
@@ -291,11 +301,17 @@ export class ManagementUtility {
 
       if (this.debug) {
         console.log(`Found ${importFunctions.length} app import functions`);
+        console.log(`Found ${directConfigs.length} direct AppConfig objects`);
       }
 
       // Load commands from each app by calling the import function
       for (const importFn of importFunctions) {
         await this.loadCommandsFromImportFn(importFn);
+      }
+
+      // Load commands from direct AppConfig objects
+      for (const config of directConfigs) {
+        await this.loadCommandsFromAppConfig(config);
       }
     } catch (error) {
       if (this.debug) {
@@ -390,6 +406,61 @@ export class ManagementUtility {
     } catch (error) {
       if (this.debug) {
         console.warn(`  Could not load commands from app: ${error}`);
+      }
+    }
+  }
+
+  /**
+   * Load commands from a direct AppConfig object.
+   *
+   * Used when INSTALLED_APPS contains plain AppConfig objects rather than
+   * import functions. Commands are discovered by convention from
+   * `<appPath>/commands/mod.ts`.
+   */
+  private async loadCommandsFromAppConfig(config: AppConfig): Promise<void> {
+    try {
+      if (this.debug) {
+        console.log(`Loading commands from app config: ${config.name}`);
+      }
+
+      // Resolve the app's source directory from appPath or convention
+      const appPath = config.appPath ?? `./src/${config.name}`;
+      let commandsUrl: string;
+
+      if (
+        appPath.startsWith("file://") ||
+        appPath.startsWith("https://") ||
+        appPath.startsWith("http://")
+      ) {
+        // Absolute URL (local file:// or remote https:// from JSR)
+        const base = appPath.endsWith("/") ? appPath : `${appPath}/`;
+        commandsUrl = `${base}commands/mod.ts`;
+      } else {
+        // Relative path — resolve against project root
+        const rel = appPath.replace(/^\.\//, "");
+        commandsUrl = toImportUrl(
+          `${this.projectRoot}/${rel}/commands/mod.ts`,
+        );
+      }
+
+      // Try to import commands/mod.ts by convention
+      try {
+        const commandsModule = await import(commandsUrl);
+        this.registerCommandsFromModule(
+          commandsModule as Record<string, unknown>,
+          config.name,
+        );
+      } catch {
+        // No commands/mod.ts — this is normal for most apps
+        if (this.debug) {
+          console.log(
+            `  ${config.name}: no commands/mod.ts found at ${commandsUrl}`,
+          );
+        }
+      }
+    } catch (error) {
+      if (this.debug) {
+        console.warn(`  Could not load commands from app config: ${error}`);
       }
     }
   }

--- a/src/core/mod.ts
+++ b/src/core/mod.ts
@@ -66,6 +66,7 @@ export {
   getWorkerApplication,
 } from "./get_application.ts";
 export type { GetApplicationSettings } from "./get_application.ts";
+export type { AppConfig } from "@alexi/types";
 
 // =============================================================================
 // Setup

--- a/src/core/tests/get_application_test.ts
+++ b/src/core/tests/get_application_test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for _buildApplication() INSTALLED_APPS processing
+ *
+ * @module @alexi/core/tests/get_application
+ */
+
+import {
+  assertEquals,
+  assertExists,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { getWorkerApplication } from "../get_application.ts";
+import { appRegistrationHooks } from "@alexi/types";
+import {
+  globalChainLoader,
+  globalFilesystemLoader,
+  templateRegistry,
+} from "@alexi/views";
+import type { AppConfig } from "@alexi/types";
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/** Drain the globalFilesystemLoader dirs after each test by replacing with empty. */
+function clearFilesystemLoaderDirs(): void {
+  // Access internal dirs via type cast for test isolation
+  (globalFilesystemLoader as unknown as { dirs: string[] }).dirs.length = 0;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+Deno.test("getWorkerApplication: returns Application with no INSTALLED_APPS", async () => {
+  const app = await getWorkerApplication({});
+  assertExists(app);
+  assertExists(app.handler);
+});
+
+Deno.test(
+  "getWorkerApplication: calls ready() on each installed app",
+  async () => {
+    const called: string[] = [];
+
+    const appA: AppConfig = {
+      name: "test-app-a",
+      ready() {
+        called.push("a");
+      },
+    };
+    const appB: AppConfig = {
+      name: "test-app-b",
+      async ready() {
+        called.push("b");
+      },
+    };
+
+    await getWorkerApplication({ INSTALLED_APPS: [appA, appB] });
+
+    assertEquals(called, ["a", "b"]);
+  },
+);
+
+Deno.test(
+  "getWorkerApplication: registers template dirs when APP_DIRS is true",
+  async () => {
+    clearFilesystemLoaderDirs();
+
+    const app: AppConfig = {
+      name: "test-app-template",
+      appPath: "/fake/path/to/my-app",
+    };
+
+    await getWorkerApplication({
+      INSTALLED_APPS: [app],
+      TEMPLATES: [{ APP_DIRS: true }],
+    });
+
+    const dirs = (globalFilesystemLoader as unknown as { dirs: string[] }).dirs;
+    assertEquals(
+      dirs.some((d) => d.endsWith("my-app/templates")),
+      true,
+    );
+
+    clearFilesystemLoaderDirs();
+  },
+);
+
+Deno.test(
+  "getWorkerApplication: registers TEMPLATES[0].DIRS entries",
+  async () => {
+    clearFilesystemLoaderDirs();
+
+    await getWorkerApplication({
+      INSTALLED_APPS: [],
+      TEMPLATES: [{ DIRS: ["/custom/templates"] }],
+    });
+
+    const dirs = (globalFilesystemLoader as unknown as { dirs: string[] }).dirs;
+    assertEquals(dirs.includes("/custom/templates"), true);
+
+    clearFilesystemLoaderDirs();
+  },
+);
+
+Deno.test(
+  "getWorkerApplication: skips template dir registration when APP_DIRS is false",
+  async () => {
+    clearFilesystemLoaderDirs();
+
+    const app: AppConfig = {
+      name: "test-app-no-dirs",
+      appPath: "/some/path",
+    };
+
+    await getWorkerApplication({
+      INSTALLED_APPS: [app],
+      TEMPLATES: [{ APP_DIRS: false }],
+    });
+
+    const dirs = (globalFilesystemLoader as unknown as { dirs: string[] }).dirs;
+    assertEquals(dirs.length, 0);
+
+    clearFilesystemLoaderDirs();
+  },
+);
+
+Deno.test(
+  "getWorkerApplication: invokes appRegistrationHooks for each installed app",
+  async () => {
+    const registered: Array<{ name: string; path: string | undefined }> = [];
+
+    const hook = (name: string, path: string | undefined) => {
+      registered.push({ name, path });
+    };
+    appRegistrationHooks.push(hook);
+
+    try {
+      const app: AppConfig = {
+        name: "hook-test-app",
+        appPath: "/hook/path",
+      };
+
+      await getWorkerApplication({ INSTALLED_APPS: [app] });
+
+      assertEquals(registered.length >= 1, true);
+      assertEquals(
+        registered.some((r) => r.name === "hook-test-app"),
+        true,
+      );
+      assertEquals(
+        registered.find((r) => r.name === "hook-test-app")?.path,
+        "/hook/path",
+      );
+    } finally {
+      // Remove the hook we added
+      const idx = appRegistrationHooks.indexOf(hook);
+      if (idx !== -1) appRegistrationHooks.splice(idx, 1);
+    }
+  },
+);
+
+Deno.test(
+  "getWorkerApplication: resolves file:// appPath for template dir registration",
+  async () => {
+    clearFilesystemLoaderDirs();
+
+    const appPath = new URL("./", import.meta.url).href; // file:// URL
+
+    const app: AppConfig = {
+      name: "fileurl-app",
+      appPath,
+    };
+
+    await getWorkerApplication({
+      INSTALLED_APPS: [app],
+      TEMPLATES: [{ APP_DIRS: true }],
+    });
+
+    const dirs = (globalFilesystemLoader as unknown as { dirs: string[] }).dirs;
+    assertEquals(
+      dirs.some((d) => d.endsWith("/templates")),
+      true,
+    );
+    // Should NOT contain "file://" in the path
+    assertEquals(dirs.every((d) => !d.startsWith("file://")), true);
+
+    clearFilesystemLoaderDirs();
+  },
+);

--- a/src/staticfiles/finders.ts
+++ b/src/staticfiles/finders.ts
@@ -11,6 +11,8 @@
  * @module alexi_staticfiles/finders
  */
 
+import { onAppRegistered } from "@alexi/types";
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -133,6 +135,22 @@ export class AppDirectoriesFinder implements StaticFileFinder {
     this.installedApps = options.installedApps;
     this.appPaths = options.appPaths;
     this.projectRoot = options.projectRoot;
+  }
+
+  /**
+   * Register an app with this finder.
+   *
+   * Adds `appName` to the installed apps list and records its `appPath`.
+   * Idempotent — registering the same name twice is a no-op.
+   *
+   * @param appName - The app's unique identifier.
+   * @param appPath - Absolute path or relative path (resolved against project root).
+   */
+  registerApp(appName: string, appPath: string): void {
+    if (!this.installedApps.includes(appName)) {
+      this.installedApps.push(appName);
+    }
+    this.appPaths[appName] = appPath;
   }
 
   /**
@@ -418,8 +436,70 @@ export class FileSystemFinder implements StaticFileFinder {
 }
 
 // =============================================================================
-// StaticFileFinders (Registry)
+// Global AppDirectoriesFinder Registry
 // =============================================================================
+
+/**
+ * Global `AppDirectoriesFinder` instance.
+ *
+ * `_buildApplication()` in `@alexi/core` populates this automatically from
+ * `INSTALLED_APPS` when the application is started.  Each installed app's
+ * `<appPath>/static/` directory is registered here so that static-file
+ * middleware and the `collectstatic` command can discover files without
+ * requiring manual `installedApps`/`appPaths` configuration.
+ *
+ * You can also register app paths manually via {@link registerStaticAppPath}.
+ */
+export const globalAppDirectoriesFinder = new AppDirectoriesFinder({
+  installedApps: [],
+  appPaths: {},
+  projectRoot: typeof Deno !== "undefined" ? Deno.cwd() : "/",
+});
+
+/**
+ * Register an installed app's static directory with the global finder.
+ *
+ * Called automatically by `_buildApplication()` for each entry in
+ * `INSTALLED_APPS`.  You may also call this manually when using the
+ * finder outside of the full application bootstrap.
+ *
+ * @param appName - The app's identifier (e.g. `"alexi_staticfiles"`).
+ * @param appPath - Absolute path or `file://` URL to the app's root directory.
+ *                  The finder will look for static files under `<appPath>/static/`.
+ *
+ * @example
+ * ```ts
+ * import { registerStaticAppPath } from "@alexi/staticfiles";
+ *
+ * registerStaticAppPath("my-app", "./src/my-app");
+ * ```
+ */
+export function registerStaticAppPath(
+  appName: string,
+  appPath: string,
+): void {
+  // Resolve file:// URLs to an OS path
+  let resolvedPath = appPath;
+  if (appPath.startsWith("file://")) {
+    try {
+      // Remove trailing slash so static/ is appended correctly
+      resolvedPath = new URL(appPath).pathname.replace(/\/$/, "");
+    } catch {
+      resolvedPath = appPath;
+    }
+  }
+
+  globalAppDirectoriesFinder.registerApp(appName, resolvedPath);
+}
+
+// Register with the global app-registration hook system so that
+// _buildApplication() automatically populates the finder for every
+// installed app without @alexi/core needing to import @alexi/staticfiles.
+onAppRegistered((appName, appPath) => {
+  if (appPath !== undefined) {
+    registerStaticAppPath(appName, appPath);
+  }
+});
 
 /**
  * Combined static file finder that searches multiple finders

--- a/src/staticfiles/mod.ts
+++ b/src/staticfiles/mod.ts
@@ -41,6 +41,8 @@ export { default } from "./app.ts";
 export {
   AppDirectoriesFinder,
   FileSystemFinder,
+  globalAppDirectoriesFinder,
+  registerStaticAppPath,
   StaticFileFinders,
 } from "./finders.ts";
 

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -25,6 +25,56 @@
  */
 
 // =============================================================================
+// App Registration Hooks
+// =============================================================================
+
+/**
+ * Callback invoked by `_buildApplication()` for every entry in `INSTALLED_APPS`
+ * as part of application startup.
+ *
+ * Higher-layer packages (e.g. `@alexi/staticfiles`) can register a hook here
+ * so that they are notified of each installed app without requiring
+ * `@alexi/core` to import them directly (which would create a circular
+ * dependency).
+ *
+ * @param appName - The app's `name` field.
+ * @param appPath - The resolved app path (absolute path string), or `undefined`
+ *                  if the app has no `appPath` configured.
+ */
+export type AppRegistrationHook = (
+  appName: string,
+  appPath: string | undefined,
+) => void | Promise<void>;
+
+/**
+ * Global list of app-registration hooks.
+ *
+ * Populated at module-load time by packages such as `@alexi/staticfiles`.
+ * `_buildApplication()` calls every hook for each installed app.
+ *
+ * @internal
+ */
+export const appRegistrationHooks: AppRegistrationHook[] = [];
+
+/**
+ * Register a hook to be called for each installed app during startup.
+ *
+ * @param hook - The callback to register.
+ *
+ * @example
+ * ```ts
+ * import { onAppRegistered } from "@alexi/types";
+ *
+ * onAppRegistered((name, appPath) => {
+ *   console.log(`App registered: ${name} at ${appPath}`);
+ * });
+ * ```
+ */
+export function onAppRegistered(hook: AppRegistrationHook): void {
+  appRegistrationHooks.push(hook);
+}
+
+// =============================================================================
 // App Configuration
 // =============================================================================
 
@@ -214,4 +264,27 @@ export interface AppConfig {
    * @example "file:///path/to/package"  // new URL("./", import.meta.url).href
    */
   appPath?: string;
+
+  /**
+   * Called once during application startup after all apps have been loaded.
+   *
+   * Mirrors Django's `AppConfig.ready()`. Use this to perform one-time
+   * initialisation that requires other apps to be available — for example,
+   * registering signals, configuring third-party libraries, or populating
+   * a cache.
+   *
+   * May be synchronous or asynchronous. Any error thrown here will abort
+   * application startup.
+   *
+   * @example
+   * ```ts
+   * const config: AppConfig = {
+   *   name: "my-app",
+   *   async ready() {
+   *     await populateCache();
+   *   },
+   * };
+   * ```
+   */
+  ready?(): Promise<void> | void;
 }

--- a/src/views/engine/mod.ts
+++ b/src/views/engine/mod.ts
@@ -17,7 +17,10 @@ export type { TemplateContext, TemplateLoader } from "./renderer.ts";
 export {
   ChainTemplateLoader,
   FilesystemTemplateLoader,
+  globalChainLoader,
+  globalFilesystemLoader,
   MemoryTemplateLoader,
+  registerTemplateDir,
   TemplateNotFoundError,
   templateRegistry,
 } from "./registry.ts";

--- a/src/views/engine/registry.ts
+++ b/src/views/engine/registry.ts
@@ -157,6 +157,69 @@ export class ChainTemplateLoader implements TemplateLoader {
 export const templateRegistry = new MemoryTemplateLoader();
 
 // =============================================================================
+// Global Filesystem Loader  (server / Deno only)
+// =============================================================================
+
+/**
+ * Global filesystem template loader.
+ *
+ * On the server, `_buildApplication()` calls {@link registerTemplateDir} for
+ * each installed app's `<appPath>/templates/` directory (when
+ * `TEMPLATES[0].APP_DIRS` is `true`) and for every entry in
+ * `TEMPLATES[0].DIRS`.
+ *
+ * `templateView` and class-based views automatically chain this loader after
+ * the in-memory {@link templateRegistry}, so filesystem templates are
+ * discovered without manual registration.
+ *
+ * In a Service Worker context this loader is never populated (SW has no
+ * filesystem access) — all templates are pre-registered into
+ * {@link templateRegistry} by the bundle command.
+ */
+export const globalFilesystemLoader = new FilesystemTemplateLoader([]);
+
+/**
+ * Register a template directory with the global filesystem loader.
+ *
+ * Call this (or let `_buildApplication()` call it automatically) for every
+ * directory that contains `.html` template files you want to resolve at
+ * runtime by name.
+ *
+ * @param dir - Absolute path or `file://` URL of the template directory.
+ *
+ * @example
+ * ```ts
+ * import { registerTemplateDir } from "@alexi/views";
+ *
+ * registerTemplateDir("./src/my-app/templates");
+ * ```
+ */
+export function registerTemplateDir(dir: string): void {
+  globalFilesystemLoader.addDir(dir);
+}
+
+// =============================================================================
+// Global Chain Loader
+// =============================================================================
+
+/**
+ * Global chain template loader.
+ *
+ * Searches {@link templateRegistry} (in-memory, populated by the SW bundle or
+ * programmatic registration) first, then falls back to
+ * {@link globalFilesystemLoader} (populated at server startup from
+ * `INSTALLED_APPS` when `APP_DIRS: true`).
+ *
+ * This is the default loader used by `templateView` and class-based views.
+ * In a Service Worker, `globalFilesystemLoader` is always empty so only the
+ * in-memory registry is searched.
+ */
+export const globalChainLoader = new ChainTemplateLoader([
+  templateRegistry,
+  globalFilesystemLoader,
+]);
+
+// =============================================================================
 // TemplateNotFoundError
 // =============================================================================
 

--- a/src/views/mod.ts
+++ b/src/views/mod.ts
@@ -46,7 +46,11 @@ export {
   // Loaders / Registry
   ChainTemplateLoader,
   FilesystemTemplateLoader,
+  globalChainLoader,
+  globalFilesystemLoader,
   MemoryTemplateLoader,
+  // Registration helper
+  registerTemplateDir,
   // Renderer
   render,
   // Errors

--- a/src/views/template.ts
+++ b/src/views/template.ts
@@ -32,14 +32,17 @@
  * @module @alexi/views/template
  */
 
-import { render, templateRegistry } from "./engine/mod.ts";
+import { globalChainLoader, render, templateRegistry } from "./engine/mod.ts";
 import type { TemplateContext, TemplateLoader } from "./engine/mod.ts";
 
 // Re-export engine symbols so callers can use them without a separate import
 export {
   ChainTemplateLoader,
   FilesystemTemplateLoader,
+  globalChainLoader,
+  globalFilesystemLoader,
   MemoryTemplateLoader,
+  registerTemplateDir,
   render,
   TemplateNotFoundError,
   TemplateParseError,
@@ -195,7 +198,7 @@ function newTemplateView(
         ? await contextFn(request, params)
         : {};
 
-      const resolvedLoader = loader ?? templateRegistry;
+      const resolvedLoader = loader ?? globalChainLoader;
       const html = await render(templateName, ctx, resolvedLoader);
 
       return new Response(html, {

--- a/src/views/views/base.ts
+++ b/src/views/views/base.ts
@@ -12,7 +12,7 @@
  * @module @alexi/views/views/base
  */
 
-import { render, templateRegistry } from "../engine/mod.ts";
+import { globalChainLoader, render, templateRegistry } from "../engine/mod.ts";
 import type { TemplateContext, TemplateLoader } from "../engine/mod.ts";
 
 // =============================================================================
@@ -277,7 +277,7 @@ export class TemplateResponseMixin extends ContextMixin {
    */
   async renderToResponse(context: TemplateContext): Promise<Response> {
     const templateName = this.getTemplateName();
-    const loader = this.templateLoader ?? templateRegistry;
+    const loader = this.templateLoader ?? globalChainLoader;
 
     try {
       const html = await render(templateName, context, loader);


### PR DESCRIPTION
## Summary

- Iterates `INSTALLED_APPS` in `_buildApplication()`, calling `app.ready()` on each `AppConfig`
- When `TEMPLATES[0].APP_DIRS: true`, auto-discovers `<appPath>/templates/` for each installed app via a new `globalFilesystemLoader` / `globalChainLoader` in `@alexi/views`
- Adds `globalAppDirectoriesFinder` and `registerStaticAppPath()` to `@alexi/staticfiles`; auto-populated per-app via an `onAppRegistered` hook system in `@alexi/types` (avoids circular imports)
- Updates `loadAppCommands` in `@alexi/core/management` to support direct `AppConfig` objects (not just import functions) in `INSTALLED_APPS`
- Adds `ready?(): Promise<void> | void` to `AppConfig` interface in `@alexi/types`
- Adds `AppRegistrationHook` system to `@alexi/types` for cross-package decoupled app lifecycle hooks
- Adds 7 integration tests covering all new `_buildApplication()` behaviours

Closes #350