### PR TITLE
feat(db): use deprecateModel/deprecateField and restoreModel/restoreField in makemigrations scaffold

### DIFF
--- a/src/core/management/commands/makemigrations.ts
+++ b/src/core/management/commands/makemigrations.ts
@@ -260,12 +260,12 @@ ${detectedChanges.map((c) => `  // ${formatChange(c)}`).join("\n")}
   // For backwards():
   // - Use schema.deprecateModel() instead of dropping tables
   // - Use schema.deprecateField() instead of removing columns
-  // - Use schema.undeprecateModel() / schema.undeprecateField() to undo deprecations
+  // - Use schema.restoreModel() / schema.restoreField() to undo deprecations
   //
   // See: https://alexi.dev/docs/migrations
-`;
+\`;
     } else if (!isEmpty) {
-      changesComment = `
+      changesComment = \`
   // TODO: Implement this migration
   // 
   // For forwards():
@@ -277,7 +277,7 @@ ${detectedChanges.map((c) => `  // ${formatChange(c)}`).join("\n")}
   // For backwards():
   // - Use schema.deprecateModel() instead of dropping tables
   // - Use schema.deprecateField() instead of removing columns
-  // - Use schema.undeprecateModel() / schema.undeprecateField() to undo deprecations
+  // - Use schema.restoreModel() / schema.restoreField() to undo deprecations
   //
   // See: https://alexi.dev/docs/migrations
 `;
@@ -431,7 +431,7 @@ ${backwardsHints}
           break;
         case "delete_model":
           lines.push(
-            `    // await schema.undeprecateModel(${change.modelName}Model);`,
+            `    // await schema.restoreModel("${change.modelName.toLowerCase()}");`,
           );
           break;
         case "add_field":
@@ -441,7 +441,7 @@ ${backwardsHints}
           break;
         case "remove_field":
           lines.push(
-            `    // await schema.undeprecateField(${change.modelName}Model, "${change.fieldName}");`,
+            `    // await schema.restoreField(${change.modelName}Model, "${change.fieldName}");`,
           );
           break;
         case "alter_field":

--- a/src/core/tests/makemigrations_scaffold_test.ts
+++ b/src/core/tests/makemigrations_scaffold_test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for MakemigrationsCommand scaffold template generation
+ *
+ * Verifies that the generated backwards() stubs use `deprecateModel` /
+ * `deprecateField` (for forwards-direction removals) and `restoreModel` /
+ * `restoreField` (for backwards-direction undos), as documented in AGENTS.md.
+ *
+ * @module @alexi/core/tests/makemigrations_scaffold_test
+ */
+
+import { assertMatch, assertStringIncludes } from "jsr:@std/assert@1";
+import { MakemigrationsCommand } from "../management/commands/makemigrations.ts";
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/** Access private methods on MakemigrationsCommand for testing. */
+// deno-lint-ignore no-explicit-any
+type AnyChange = any;
+
+// deno-lint-ignore no-explicit-any
+function cmd(): any {
+  return new MakemigrationsCommand();
+}
+
+// =============================================================================
+// Tests — backwards() stubs use deprecate* / restore*
+// =============================================================================
+
+Deno.test(
+  "makemigrations scaffold: backwards stub for create_model uses deprecateModel",
+  () => {
+    const changes: AnyChange[] = [
+      { type: "create_model", modelName: "Article", appLabel: "blog" },
+    ];
+    const result: string = cmd()._generateBackwardsHints(changes);
+    assertStringIncludes(result, "schema.deprecateModel(");
+  },
+);
+
+Deno.test(
+  "makemigrations scaffold: backwards stub for delete_model uses restoreModel",
+  () => {
+    const changes: AnyChange[] = [
+      { type: "delete_model", modelName: "Article", appLabel: "blog" },
+    ];
+    const result: string = cmd()._generateBackwardsHints(changes);
+    assertStringIncludes(result, "schema.restoreModel(");
+  },
+);
+
+Deno.test(
+  "makemigrations scaffold: backwards stub for add_field uses deprecateField",
+  () => {
+    const changes: AnyChange[] = [
+      {
+        type: "add_field",
+        modelName: "Article",
+        appLabel: "blog",
+        fieldName: "title",
+        field: {
+          type: "CharField",
+          options: { maxLength: 200 },
+          columnName: "title",
+        },
+      },
+    ];
+    const result: string = cmd()._generateBackwardsHints(changes);
+    assertStringIncludes(result, "schema.deprecateField(");
+    assertStringIncludes(result, '"title"');
+  },
+);
+
+Deno.test(
+  "makemigrations scaffold: backwards stub for remove_field uses restoreField",
+  () => {
+    const changes: AnyChange[] = [
+      {
+        type: "remove_field",
+        modelName: "Article",
+        appLabel: "blog",
+        fieldName: "legacy",
+        field: {
+          type: "CharField",
+          options: { maxLength: 100 },
+          columnName: "legacy",
+        },
+      },
+    ];
+    const result: string = cmd()._generateBackwardsHints(changes);
+    assertStringIncludes(result, "schema.restoreField(");
+    assertStringIncludes(result, '"legacy"');
+  },
+);
+
+Deno.test(
+  "makemigrations scaffold: forwards stub for delete_model uses deprecateModel",
+  () => {
+    const changes: AnyChange[] = [
+      { type: "delete_model", modelName: "Article", appLabel: "blog" },
+    ];
+    const result: string = cmd()._generateForwardsHints(changes);
+    assertStringIncludes(result, "schema.deprecateModel(");
+  },
+);
+
+Deno.test(
+  "makemigrations scaffold: forwards stub for remove_field uses deprecateField",
+  () => {
+    const changes: AnyChange[] = [
+      {
+        type: "remove_field",
+        modelName: "Article",
+        appLabel: "blog",
+        fieldName: "legacy",
+        field: {
+          type: "CharField",
+          options: { maxLength: 100 },
+          columnName: "legacy",
+        },
+      },
+    ];
+    const result: string = cmd()._generateForwardsHints(changes);
+    assertStringIncludes(result, "schema.deprecateField(");
+    assertStringIncludes(result, '"legacy"');
+  },
+);
+
+Deno.test(
+  "makemigrations scaffold: template comments reference restoreModel/restoreField",
+  () => {
+    const changes: AnyChange[] = [
+      { type: "create_model", modelName: "Article", appLabel: "blog" },
+    ];
+    const result: string = cmd()._generateMigrationTemplate(
+      "blog",
+      "0001_create_article",
+      [],
+      false,
+      changes,
+    );
+    assertStringIncludes(result, "restoreModel");
+    assertStringIncludes(result, "restoreField");
+    // Must NOT contain the old undeprecate terminology
+    assertMatch(result, /^(?!.*undeprecate)[\s\S]*$/);
+  },
+);


### PR DESCRIPTION
## Summary

- Updates `makemigrations` scaffold template to use `schema.restoreModel()` / `schema.restoreField()` in backwards() stubs for `delete_model` and `remove_field` changes (previously incorrectly referenced non-existent `undeprecateModel` / `undeprecateField`)
- Updates template comment hints to reference `restoreModel` / `restoreField` instead of `undeprecateModel` / `undeprecateField`
- Adds 7 tests in `src/core/tests/makemigrations_scaffold_test.ts` verifying that generated stubs correctly use `deprecateModel`, `deprecateField`, `restoreModel`, and `restoreField`

Closes #349