### PR TITLE
refactor(core): remove createMiddleware in favour of MIDDLEWARE array

### DIFF
--- a/src/core/get_application.ts
+++ b/src/core/get_application.ts
@@ -74,16 +74,6 @@ export interface GetApplicationSettings {
    */
   MIDDLEWARE?: Array<MiddlewareClass | Middleware>;
 
-  /**
-   * Middleware factory function (alternative to MIDDLEWARE array).
-   *
-   * @deprecated Use the `MIDDLEWARE` array instead.
-   * `createMiddleware` will be removed in a future release.
-   */
-  createMiddleware?: (
-    options: { debug: boolean },
-  ) => Array<MiddlewareClass | Middleware>;
-
   /** Debug mode */
   DEBUG?: boolean;
 
@@ -372,20 +362,14 @@ async function _resolveUrlPatterns(
 /**
  * Resolve middleware from settings.
  *
- * Supports two forms:
- * - MIDDLEWARE as a direct array
- * - createMiddleware() factory function
+ * Reads the `MIDDLEWARE` array from settings.
  */
 function _resolveMiddleware(
   settings: GetApplicationSettings,
-  debug: boolean,
+  _debug: boolean,
 ): Array<MiddlewareClass | Middleware> {
   if (settings.MIDDLEWARE) {
     return settings.MIDDLEWARE;
-  }
-
-  if (settings.createMiddleware) {
-    return settings.createMiddleware({ debug });
   }
 
   return [];

--- a/src/core/management/commands/runserver.ts
+++ b/src/core/management/commands/runserver.ts
@@ -549,7 +549,7 @@ export class RunServerCommand extends BaseCommand {
     // Build augmented settings for getApplication():
     //   1. DEBUG is always true in dev mode
     //   2. ROOT_URLCONF is wrapped to prepend the HMR endpoint (if active)
-    //   3. createMiddleware is wrapped to prepend staticFilesMiddleware
+    //   3. MIDDLEWARE is prepended with staticFilesMiddleware
     const baseSettings = settings as unknown as GetApplicationSettings;
 
     const augmentedSettings: GetApplicationSettings = {
@@ -585,19 +585,9 @@ export class RunServerCommand extends BaseCommand {
         debug: config.debug,
       });
 
-      const originalCreateMiddleware = baseSettings.createMiddleware;
       const originalMiddleware = baseSettings.MIDDLEWARE;
 
-      augmentedSettings.MIDDLEWARE = undefined;
-      augmentedSettings.createMiddleware = (opts) => {
-        let userMiddleware: Array<MiddlewareClass | Middleware> = [];
-        if (originalCreateMiddleware) {
-          userMiddleware = originalCreateMiddleware(opts);
-        } else if (originalMiddleware) {
-          userMiddleware = originalMiddleware;
-        }
-        return [staticMw, ...userMiddleware];
-      };
+      augmentedSettings.MIDDLEWARE = [staticMw, ...(originalMiddleware ?? [])];
     }
 
     // Configure global settings registry, then build the application.

--- a/src/core/management/config.ts
+++ b/src/core/management/config.ts
@@ -79,11 +79,6 @@ export interface AlexiSettings {
 
   // Testing
   TEST_PATTERN?: string;
-
-  // Middleware factory
-  createMiddleware?: (options: {
-    debug: boolean;
-  }) => unknown[];
 }
 
 /**
@@ -201,9 +196,6 @@ export async function loadSettings(
 
       // Testing
       TEST_PATTERN: module.TEST_PATTERN,
-
-      // Middleware factory
-      createMiddleware: module.createMiddleware,
     };
 
     _settings = settings;

--- a/src/create/templates/project/settings_ts.ts
+++ b/src/create/templates/project/settings_ts.ts
@@ -183,13 +183,11 @@ export const CORS_ORIGINS = Deno.env.get("CORS_ORIGINS")?.split(",") ?? [
 // Middleware
 // =============================================================================
 
-export function createMiddleware() {
-  return [
-    loggingMiddleware(),
-    corsMiddleware({ origins: CORS_ORIGINS }),
-    errorHandlerMiddleware(),
-  ];
-}
+export const MIDDLEWARE = [
+  loggingMiddleware(),
+  corsMiddleware({ origins: CORS_ORIGINS }),
+  errorHandlerMiddleware(),
+];
 `
   );
 }
@@ -340,13 +338,11 @@ export const CORS_ORIGINS = Deno.env.get("CORS_ORIGINS")?.split(",") ?? [];
 // Middleware
 // =============================================================================
 
-export function createMiddleware() {
-  return [
-    loggingMiddleware(),
-    corsMiddleware({ origins: CORS_ORIGINS }),
-    errorHandlerMiddleware(),
-  ];
-}
+export const MIDDLEWARE = [
+  loggingMiddleware(),
+  corsMiddleware({ origins: CORS_ORIGINS }),
+  errorHandlerMiddleware(),
+];
 `
   );
 }

--- a/src/create/tests/scaffold_test.ts
+++ b/src/create/tests/scaffold_test.ts
@@ -167,7 +167,7 @@ Deno.test({
         "DEFAULT_PORT",
         "STATIC_URL",
         "CORS_ORIGINS",
-        "createMiddleware",
+        "MIDDLEWARE",
         "ASSETFILES_DIRS",
         "STATICFILES_DIRS",
       ];


### PR DESCRIPTION
## Summary

- Removes the deprecated `createMiddleware` factory function from `GetApplicationSettings` and `AlexiSettings`
- Updates `runserver` to prepend `staticFilesMiddleware` directly into the `MIDDLEWARE` array instead of wrapping via `createMiddleware`
- Updates scaffolded `settings.ts` (dev and production templates) to export `MIDDLEWARE` array constant
- Updates scaffold test to check for `MIDDLEWARE` export instead of `createMiddleware`

Closes #348