### PR TITLE
feat(admin): add AdminRouter.asView() and update mounting docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -859,7 +859,8 @@ const payload = await verifyToken(accessToken);
 ## Admin Panel
 
 ```typescript
-import { AdminRouter, AdminSite, ModelAdmin, register } from "@alexi/admin";
+import { AdminSite, ModelAdmin, register } from "@alexi/admin";
+import { include, path } from "@alexi/urls";
 
 const adminSite = new AdminSite({ title: "My App", urlPrefix: "/admin" });
 
@@ -871,12 +872,27 @@ class ArticleAdmin extends ModelAdmin {
   ordering = ["-createdAt"];
 }
 
-// Mount in your URL conf
-const adminRouter = new AdminRouter(adminSite, backend);
-path("admin/", (req, params) => adminRouter.handle(req));
+// Mount in your URL conf — routes pass through the full middleware stack
+export const urlpatterns = [
+  path("admin/", include(adminSite.urls)),
+];
 ```
 
 Admin requires a JWT with `isAdmin: true`.
+
+If you need a pre-instantiated `AdminRouter` (e.g. to call `router.handle()`
+directly in tests or a custom server), use `AdminRouter.asView()` to mount it
+via `path()` so that middleware still applies:
+
+```typescript
+import { AdminRouter, AdminSite } from "@alexi/admin";
+
+const adminRouter = new AdminRouter(adminSite, backend);
+
+export const urlpatterns = [
+  path("admin/", adminRouter.asView()),
+];
+```
 
 ---
 

--- a/src/admin/tests/urls_test.ts
+++ b/src/admin/tests/urls_test.ts
@@ -487,3 +487,53 @@ Deno.test({
     }
   },
 });
+
+// =============================================================================
+// AdminRouter.asView() tests (#346)
+// =============================================================================
+
+Deno.test({
+  name: "AdminRouter.asView: returns a two-argument view function",
+  fn() {
+    const site = new AdminSite({ urlPrefix: "/admin" });
+    site.register(TestArticle);
+    const router = new AdminRouter(site);
+
+    const view = router.asView();
+
+    assertEquals(typeof view, "function");
+    assertEquals(view.length, 2); // (request, params)
+  },
+});
+
+Deno.test({
+  name: "AdminRouter.asView: view function dispatches to handle()",
+  async fn() {
+    const backend = new DenoKVBackend({
+      name: "as_view_test",
+      path: ":memory:",
+    });
+    await backend.connect();
+
+    try {
+      const site = new AdminSite({ urlPrefix: "/admin" });
+      site.register(TestArticle);
+      const router = new AdminRouter(site, backend);
+
+      const view = router.asView();
+
+      // The asView() wrapper should dispatch the same way as handle() directly.
+      const req = new Request("http://localhost/admin/static/css/admin.css");
+      const res = await view(req, {});
+
+      assertEquals(res.status, 200);
+      assertEquals(
+        res.headers.get("Content-Type"),
+        "text/css; charset=utf-8",
+      );
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});

--- a/src/admin/urls.ts
+++ b/src/admin/urls.ts
@@ -578,6 +578,39 @@ export class AdminRouter {
   }
 
   /**
+   * Return a view function compatible with `path()` that dispatches all
+   * matching requests to this `AdminRouter`.
+   *
+   * This is the idiomatic way to mount `AdminRouter` in a URL conf when you
+   * need to pass the router through the full middleware chain:
+   *
+   * ```ts
+   * import { path } from "@alexi/urls";
+   * import { AdminRouter, AdminSite } from "@alexi/admin";
+   *
+   * const adminSite = new AdminSite({ title: "My App", urlPrefix: "/admin" });
+   * const adminRouter = new AdminRouter(adminSite, backend);
+   *
+   * export const urlpatterns = [
+   *   path("admin/", adminRouter.asView()),
+   * ];
+   * ```
+   *
+   * Prefer `path("admin/", include(adminSite.urls))` when you do not need a
+   * pre-instantiated `AdminRouter` — it is slightly simpler and equally
+   * middleware-friendly.
+   *
+   * @returns A two-argument view function `(request, _params) => Promise<Response>`.
+   */
+  asView(): (
+    request: Request,
+    params: Record<string, string>,
+  ) => Promise<Response> {
+    return (request: Request, _params: Record<string, string>) =>
+      this.handle(request);
+  }
+
+  /**
    * Reverse a URL by name.
    *
    * @param name - The URL name (e.g., `"admin:article_changelist"`)


### PR DESCRIPTION
## Summary

- Adds `AdminRouter.asView()` — returns a two-argument view function compatible with `path()` so `AdminRouter` can be mounted in a URL conf and remain in the full middleware chain
- Updates `AGENTS.md` to use the preferred `path("admin/", include(adminSite.urls))` pattern as the primary example
- Documents `AdminRouter.asView()` as the idiomatic alternative when a pre-instantiated router is needed
- Adds 2 tests: verifies `asView()` returns a 2-arg function and correctly dispatches requests

Closes #346