### PR TITLE
feat(core): add DEFAULT_HOST and DEFAULT_PORT to GetApplicationSettings interface

### DIFF
--- a/src/core/get_application.ts
+++ b/src/core/get_application.ts
@@ -148,6 +148,35 @@ export interface GetApplicationSettings {
    * ```
    */
   INSTALLED_APPS?: AppConfig[];
+
+  /**
+   * Default hostname the development server (`runserver`) binds to.
+   *
+   * Mirrors Django's convention of exposing the bind address in settings.
+   * CLI flags (`--host`) take precedence over this value.
+   *
+   * @default "0.0.0.0"
+   *
+   * @example
+   * ```ts
+   * export const DEFAULT_HOST = "127.0.0.1";
+   * ```
+   */
+  DEFAULT_HOST?: string;
+
+  /**
+   * Default port the development server (`runserver`) listens on.
+   *
+   * CLI flags (`--port`) take precedence over this value.
+   *
+   * @default 8000
+   *
+   * @example
+   * ```ts
+   * export const DEFAULT_PORT = 3000;
+   * ```
+   */
+  DEFAULT_PORT?: number;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Added `DEFAULT_HOST?: string` and `DEFAULT_PORT?: number` to the `GetApplicationSettings` interface in `@alexi/core`
- Both fields are fully documented with JSDoc including `@default` values and examples
- `runserver` already reads these fields correctly; this change makes the interface match the documented API

Closes #344