### PR TITLE
feat(staticfiles): merge per-app staticfiles.json manifests in collectstatic

### DIFF
--- a/src/staticfiles/commands/collectstatic.ts
+++ b/src/staticfiles/commands/collectstatic.ts
@@ -20,6 +20,7 @@ import type {
   IArgumentParser,
 } from "@alexi/core/management";
 import type { AppConfig } from "@alexi/types";
+import type { StaticFilesManifest } from "./bundle.ts";
 
 // =============================================================================
 // Helper Functions
@@ -213,6 +214,11 @@ export class CollectStaticCommand extends BaseCommand {
         results.push(result);
       }
 
+      // Merge per-app staticfiles.json manifests into STATIC_ROOT/staticfiles.json
+      if (!dryRun) {
+        await this.mergeManifests(appsWithStatic, staticRoot);
+      }
+
       // Print results
       this.printResults(results, dryRun);
 
@@ -402,6 +408,47 @@ export class CollectStaticCommand extends BaseCommand {
   // ===========================================================================
   // File Operations
   // ===========================================================================
+
+  /**
+   * Merge all per-app `staticfiles.json` manifests found inside each app's
+   * `staticDir` into a single `<staticRoot>/staticfiles.json`.
+   *
+   * The bundle command writes a `staticfiles.json` manifest to the
+   * `<appDir>/static/` directory (one level above the per-namespace
+   * `outputDir`).  After copying files, collectstatic reads those manifests
+   * and merges them into a single authoritative manifest at the STATIC_ROOT
+   * level so that the template engine can resolve fingerprinted URLs
+   * regardless of which app they belong to.
+   *
+   * @param apps       - Apps collected by {@link findAppsWithStatic}
+   * @param staticRoot - Absolute path to the destination STATIC_ROOT
+   */
+  private async mergeManifests(
+    apps: Array<{ name: string; path: string; staticDir: string }>,
+    staticRoot: string,
+  ): Promise<void> {
+    const merged: StaticFilesManifest = { version: 1, files: {} };
+
+    for (const app of apps) {
+      const manifestPath = `${app.staticDir}/staticfiles.json`;
+      try {
+        const raw = await Deno.readTextFile(manifestPath);
+        const parsed = JSON.parse(raw) as StaticFilesManifest;
+        if (parsed.version === 1 && typeof parsed.files === "object") {
+          Object.assign(merged.files, parsed.files);
+        }
+      } catch {
+        // No manifest for this app — that's fine
+      }
+    }
+
+    if (Object.keys(merged.files).length === 0) {
+      return; // Nothing to write
+    }
+
+    const destPath = `${staticRoot}/staticfiles.json`;
+    await Deno.writeTextFile(destPath, JSON.stringify(merged, null, 2));
+  }
 
   /**
    * Count files in a directory recursively

--- a/src/staticfiles/commands/collectstatic_test.ts
+++ b/src/staticfiles/commands/collectstatic_test.ts
@@ -9,6 +9,7 @@
 import { assertEquals } from "@std/assert";
 import { join } from "@std/path";
 import { CollectStaticCommand } from "./collectstatic.ts";
+import type { StaticFilesManifest } from "./bundle.ts";
 import type { AppConfig } from "@alexi/types";
 
 // =============================================================================
@@ -246,6 +247,164 @@ export const DEBUG = false;
         // expected
       }
       assertEquals(staticRootExists, false);
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "collectstatic: merges per-app staticfiles.json manifests into STATIC_ROOT",
+  async fn() {
+    const tmpDir = await Deno.makeTempDir({
+      prefix: "alexi_collectstatic_manifest_",
+    });
+
+    try {
+      // Two apps, each with their own staticfiles.json manifest
+      const app1StaticDir = join(tmpDir, "src", "app1", "static");
+      const app2StaticDir = join(tmpDir, "src", "app2", "static");
+
+      await Deno.mkdir(app1StaticDir, { recursive: true });
+      await Deno.mkdir(app2StaticDir, { recursive: true });
+
+      // Write per-app manifests (as the bundle command would)
+      const manifest1: StaticFilesManifest = {
+        version: 1,
+        files: { "app1/document.js": "app1/document-abc123.js" },
+      };
+      const manifest2: StaticFilesManifest = {
+        version: 1,
+        files: { "app2/main.js": "app2/main-def456.js" },
+      };
+      await Deno.writeTextFile(
+        join(app1StaticDir, "staticfiles.json"),
+        JSON.stringify(manifest1),
+      );
+      await Deno.writeTextFile(
+        join(app2StaticDir, "staticfiles.json"),
+        JSON.stringify(manifest2),
+      );
+
+      // Write dummy static files so the apps are discovered
+      await Deno.writeTextFile(join(app1StaticDir, "app1.css"), "/* app1 */");
+      await Deno.writeTextFile(join(app2StaticDir, "app2.css"), "/* app2 */");
+
+      const staticRoot = join(tmpDir, "static");
+      await Deno.mkdir(join(tmpDir, "project"), { recursive: true });
+
+      const config1: AppConfig = {
+        name: "app1",
+        verboseName: "App 1",
+        appPath: `./src/app1`,
+      };
+      const config2: AppConfig = {
+        name: "app2",
+        verboseName: "App 2",
+        appPath: `./src/app2`,
+      };
+
+      await Deno.writeTextFile(
+        join(tmpDir, "project", "web.settings.ts"),
+        `
+export const INSTALLED_APPS = [
+  () => Promise.resolve({ default: ${JSON.stringify(config1)} }),
+  () => Promise.resolve({ default: ${JSON.stringify(config2)} }),
+];
+export const STATIC_ROOT = ${JSON.stringify(staticRoot)};
+export const DEBUG = false;
+`,
+      );
+
+      const cmd = new CollectStaticCommand();
+      // @ts-ignore — accessing private field for testing
+      cmd["projectRoot"] = tmpDir;
+
+      const result = await cmd.handle({
+        args: {
+          _: [],
+          settings: "web",
+          "no-input": true,
+          clear: false,
+          "dry-run": false,
+          link: false,
+        },
+        rawArgs: [],
+        debug: false,
+      });
+
+      assertEquals(result.exitCode, 0);
+
+      // Verify merged manifest at STATIC_ROOT/staticfiles.json
+      const mergedRaw = await Deno.readTextFile(
+        join(staticRoot, "staticfiles.json"),
+      );
+      const merged = JSON.parse(mergedRaw) as StaticFilesManifest;
+
+      assertEquals(merged.version, 1);
+      assertEquals(
+        merged.files["app1/document.js"],
+        "app1/document-abc123.js",
+      );
+      assertEquals(merged.files["app2/main.js"], "app2/main-def456.js");
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "collectstatic: skips manifest write when no per-app staticfiles.json exist",
+  async fn() {
+    const tmpDir = await Deno.makeTempDir({
+      prefix: "alexi_collectstatic_no_manifest_",
+    });
+
+    try {
+      const appStaticDir = join(tmpDir, "src", "myapp", "static");
+      const appConfig: AppConfig = {
+        name: "myapp",
+        verboseName: "My App",
+        appPath: "./src/myapp",
+      };
+
+      const { staticRoot } = await createTempProject({
+        tmpDir,
+        appConfig,
+        appStaticDir,
+        files: { "style.css": "body {}" },
+      });
+
+      const cmd = new CollectStaticCommand();
+      // @ts-ignore — accessing private field for testing
+      cmd["projectRoot"] = tmpDir;
+
+      const result = await cmd.handle({
+        args: {
+          _: [],
+          settings: "web",
+          "no-input": true,
+          clear: false,
+          "dry-run": false,
+          link: false,
+        },
+        rawArgs: [],
+        debug: false,
+      });
+
+      assertEquals(result.exitCode, 0);
+
+      // No staticfiles.json should be written when there are no per-app manifests
+      let manifestExists = false;
+      try {
+        await Deno.stat(join(staticRoot, "staticfiles.json"));
+        manifestExists = true;
+      } catch {
+        // expected
+      }
+      assertEquals(manifestExists, false);
     } finally {
       await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
     }


### PR DESCRIPTION
## Summary

- After copying files, `collectstatic` now scans each app's `staticDir` for a `staticfiles.json` manifest (written by the `bundle` command)
- All per-app manifests are merged into a single `STATIC_ROOT/staticfiles.json` so the template engine can resolve fingerprinted URLs at runtime
- Manifest write is skipped when none of the collected apps have a manifest (no empty file created)
- Added 2 new tests: one verifying the merge across two apps, one verifying the skip when no manifests exist

Closes #343