### PR TITLE
refactor(core): remove deprecated getApplication() factory

### DIFF
--- a/src/core/application.ts
+++ b/src/core/application.ts
@@ -127,22 +127,21 @@ export type Handler = (request: Request) => Promise<Response> | Response;
  *
  * @example Service Worker
  * ```ts
- * import { getApplication } from "@alexi/core";
+ * import { getWorkerApplication } from "@alexi/core";
  * import * as settings from "./settings.ts";
  *
- * const app = await getApplication(settings);
+ * const app = await getWorkerApplication(settings);
  *
  * self.addEventListener("fetch", (event) => {
  *   event.respondWith(app.handler(event.request));
  * });
  * ```
  *
- * @example Deno Deploy (http.ts)
+ * @example Deno serve (http.ts)
  * ```ts
- * import { getApplication } from "@alexi/core";
- * import * as settings from "./settings.ts";
+ * import { getHttpApplication } from "@alexi/core";
  *
- * export default await getApplication(settings);
+ * export default await getHttpApplication();
  * ```
  */
 export class Application {
@@ -168,7 +167,7 @@ export class Application {
   /**
    * Deno Deploy default export compatibility.
    *
-   * Allows `export default await getApplication(settings)` to work
+   * Allows `export default await getHttpApplication()` to work
    * with Deno Deploy, which expects `{ fetch: Handler }`.
    */
   fetch: Handler = async (request: Request): Promise<Response> => {

--- a/src/core/conf.ts
+++ b/src/core/conf.ts
@@ -5,7 +5,7 @@
  *
  * `conf` is a global, lazily-loaded settings proxy that always reflects the
  * *active* settings module regardless of how the application was started.
- * It is populated by `getApplication()` / `setup()` and can be imported from
+ * It is populated by `getHttpApplication()` / `getWorkerApplication()` / `setup()` and can be imported from
  * any module without hardcoding the settings file path.
  *
  * @module @alexi/core/conf
@@ -37,10 +37,10 @@ let _settings: GetApplicationSettings | null = null;
 /**
  * Configure the global settings registry.
  *
- * This is called automatically by `getApplication()`. You do not normally need
+ * This is called automatically by `getHttpApplication()` and `getWorkerApplication()`. You do not normally need
  * to call this directly.
  *
- * @param settings - The settings object passed to `getApplication()`
+ * @param settings - The settings object passed to `getWorkerApplication()`
  */
 export function configureSettings(settings: GetApplicationSettings): void {
   _settings = settings;
@@ -66,7 +66,7 @@ export function isSettingsConfigured(): boolean {
  * Global settings proxy — always reflects the active settings module.
  *
  * This is the Alexi equivalent of Django's `django.conf.settings`.
- * Access it after `getApplication()` has been called.
+ * Access it after `getHttpApplication()` or `getWorkerApplication()` has been called.
  *
  * @example
  * ```ts
@@ -77,7 +77,7 @@ export function isSettingsConfigured(): boolean {
  * const db = conf.DATABASES?.default;
  * ```
  *
- * @throws {Error} If accessed before `getApplication()` has been called.
+ * @throws {Error} If accessed before `getHttpApplication()` or `getWorkerApplication()` has been called.
  */
 export const conf: GetApplicationSettings = new Proxy(
   {} as GetApplicationSettings,

--- a/src/core/get_application.ts
+++ b/src/core/get_application.ts
@@ -228,23 +228,6 @@ export async function getWorkerApplication(
 // =============================================================================
 // Legacy alias — kept for backwards compatibility
 // =============================================================================
-
-/**
- * Builds an Application from a settings object.
- *
- * @deprecated Use `getHttpApplication()` for server-side code or
- * `getWorkerApplication(settings)` for Service Workers.
- *
- * @param settings Settings object used to build the application.
- */
-export async function getApplication(
-  settings: GetApplicationSettings,
-): Promise<Application> {
-  configureSettings(settings);
-  return _buildApplication(settings);
-}
-
-// =============================================================================
 // Internal helpers
 // =============================================================================
 

--- a/src/core/management/commands/runserver.ts
+++ b/src/core/management/commands/runserver.ts
@@ -546,7 +546,7 @@ export class RunServerCommand extends BaseCommand {
     // that this.appNames / this.appPaths are populated for staticFilesMiddleware.
     await this.loadInstalledApps(settings);
 
-    // Build augmented settings for getApplication():
+    // Build augmented settings for getHttpApplication():
     //   1. DEBUG is always true in dev mode
     //   2. ROOT_URLCONF is wrapped to prepend the HMR endpoint (if active)
     //   3. createMiddleware is wrapped to prepend staticFilesMiddleware

--- a/src/core/mod.ts
+++ b/src/core/mod.ts
@@ -60,11 +60,7 @@ export type {
 // Application Factories
 // =============================================================================
 
-export {
-  getApplication,
-  getHttpApplication,
-  getWorkerApplication,
-} from "./get_application.ts";
+export { getHttpApplication, getWorkerApplication } from "./get_application.ts";
 export type { GetApplicationSettings } from "./get_application.ts";
 export type { AppConfig } from "@alexi/types";
 

--- a/src/create/templates/unified/workers/settings_ts.ts
+++ b/src/create/templates/unified/workers/settings_ts.ts
@@ -8,14 +8,14 @@
  * Generate workers/<name>/settings.ts content
  *
  * This is the Service Worker's settings module — the browser-side equivalent
- * of project/settings.ts. It is passed to getApplication(settings) in mod.ts.
+ * of project/settings.ts. It is passed to getWorkerApplication(settings) in the Service Worker entry point.
  */
 export function generateWorkerSettingsTs(name: string): string {
   return `/**
  * ${toPascalCase(name)} Worker Settings
  *
  * Service Worker settings module — the browser-side equivalent of
- * project/settings.ts. Passed to getApplication() in mod.ts.
+ * project/settings.ts. Passed to getWorkerApplication() in the Service Worker entry point.
  *
  * @module ${name}/workers/${name}/settings
  */


### PR DESCRIPTION
## Summary

- Removes the deprecated `getApplication(settings)` function from `get_application.ts` and its re-export from `mod.ts`
- Updates JSDoc examples in `Application` class to use `getHttpApplication()` and `getWorkerApplication()` instead
- Updates `conf.ts` JSDoc to reference `getHttpApplication()` / `getWorkerApplication()` in all mentions
- Updates scaffold template and internal comment in `runserver.ts` to remove stale references

Closes #347