### PR TITLE
feat(auth): export AuthConfig as named export and document in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,8 @@ alexi/
     │   ├── viewsets/        # ViewSet, ModelViewSet
     │   ├── authentication/  # BaseAuthentication, JWTAuthentication
     │   └── router.ts        # DefaultRouter
-    ├── auth/                # AbstractUser, loginRequired, createTokenPair
+     ├── auth/                # AbstractUser, loginRequired, createTokenPair
+     │   └── commands/        # createsuperuser (contributed via AppConfig)
     ├── core/
     │   ├── management/
     │   │   └── commands/    # runserver, test, makemigrations, migrate,
@@ -241,6 +242,7 @@ await app.launch();
 deno run -A --unstable-kv manage.ts runserver --settings ./project/settings.ts
 deno run -A --unstable-kv manage.ts makemigrations myapp --settings ./project/settings.ts
 deno run -A --unstable-kv manage.ts migrate --settings ./project/settings.ts
+deno run -A --unstable-kv manage.ts createsuperuser --settings ./project/settings.ts
 ```
 
 ---

--- a/src/auth/app_test.ts
+++ b/src/auth/app_test.ts
@@ -1,0 +1,30 @@
+/**
+ * Tests for @alexi/auth app configuration exports
+ *
+ * Verifies that AuthConfig is exported as a named export so that
+ * `import { AuthConfig } from "@alexi/auth"` works in INSTALLED_APPS.
+ *
+ * @module @alexi/auth/app_test
+ */
+
+import { assertEquals, assertExists } from "@std/assert";
+import AuthConfigDefault, { AuthConfig, config } from "./mod.ts";
+
+Deno.test("auth mod: AuthConfig is a named export identical to config", () => {
+  assertExists(AuthConfig);
+  assertEquals(AuthConfig, config);
+  assertEquals(AuthConfig, AuthConfigDefault);
+});
+
+Deno.test("auth mod: AuthConfig has required AppConfig fields", () => {
+  assertExists(AuthConfig.name);
+  assertExists(AuthConfig.appPath);
+  assertEquals(AuthConfig.name, "alexi_auth");
+});
+
+Deno.test("auth mod: AuthConfig.appPath points to auth directory", () => {
+  // appPath should be an absolute file:// URL ending with /auth/
+  const appPath = AuthConfig.appPath ?? "";
+  assertEquals(typeof appPath, "string");
+  assertEquals(appPath.includes("auth"), true);
+});

--- a/src/auth/mod.ts
+++ b/src/auth/mod.ts
@@ -56,6 +56,7 @@
 
 // App configuration
 export { default } from "./app.ts";
+export { default as AuthConfig } from "./app.ts";
 export { default as config } from "./app.ts";
 
 // Abstract base user model


### PR DESCRIPTION
## Summary

- Adds `AuthConfig` as a named export from `@alexi/auth` so that `import { AuthConfig } from "@alexi/auth"` works correctly in `INSTALLED_APPS` (as documented in AGENTS.md)
- Updates AGENTS.md project structure to show `src/auth/commands/` containing `createsuperuser`
- Adds `createsuperuser` to the management commands bash example block
- Adds 3 tests in `src/auth/app_test.ts` verifying the `AuthConfig` export

Closes #336