### PR TITLE
feat(auth): add loginRequired, permissionRequired, getRequestUser view decorators

### DIFF
--- a/src/auth/decorators.ts
+++ b/src/auth/decorators.ts
@@ -1,0 +1,231 @@
+/**
+ * View decorators for Alexi authentication.
+ *
+ * Provides Django-equivalent view decorators that enforce authentication and
+ * permission checks before a view handler is invoked.  The authenticated user
+ * is stored on the request object via a `WeakMap` and can be retrieved inside
+ * the decorated view with {@link getRequestUser}.
+ *
+ * @module
+ */
+
+import type { TokenPayload } from "./jwt.ts";
+import { verifyToken } from "./jwt.ts";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * An authenticated user attached to a request by {@link loginRequired} or
+ * {@link permissionRequired}.
+ *
+ * @category Decorators
+ */
+export interface AuthenticatedUser {
+  /** The user's primary key. */
+  id: number | string;
+  /** The user's email address. */
+  email?: string;
+  /** Whether the user has admin privileges. */
+  isAdmin?: boolean;
+}
+
+/**
+ * Standard Alexi view function signature.
+ *
+ * @category Decorators
+ */
+export type ViewFunction = (
+  request: Request,
+  params: Record<string, string>,
+) => Promise<Response>;
+
+// =============================================================================
+// Internal request → user map
+// =============================================================================
+
+/**
+ * Maps each in-flight `Request` to the authenticated user attached during
+ * decoration.  Uses a `WeakMap` so entries are collected automatically when
+ * the request object is GC'd.
+ *
+ * @internal
+ */
+const _requestUsers = new WeakMap<Request, AuthenticatedUser>();
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Return the {@link AuthenticatedUser} attached to `request` by
+ * {@link loginRequired} or {@link permissionRequired}.
+ *
+ * Call this inside a view that has already been wrapped by one of the
+ * decorators.  The user is guaranteed non-null when the decorator has
+ * allowed the request through.
+ *
+ * @param request - The current HTTP request.
+ * @returns The authenticated user, or `undefined` if the request was not
+ *   processed by an auth decorator.
+ *
+ * @example
+ * ```ts
+ * import { getRequestUser, loginRequired } from "@alexi/auth";
+ *
+ * const profileView = loginRequired(async (request, _params) => {
+ *   const user = getRequestUser(request)!;
+ *   return Response.json({ id: user.id, email: user.email });
+ * });
+ * ```
+ *
+ * @category Decorators
+ */
+export function getRequestUser(
+  request: Request,
+): AuthenticatedUser | undefined {
+  return _requestUsers.get(request);
+}
+
+/**
+ * Wrap a view function so that it requires a valid JWT bearer token.
+ *
+ * Reads the token from the `Authorization: Bearer <token>` header and verifies
+ * it using {@link verifyToken}.  On success the decoded user is stored on the
+ * request (retrievable with {@link getRequestUser}) and the inner view is
+ * called.  On failure a `401 Authentication required` JSON response is returned
+ * immediately.
+ *
+ * @param view - The view function to protect.
+ * @returns A new view function that enforces authentication.
+ *
+ * @example
+ * ```ts
+ * import { loginRequired } from "@alexi/auth";
+ *
+ * export const profileView = loginRequired(async (request, params) => {
+ *   return Response.json({ ok: true });
+ * });
+ *
+ * // In urls.ts:
+ * path("profile/", profileView);
+ * ```
+ *
+ * @category Decorators
+ */
+export function loginRequired(view: ViewFunction): ViewFunction {
+  return async function (
+    request: Request,
+    params: Record<string, string>,
+  ): Promise<Response> {
+    const user = await _resolveUser(request);
+    if (!user) {
+      return Response.json(
+        { detail: "Authentication required." },
+        { status: 401 },
+      );
+    }
+    _requestUsers.set(request, user);
+    return view(request, params);
+  };
+}
+
+/**
+ * Wrap a view function so that it requires both authentication and a specific
+ * permission.
+ *
+ * Currently supports the `"admin"` permission, which requires `user.isAdmin`
+ * to be truthy.  Additional permission strings are reserved for future use.
+ *
+ * On authentication failure a `401` response is returned; on permission
+ * failure a `403` response is returned.
+ *
+ * @param perm - The required permission string (currently `"admin"`).
+ * @param view - The view function to protect.
+ * @returns A new view function that enforces authentication and the given
+ *   permission.
+ *
+ * @example
+ * ```ts
+ * import { permissionRequired } from "@alexi/auth";
+ *
+ * export const dashboardView = permissionRequired("admin", async (request, params) => {
+ *   return Response.json({ ok: true });
+ * });
+ *
+ * // In urls.ts:
+ * path("dashboard/", dashboardView);
+ * ```
+ *
+ * @category Decorators
+ */
+export function permissionRequired(
+  perm: string,
+  view: ViewFunction,
+): ViewFunction {
+  return async function (
+    request: Request,
+    params: Record<string, string>,
+  ): Promise<Response> {
+    const user = await _resolveUser(request);
+    if (!user) {
+      return Response.json(
+        { detail: "Authentication required." },
+        { status: 401 },
+      );
+    }
+    if (!_hasPermission(user, perm)) {
+      return Response.json(
+        { detail: "Permission denied." },
+        { status: 403 },
+      );
+    }
+    _requestUsers.set(request, user);
+    return view(request, params);
+  };
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Extract and verify the JWT bearer token from an `Authorization` header.
+ *
+ * @param request - Incoming HTTP request.
+ * @returns The decoded user, or `null` if the token is absent or invalid.
+ *
+ * @internal
+ */
+async function _resolveUser(
+  request: Request,
+): Promise<AuthenticatedUser | null> {
+  const authHeader = request.headers.get("Authorization") ?? "";
+  const match = /^Bearer\s+(.+)$/i.exec(authHeader);
+  if (!match) return null;
+
+  const token = match[1];
+  const payload: TokenPayload | null = await verifyToken(token);
+  if (!payload) return null;
+
+  const userId = payload.userId ?? (payload as Record<string, unknown>).sub;
+  if (userId == null) return null;
+
+  return {
+    id: userId as number | string,
+    email: payload.email,
+    isAdmin: payload.isAdmin ?? false,
+  };
+}
+
+/**
+ * Return `true` if `user` satisfies the given permission string.
+ *
+ * @internal
+ */
+function _hasPermission(user: AuthenticatedUser, perm: string): boolean {
+  if (perm === "admin") return user.isAdmin === true;
+  // Future: look up app-level permissions, groups, etc.
+  return false;
+}

--- a/src/auth/decorators_test.ts
+++ b/src/auth/decorators_test.ts
@@ -1,0 +1,159 @@
+import { assertEquals } from "jsr:@std/assert@1";
+import {
+  getRequestUser,
+  loginRequired,
+  permissionRequired,
+} from "./decorators.ts";
+import { createTokenPair } from "./jwt.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a Request with a valid JWT bearer token for the given user. */
+async function requestWithToken(
+  userId: number,
+  email: string,
+  isAdmin = false,
+): Promise<Request> {
+  const { accessToken } = await createTokenPair(userId, email, isAdmin);
+  return new Request("http://localhost/test", {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+}
+
+/** A minimal view that always returns 200 OK. */
+async function okView(
+  _request: Request,
+  _params: Record<string, string>,
+): Promise<Response> {
+  return new Response("ok", { status: 200 });
+}
+
+// ---------------------------------------------------------------------------
+// loginRequired
+// ---------------------------------------------------------------------------
+
+Deno.test("loginRequired: allows authenticated request", async () => {
+  const request = await requestWithToken(1, "user@example.com");
+  const view = loginRequired(okView);
+  const response = await view(request, {});
+  assertEquals(response.status, 200);
+});
+
+Deno.test("loginRequired: returns 401 with no Authorization header", async () => {
+  const request = new Request("http://localhost/test");
+  const view = loginRequired(okView);
+  const response = await view(request, {});
+  assertEquals(response.status, 401);
+  const body = await response.json();
+  assertEquals(body.detail, "Authentication required.");
+});
+
+Deno.test("loginRequired: returns 401 with invalid token", async () => {
+  const request = new Request("http://localhost/test", {
+    headers: { Authorization: "Bearer not.a.valid.token" },
+  });
+  const view = loginRequired(okView);
+  const response = await view(request, {});
+  assertEquals(response.status, 401);
+});
+
+Deno.test("loginRequired: returns 401 with malformed header", async () => {
+  const request = new Request("http://localhost/test", {
+    headers: { Authorization: "Token abc123" },
+  });
+  const view = loginRequired(okView);
+  const response = await view(request, {});
+  assertEquals(response.status, 401);
+});
+
+// ---------------------------------------------------------------------------
+// getRequestUser
+// ---------------------------------------------------------------------------
+
+Deno.test("getRequestUser: returns undefined for unauthenticated request", () => {
+  const request = new Request("http://localhost/test");
+  assertEquals(getRequestUser(request), undefined);
+});
+
+Deno.test("getRequestUser: returns user inside loginRequired view", async () => {
+  const request = await requestWithToken(42, "alice@example.com", false);
+  let capturedUser: ReturnType<typeof getRequestUser>;
+
+  const view = loginRequired(async (req, _params) => {
+    capturedUser = getRequestUser(req);
+    return new Response("ok");
+  });
+
+  await view(request, {});
+
+  assertEquals(capturedUser?.id, 42);
+  assertEquals(capturedUser?.email, "alice@example.com");
+  assertEquals(capturedUser?.isAdmin, false);
+});
+
+Deno.test("getRequestUser: returns admin user inside loginRequired view", async () => {
+  const request = await requestWithToken(1, "admin@example.com", true);
+  let capturedUser: ReturnType<typeof getRequestUser>;
+
+  const view = loginRequired(async (req, _params) => {
+    capturedUser = getRequestUser(req);
+    return new Response("ok");
+  });
+
+  await view(request, {});
+
+  assertEquals(capturedUser?.isAdmin, true);
+});
+
+// ---------------------------------------------------------------------------
+// permissionRequired
+// ---------------------------------------------------------------------------
+
+Deno.test("permissionRequired: allows admin user with 'admin' perm", async () => {
+  const request = await requestWithToken(1, "admin@example.com", true);
+  const view = permissionRequired("admin", okView);
+  const response = await view(request, {});
+  assertEquals(response.status, 200);
+});
+
+Deno.test("permissionRequired: returns 403 for non-admin user with 'admin' perm", async () => {
+  const request = await requestWithToken(2, "user@example.com", false);
+  const view = permissionRequired("admin", okView);
+  const response = await view(request, {});
+  assertEquals(response.status, 403);
+  const body = await response.json();
+  assertEquals(body.detail, "Permission denied.");
+});
+
+Deno.test("permissionRequired: returns 401 with no token", async () => {
+  const request = new Request("http://localhost/test");
+  const view = permissionRequired("admin", okView);
+  const response = await view(request, {});
+  assertEquals(response.status, 401);
+  const body = await response.json();
+  assertEquals(body.detail, "Authentication required.");
+});
+
+Deno.test("permissionRequired: returns 403 for unknown permission string", async () => {
+  const request = await requestWithToken(1, "user@example.com", true);
+  const view = permissionRequired("superpower", okView);
+  const response = await view(request, {});
+  assertEquals(response.status, 403);
+});
+
+Deno.test("permissionRequired: sets user on request when allowed", async () => {
+  const request = await requestWithToken(7, "admin@example.com", true);
+  let capturedUser: ReturnType<typeof getRequestUser>;
+
+  const view = permissionRequired("admin", async (req, _params) => {
+    capturedUser = getRequestUser(req);
+    return new Response("ok");
+  });
+
+  await view(request, {});
+
+  assertEquals(capturedUser?.id, 7);
+  assertEquals(capturedUser?.isAdmin, true);
+});

--- a/src/auth/mod.ts
+++ b/src/auth/mod.ts
@@ -38,6 +38,16 @@
  * const payload = await verifyToken(accessToken);
  * if (!payload) return Response.json({ error: "Unauthorized" }, { status: 401 });
  * ```
+ *
+ * @example Protect a view with login_required
+ * ```ts
+ * import { loginRequired, getRequestUser } from "@alexi/auth";
+ *
+ * export const profileView = loginRequired(async (request, _params) => {
+ *   const user = getRequestUser(request)!;
+ *   return Response.json({ id: user.id, email: user.email });
+ * });
+ * ```
  */
 
 // =============================================================================
@@ -54,5 +64,13 @@ export { AbstractUser } from "./models/mod.ts";
 // JWT utilities
 export { createTokenPair, verifyToken } from "./jwt.ts";
 export type { TokenPair, TokenPayload } from "./jwt.ts";
+
+// View decorators
+export {
+  getRequestUser,
+  loginRequired,
+  permissionRequired,
+} from "./decorators.ts";
+export type { AuthenticatedUser, ViewFunction } from "./decorators.ts";
 
 // Commands are loaded dynamically via app.ts commandsModule


### PR DESCRIPTION
## Summary

- Adds `loginRequired(view)` decorator — returns 401 if no valid JWT bearer token is present
- Adds `permissionRequired(perm, view)` decorator — returns 401/403 based on auth state and permission check
- Adds `getRequestUser(request)` — retrieves the `AuthenticatedUser` stored on the request via `WeakMap`
- All three are exported from `@alexi/auth` root entrypoint alongside `AuthenticatedUser` and `ViewFunction` types
- 12 new tests covering all decorator behaviours

Closes #331