### PR TITLE
feat(db): add partialUpdate to PostgresBackend and mark as experimental

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -439,12 +439,13 @@ Key design principles:
 
 ### Database Backends
 
-| Backend            | Import                         | Environment | Notes                      |
-| ------------------ | ------------------------------ | ----------- | -------------------------- |
-| `DenoKVBackend`    | `@alexi/db/backends/denokv`    | Server      | Deno KV store              |
-| `SQLiteBackend`    | `@alexi/db/backends/sqlite`    | Server      | Requires `--unstable-ffi`  |
-| `IndexedDBBackend` | `@alexi/db/backends/indexeddb` | Browser     | Local browser storage      |
-| `RestBackend`      | `@alexi/db/backends/rest`      | Browser     | Maps ORM calls to REST API |
+| Backend            | Import                         | Environment | Notes                          |
+| ------------------ | ------------------------------ | ----------- | ------------------------------ |
+| `DenoKVBackend`    | `@alexi/db/backends/denokv`    | Server      | Deno KV store                  |
+| `SQLiteBackend`    | `@alexi/db/backends/sqlite`    | Server      | Requires `--unstable-ffi`      |
+| `PostgresBackend`  | `@alexi/db/backends/postgres`  | Server      | PostgreSQL via connection pool |
+| `IndexedDBBackend` | `@alexi/db/backends/indexeddb` | Browser     | Local browser storage          |
+| `RestBackend`      | `@alexi/db/backends/rest`      | Browser     | Maps ORM calls to REST API     |
 
 ---
 

--- a/src/db/backends/postgres/backend.ts
+++ b/src/db/backends/postgres/backend.ts
@@ -90,8 +90,14 @@ class PostgresTransaction implements Transaction {
 /**
  * PostgreSQL database backend
  *
- * Uses connection pooling via npm:pg for optimal performance.
+ * Uses connection pooling via `npm:pg` for optimal performance.
  * Supports both connection strings and individual connection parameters.
+ *
+ * @experimental This backend is functional but not yet considered
+ * production-ready. Use in production at your own risk. Feedback and
+ * bug reports are welcome.
+ *
+ * @category Backends
  *
  * @example
  * ```ts
@@ -504,6 +510,48 @@ export class PostgresBackend extends DatabaseBackend {
 
     if (this._debug) {
       console.log("[PostgresBackend] Update:", compiled.sql, compiled.params);
+    }
+
+    await this._pool!.query(compiled.sql!, compiled.params);
+  }
+
+  async partialUpdate<T extends Model>(
+    instance: T,
+    fields: string[],
+  ): Promise<void> {
+    this.ensureConnected();
+
+    const tableName = instance.getTableName();
+    const fullData = this.prepareData(instance.toDB());
+    const id = fullData.id;
+
+    if (id === null || id === undefined) {
+      throw new Error("Cannot update a record without an ID");
+    }
+
+    // Keep only the requested fields.
+    const data: Record<string, unknown> = {};
+    for (const field of fields) {
+      if (field in fullData) {
+        data[field] = fullData[field];
+      }
+    }
+
+    if (Object.keys(data).length === 0) return;
+
+    const compiled = PostgresQueryBuilder.buildUpdate(
+      tableName,
+      id,
+      data,
+      this._schema,
+    );
+
+    if (this._debug) {
+      console.log(
+        "[PostgresBackend] PartialUpdate:",
+        compiled.sql,
+        compiled.params,
+      );
     }
 
     await this._pool!.query(compiled.sql!, compiled.params);

--- a/src/db/backends/postgres/backend_test.ts
+++ b/src/db/backends/postgres/backend_test.ts
@@ -226,6 +226,42 @@ Deno.test({
 });
 
 Deno.test({
+  name: "PostgresBackend - partialUpdate",
+  ignore: !hasPostgres(),
+  async fn() {
+    const config = getTestConfig();
+    const backend = new PostgresBackend(config);
+
+    try {
+      await backend.connect();
+      await setupTestTable(backend);
+
+      // Insert
+      const article = new PgTestArticle();
+      article.title.set("Original Title");
+      article.views.set(42);
+
+      const inserted = await backend.insert(article);
+      article.id.set(inserted.id as number);
+
+      // Partial update — change only title, views should remain 42
+      article.title.set("Partial Update Title");
+      article.views.set(999); // should be ignored
+
+      await backend.partialUpdate(article, ["title"]);
+
+      // Verify only title changed
+      const retrieved = await backend.getById(PgTestArticle, inserted.id);
+      assertEquals(retrieved!.title, "Partial Update Title");
+      assertEquals(retrieved!.views, 42);
+    } finally {
+      await cleanupTestTable(backend);
+      await backend.disconnect();
+    }
+  },
+});
+
+Deno.test({
   name: "PostgresBackend - delete",
   ignore: !hasPostgres(),
   async fn() {


### PR DESCRIPTION
## Summary

- Implements the missing `partialUpdate()` abstract method so `PostgresBackend` satisfies the `DatabaseBackend` contract and PATCH-style saves (e.g. `instance.save({ updateFields: [...] })`) work correctly
- Adds `@experimental` and `@category Backends` JSDoc tags to the `PostgresBackend` class
- Adds a `partialUpdate` test (gated behind `hasPostgres()`) in `backend_test.ts`
- Documents `PostgresBackend` in `AGENTS.md` database backends table

Closes #339