### PR TITLE
feat(create): upgrade scaffolded posts app with full dark-theme UI, CBVs, and detail/publish/delete views

### DIFF
--- a/src/create/project.ts
+++ b/src/create/project.ts
@@ -47,6 +47,7 @@ import { generateWorkerBaseHtml } from "./templates/unified/workers/base_html.ts
 import { generateWorkerIndexHtml } from "./templates/unified/workers/index_html.ts";
 import { generateWorkerPostListHtml } from "./templates/unified/workers/post_list_html.ts";
 import { generateWorkerPostFormHtml } from "./templates/unified/workers/post_form_html.ts";
+import { generateWorkerPostDetailHtml } from "./templates/unified/workers/post_detail_html.ts";
 
 import { VERSION } from "./version.ts";
 
@@ -266,6 +267,10 @@ async function generateFiles(name: string, version: string): Promise<void> {
     {
       path: `${name}/src/${name}/templates/${name}/post_form.html`,
       content: generateWorkerPostFormHtml(name),
+    },
+    {
+      path: `${name}/src/${name}/templates/${name}/post_detail.html`,
+      content: generateWorkerPostDetailHtml(name),
     },
   ];
 

--- a/src/create/templates/unified/urls_ts.ts
+++ b/src/create/templates/unified/urls_ts.ts
@@ -17,7 +17,15 @@ export function generateUrlsTs(name: string): string {
 import { path, include } from "@alexi/urls";
 import { DefaultRouter } from "@alexi/restframework";
 import { PostViewSet } from "@${name}/viewsets.ts";
-import { HomeView, PostListView, PostCreateView, healthView } from "@${name}/views.ts";
+import {
+  HomeView,
+  PostListView,
+  PostDetailView,
+  PostCreateView,
+  PostPublishView,
+  PostDeleteView,
+  healthView,
+} from "@${name}/views.ts";
 
 // Create router and register viewsets
 const router = new DefaultRouter();
@@ -36,6 +44,9 @@ export const urlpatterns = [
   path("", HomeView.as_view()),
   path("posts/", PostListView.as_view()),
   path("posts/new/", PostCreateView.as_view()),
+  path("posts/:id/", PostDetailView.as_view()),
+  path("posts/:id/publish/", PostPublishView.as_view()),
+  path("posts/:id/delete/", PostDeleteView.as_view()),
   path("api/", include(apiPatterns)),
 ];
 `;

--- a/src/create/templates/unified/views_ts.ts
+++ b/src/create/templates/unified/views_ts.ts
@@ -17,7 +17,7 @@ export function generateViewsTs(name: string): string {
  * @module ${name}/views
  */
 
-import { ListView, TemplateView, View } from "@alexi/views";
+import { DetailView, ListView, TemplateView, View } from "@alexi/views";
 import { PostModel } from "@${name}/models.ts";
 
 /** Home page view. */
@@ -33,10 +33,37 @@ export class HomeView extends TemplateView {
   }
 }
 
-/** Displays the full list of posts. */
+/** Displays the full list of posts with stats. */
 export class PostListView extends ListView<typeof PostModel.prototype> {
   override model = PostModel;
   override templateName = "${name}/post_list.html";
+
+  override async getContextData(
+    request: Request,
+    params: Record<string, string>,
+  ): Promise<Record<string, unknown>> {
+    const base = await super.getContextData(request, params);
+    const posts = (base["post_list"] ?? []) as Record<string, unknown>[];
+    const total = posts.length;
+    const published_count = posts.filter((p) => p["published"]).length;
+    const draft_count = total - published_count;
+    return { ...base, posts, total, published_count, draft_count };
+  }
+}
+
+/** Displays a single post. */
+export class PostDetailView extends DetailView<typeof PostModel.prototype> {
+  override model = PostModel;
+  override templateName = "${name}/post_detail.html";
+  override pkUrlKwarg = "id";
+
+  override async getContextData(
+    request: Request,
+    params: Record<string, string>,
+  ): Promise<Record<string, unknown>> {
+    const base = await super.getContextData(request, params);
+    return { ...base, post: base["object"] };
+  }
 }
 
 /** Handles creating a new post via a GET form and a POST submission. */
@@ -50,7 +77,27 @@ export class PostCreateView extends View {
     const formData = await request.formData();
     const title = (formData.get("title") as string | null) ?? "";
     const content = (formData.get("content") as string | null) ?? "";
-    await PostModel.objects.create({ title, content, published: false });
+    const published = formData.get("published") === "true";
+    await PostModel.objects.create({ title, content, published });
+    return Response.redirect(new URL("/posts/", request.url), 303);
+  }
+}
+
+/** Publishes a draft post. */
+export class PostPublishView extends View {
+  async post(request: Request, params: Record<string, string>): Promise<Response> {
+    const post = await PostModel.objects.get({ id: Number(params["id"]) });
+    post.published.set(true);
+    await post.save({ updateFields: ["published"] });
+    return Response.redirect(new URL("/posts/", request.url), 303);
+  }
+}
+
+/** Deletes a post. */
+export class PostDeleteView extends View {
+  async post(request: Request, params: Record<string, string>): Promise<Response> {
+    const post = await PostModel.objects.get({ id: Number(params["id"]) });
+    await post.delete();
     return Response.redirect(new URL("/posts/", request.url), 303);
   }
 }

--- a/src/create/templates/unified/workers/base_html.ts
+++ b/src/create/templates/unified/workers/base_html.ts
@@ -18,15 +18,412 @@ export function generateWorkerBaseHtml(name: string): string {
   <title>{% block title %}${title}{% endblock %}</title>
   <script src="https://unpkg.com/htmx.org@2/dist/htmx.min.js"></script>
   <script type="module" src="/static/${name}/${name}.js"></script>
+  <style>
+    /* ── Design tokens ─────────────────────────────────────── */
+    :root {
+      --bg:           #0f0f13;
+      --surface:      #18181f;
+      --surface2:     #22222c;
+      --border:       #2e2e3a;
+      --accent:       #7c6af7;
+      --accent2:      #a78bfa;
+      --accent-glow:  rgba(124,106,247,.22);
+      --text:         #e8e8f0;
+      --muted:        #7a7a90;
+      --success:      #34d399;
+      --danger:       #f87171;
+      --radius:       12px;
+      --radius-sm:    6px;
+      --shadow:       0 4px 24px rgba(0,0,0,.45);
+    }
+
+    /* ── Reset ─────────────────────────────────────────────── */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html { font-size: 16px; scroll-behavior: smooth; }
+    body {
+      font-family: "Inter", system-ui, -apple-system, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+      display: grid;
+      grid-template-rows: auto 1fr auto;
+    }
+    a { color: inherit; text-decoration: none; }
+
+    ::-webkit-scrollbar { width: 6px; }
+    ::-webkit-scrollbar-track { background: var(--bg); }
+    ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+
+    /* ── Nav ───────────────────────────────────────────────── */
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      background: rgba(15,15,19,.85);
+      backdrop-filter: blur(14px);
+      border-bottom: 1px solid var(--border);
+      padding: 0 clamp(1rem, 5vw, 3rem);
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      height: 56px;
+    }
+    .nav-logo {
+      font-size: .85rem;
+      font-weight: 700;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+      color: var(--accent2);
+      display: flex;
+      align-items: center;
+      gap: .45rem;
+    }
+    .nav-logo svg { width: 20px; height: 20px; }
+    .nav-links {
+      display: flex;
+      gap: .25rem;
+      list-style: none;
+      margin-left: auto;
+      align-items: center;
+    }
+    .nav-links a {
+      color: var(--muted);
+      font-size: .85rem;
+      padding: .35rem .75rem;
+      border-radius: var(--radius-sm);
+      transition: color .15s, background .15s;
+    }
+    .nav-links a:hover { color: var(--text); background: var(--surface2); }
+    .nav-links a.active { color: var(--text); background: var(--surface2); }
+    .btn-new {
+      background: var(--accent) !important;
+      color: #fff !important;
+      font-weight: 600;
+      font-size: .8rem !important;
+      padding: .4rem .9rem !important;
+      border-radius: var(--radius-sm) !important;
+      transition: background .15s, box-shadow .15s !important;
+    }
+    .btn-new:hover {
+      background: var(--accent2) !important;
+      box-shadow: 0 0 18px var(--accent-glow) !important;
+    }
+
+    /* ── Page wrapper ──────────────────────────────────────── */
+    .page-wrapper {
+      max-width: 860px;
+      margin: 0 auto;
+      padding: 2rem clamp(1rem, 5vw, 3rem) 3rem;
+      width: 100%;
+    }
+
+    /* ── Page header ───────────────────────────────────────── */
+    .page-header { margin-bottom: 1.5rem; }
+    .page-header h1 {
+      font-size: clamp(1.5rem, 4vw, 2.2rem);
+      font-weight: 800;
+      letter-spacing: -.02em;
+      line-height: 1.15;
+    }
+    .page-header p { color: var(--muted); margin-top: .35rem; font-size: .88rem; }
+
+    /* ── Stats bar ─────────────────────────────────────────── */
+    .stats-bar {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 1px;
+      border-radius: var(--radius);
+      overflow: hidden;
+      border: 1px solid var(--border);
+      margin-bottom: 1.25rem;
+    }
+    .stat-card {
+      background: var(--surface);
+      padding: .9rem 1.2rem;
+      display: flex;
+      flex-direction: column;
+      gap: .15rem;
+      transition: background .15s;
+    }
+    .stat-card:hover { background: var(--surface2); }
+    .stat-label {
+      font-size: .68rem;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: .07em;
+      font-weight: 600;
+    }
+    .stat-value {
+      font-size: 1.5rem;
+      font-weight: 800;
+      letter-spacing: -.03em;
+    }
+    .stat-value.total     { color: var(--text); }
+    .stat-value.published { color: var(--success); }
+    .stat-value.draft     { color: var(--accent2); }
+
+    /* ── Post list ─────────────────────────────────────────── */
+    .post-list {
+      display: flex;
+      flex-direction: column;
+      gap: 1px;
+      border-radius: var(--radius);
+      overflow: hidden;
+      border: 1px solid var(--border);
+    }
+    .post-card {
+      background: var(--surface);
+      padding: 1.1rem 1.4rem;
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: .5rem 1.25rem;
+      align-items: start;
+      transition: background .15s;
+      position: relative;
+    }
+    .post-card::before {
+      content: "";
+      position: absolute;
+      left: 0; top: 0; bottom: 0;
+      width: 3px;
+      background: transparent;
+      transition: background .15s;
+    }
+    .post-card:hover { background: var(--surface2); }
+    .post-card:hover::before { background: var(--accent); }
+    .post-card-main { min-width: 0; }
+
+    .post-meta {
+      display: flex;
+      align-items: center;
+      gap: .45rem;
+      margin-bottom: .25rem;
+    }
+    .badge {
+      font-size: .65rem;
+      font-weight: 700;
+      letter-spacing: .05em;
+      text-transform: uppercase;
+      padding: .13rem .45rem;
+      border-radius: 4px;
+    }
+    .badge-published { background: rgba(52,211,153,.13); color: var(--success); }
+    .badge-draft     { background: rgba(122,122,144,.1);  color: var(--muted); }
+    .post-date       { font-size: .72rem; color: var(--muted); }
+
+    .post-title {
+      font-size: .95rem;
+      font-weight: 600;
+      color: var(--text);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      line-height: 1.3;
+    }
+    .post-excerpt {
+      font-size: .8rem;
+      color: var(--muted);
+      margin-top: .2rem;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      line-height: 1.5;
+    }
+    .post-card-actions {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      gap: .4rem;
+      padding-top: .05rem;
+    }
+
+    .publish-btn {
+      font-size: .7rem;
+      font-weight: 600;
+      padding: .22rem .55rem;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--accent);
+      background: transparent;
+      color: var(--accent2);
+      cursor: pointer;
+      white-space: nowrap;
+      transition: background .15s, color .15s;
+      font-family: inherit;
+    }
+    .publish-btn:hover { background: var(--accent); color: #fff; }
+
+    .icon-btn {
+      background: none;
+      border: none;
+      color: var(--muted);
+      cursor: pointer;
+      padding: .28rem;
+      border-radius: var(--radius-sm);
+      display: flex;
+      align-items: center;
+      transition: color .15s, background .15s;
+    }
+    .icon-btn:hover { color: var(--danger); background: rgba(248,113,113,.08); }
+    .icon-btn svg { width: 14px; height: 14px; }
+
+    /* ── Empty state ───────────────────────────────────────── */
+    .empty-state {
+      text-align: center;
+      padding: 3.5rem 1rem;
+      color: var(--muted);
+    }
+    .empty-state svg { width: 44px; height: 44px; opacity: .25; margin-bottom: .9rem; }
+    .empty-state h3  { font-size: .95rem; font-weight: 600; color: var(--text); margin-bottom: .3rem; }
+    .empty-state p   { font-size: .82rem; }
+    .empty-state a   { color: var(--accent2); text-decoration: underline; text-underline-offset: 3px; }
+
+    /* ── Detail view ───────────────────────────────────────── */
+    .back-link {
+      display: inline-flex;
+      align-items: center;
+      gap: .4rem;
+      font-size: .82rem;
+      color: var(--muted);
+      margin-bottom: 1.5rem;
+      transition: color .15s;
+    }
+    .back-link:hover { color: var(--text); }
+    .back-link svg { width: 13px; height: 13px; }
+
+    .detail-header {
+      margin-bottom: 1.5rem;
+      padding-bottom: 1.5rem;
+      border-bottom: 1px solid var(--border);
+    }
+    .detail-header h1 {
+      font-size: clamp(1.4rem, 4vw, 2rem);
+      font-weight: 800;
+      letter-spacing: -.02em;
+      line-height: 1.2;
+      margin-bottom: .7rem;
+    }
+    .detail-meta {
+      display: flex;
+      align-items: center;
+      gap: .7rem;
+      flex-wrap: wrap;
+    }
+    .detail-meta time { font-size: .78rem; color: var(--muted); }
+    .detail-content {
+      font-size: .93rem;
+      line-height: 1.8;
+      color: #c0c0d4;
+      white-space: pre-wrap;
+    }
+
+    /* ── Forms ─────────────────────────────────────────────── */
+    .form-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 2rem;
+      max-width: 600px;
+    }
+    .form-card h2 { font-size: 1.1rem; font-weight: 700; margin-bottom: 1.5rem; }
+    .form-group { margin-bottom: 1.1rem; }
+    .form-label {
+      display: block;
+      font-size: .75rem;
+      font-weight: 600;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: .06em;
+      margin-bottom: .38rem;
+    }
+    .form-input, .form-textarea {
+      width: 100%;
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      color: var(--text);
+      font-size: .9rem;
+      padding: .6rem .85rem;
+      border-radius: var(--radius-sm);
+      outline: none;
+      font-family: inherit;
+      transition: border-color .15s;
+    }
+    .form-input:focus, .form-textarea:focus { border-color: var(--accent); }
+    .form-textarea { min-height: 150px; resize: vertical; line-height: 1.55; }
+    .form-check {
+      display: flex;
+      align-items: center;
+      gap: .45rem;
+      font-size: .83rem;
+      color: var(--muted);
+      cursor: pointer;
+      margin-bottom: 1.4rem;
+    }
+    .form-check input { accent-color: var(--accent); width: 15px; height: 15px; cursor: pointer; }
+    .form-actions { display: flex; gap: .6rem; }
+    .btn {
+      font-size: .83rem;
+      font-weight: 600;
+      padding: .55rem 1.1rem;
+      border-radius: var(--radius-sm);
+      border: none;
+      cursor: pointer;
+      transition: all .15s;
+      font-family: inherit;
+    }
+    .btn-primary { background: var(--accent); color: #fff; }
+    .btn-primary:hover { background: var(--accent2); box-shadow: 0 0 18px var(--accent-glow); }
+    .btn-ghost {
+      background: var(--surface2);
+      color: var(--muted);
+      border: 1px solid var(--border);
+    }
+    .btn-ghost:hover { color: var(--text); border-color: var(--muted); }
+
+    /* ── Footer ────────────────────────────────────────────── */
+    footer {
+      border-top: 1px solid var(--border);
+      padding: .9rem clamp(1rem, 5vw, 3rem);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      font-size: .72rem;
+      color: var(--muted);
+    }
+
+    /* ── Responsive ────────────────────────────────────────── */
+    @media (max-width: 540px) {
+      .stats-bar { grid-template-columns: 1fr; }
+      .post-card { grid-template-columns: 1fr; }
+      .post-card-actions { flex-direction: row; padding-top: 0; }
+    }
+  </style>
 </head>
 <body hx-boost="true">
   <nav>
-    <a href="/">Home</a>
-    <a href="/posts/">Posts</a>
+    <a class="nav-logo" href="/">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"
+           stroke-linecap="round" stroke-linejoin="round">
+        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+        <polyline points="14 2 14 8 20 8"/>
+        <line x1="16" y1="13" x2="8" y2="13"/>
+        <line x1="16" y1="17" x2="8" y2="17"/>
+      </svg>
+      ${title}
+    </a>
+    <ul class="nav-links">
+      <li><a href="/posts/" {% block nav_posts_active %}{% endblock %}>Posts</a></li>
+      <li><a href="/posts/new/" class="btn-new">+ New</a></li>
+    </ul>
   </nav>
-  <main>
-    {% block content %}{% endblock %}
-  </main>
+
+  {% block content %}{% endblock %}
+
+  <footer>
+    <span>${title}</span>
+    <span>{% block footer_extra %}{% endblock %}</span>
+  </footer>
+
   <script>
     if ("serviceWorker" in navigator) {
       navigator.serviceWorker.register("/static/${name}/worker.js", { type: "module" });

--- a/src/create/templates/unified/workers/index_html.ts
+++ b/src/create/templates/unified/workers/index_html.ts
@@ -12,12 +12,21 @@ export function generateWorkerIndexHtml(name: string): string {
 
   return `{% extends "${name}/base.html" %}
 
-{% block title %}{{ title }}{% endblock %}
+{% block title %}${title}{% endblock %}
 
 {% block content %}
-<h1>Welcome to ${title}</h1>
-<p>This page is rendered by a Service Worker using Alexi.</p>
-<p><a href="/posts/">Browse Posts</a></p>
+<div class="page-wrapper">
+  <div class="page-header" style="text-align:center; padding: 3rem 0 2rem;">
+    <h1>Welcome to ${title}</h1>
+    <p style="margin-top:.6rem; font-size:.95rem;">
+      Write, manage and publish your thoughts.
+    </p>
+    <div style="margin-top:1.5rem; display:flex; gap:.75rem; justify-content:center; flex-wrap:wrap;">
+      <a href="/posts/" class="btn btn-primary" style="font-size:.88rem;">Browse posts</a>
+      <a href="/posts/new/" class="btn btn-ghost" style="font-size:.88rem;">Write new</a>
+    </div>
+  </div>
+</div>
 {% endblock %}
 `;
 }

--- a/src/create/templates/unified/workers/post_detail_html.ts
+++ b/src/create/templates/unified/workers/post_detail_html.ts
@@ -1,0 +1,65 @@
+/**
+ * Worker post_detail.html template generator
+ *
+ * @module @alexi/create/templates/unified/workers/post_detail_html
+ */
+
+/**
+ * Generate workers/<name>/templates/<name>/post_detail.html content
+ */
+export function generateWorkerPostDetailHtml(name: string): string {
+  const title = toPascalCase(name);
+
+  return `{% extends "${name}/base.html" %}
+
+{% block title %}{{ post.title }} — ${title}{% endblock %}
+{% block nav_posts_active %}class="active"{% endblock %}
+
+{% block content %}
+<div class="page-wrapper">
+
+  <a class="back-link" href="/posts/">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"
+         stroke-linecap="round" stroke-linejoin="round">
+      <polyline points="15 18 9 12 15 6"/>
+    </svg>
+    Back
+  </a>
+
+  <div class="detail-header">
+    <h1>{{ post.title }}</h1>
+    <div class="detail-meta">
+      <span class="badge {% if post.published %}badge-published{% else %}badge-draft{% endif %}">
+        {% if post.published %}Published{% else %}Draft{% endif %}
+      </span>
+      <time>{{ post.created_at }}</time>
+      {% if not post.published %}
+      <form method="post" action="/posts/{{ post.id }}/publish/" style="margin:0">
+        <button type="submit" class="publish-btn">Publish now</button>
+      </form>
+      {% endif %}
+    </div>
+  </div>
+
+  {% if post.content %}
+  <div class="detail-content">{{ post.content }}</div>
+  {% else %}
+  <p style="color:var(--muted); font-style:italic; font-size:.88rem;">No content.</p>
+  {% endif %}
+
+</div>
+{% endblock %}
+
+{% block footer_extra %}{{ post.created_at }}{% endblock %}
+`;
+}
+
+/**
+ * Convert kebab-case to PascalCase
+ */
+function toPascalCase(str: string): string {
+  return str
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join("");
+}

--- a/src/create/templates/unified/workers/post_form_html.ts
+++ b/src/create/templates/unified/workers/post_form_html.ts
@@ -13,24 +13,44 @@ export function generateWorkerPostFormHtml(name: string): string {
   return `{% extends "${name}/base.html" %}
 
 {% block title %}New Post — ${title}{% endblock %}
+{% block nav_posts_active %}class="active"{% endblock %}
 
 {% block content %}
-<h1>New Post</h1>
+<div class="page-wrapper">
 
-<form method="post" action="/posts/new/">
-  <div>
-    <label for="title">Title</label>
-    <input type="text" id="title" name="title" required>
+  <a class="back-link" href="/posts/">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"
+         stroke-linecap="round" stroke-linejoin="round">
+      <polyline points="15 18 9 12 15 6"/>
+    </svg>
+    Back
+  </a>
+
+  <div class="form-card">
+    <h2>New Post</h2>
+    <form method="post" action="/posts/new/">
+      <div class="form-group">
+        <label class="form-label" for="title">Title</label>
+        <input class="form-input" type="text" id="title" name="title"
+               placeholder="Enter a title…" required autofocus>
+      </div>
+      <div class="form-group">
+        <label class="form-label" for="content">Content</label>
+        <textarea class="form-textarea" id="content" name="content"
+                  placeholder="Start writing…"></textarea>
+      </div>
+      <label class="form-check">
+        <input type="checkbox" name="published" value="true">
+        Publish immediately
+      </label>
+      <div class="form-actions">
+        <button type="submit" class="btn btn-primary">Create Post</button>
+        <a href="/posts/" class="btn btn-ghost">Cancel</a>
+      </div>
+    </form>
   </div>
-  <div>
-    <label for="content">Content</label>
-    <textarea id="content" name="content" rows="6"></textarea>
-  </div>
-  <div>
-    <button type="submit">Create Post</button>
-    <a href="/posts/">Cancel</a>
-  </div>
-</form>
+
+</div>
 {% endblock %}
 `;
 }

--- a/src/create/templates/unified/workers/post_list_html.ts
+++ b/src/create/templates/unified/workers/post_list_html.ts
@@ -13,29 +13,96 @@ export function generateWorkerPostListHtml(name: string): string {
   return `{% extends "${name}/base.html" %}
 
 {% block title %}Posts — ${title}{% endblock %}
+{% block nav_posts_active %}class="active"{% endblock %}
 
 {% block content %}
-<h1>Posts</h1>
+<div class="page-wrapper">
 
-<a href="/posts/new/">New Post</a>
+  <div class="page-header">
+    <h1>Posts</h1>
+    <p>
+      {% if posts %}
+        {{ total }} post{{ total|pluralize }} &middot; {{ published_count }} published &middot; {{ draft_count }} draft{{ draft_count|pluralize }}
+      {% else %}
+        Create your first post
+      {% endif %}
+    </p>
+  </div>
 
-{% if posts %}
-<ul>
-  {% for post in posts %}
-  <li>
-    <strong>{{ post.title }}</strong>
-    {% if post.published %}
-    <span>(published)</span>
-    {% else %}
-    <span>(draft)</span>
-    {% endif %}
-  </li>
-  {% endfor %}
-</ul>
-{% else %}
-<p>No posts yet. <a href="/posts/new/">Create the first one.</a></p>
-{% endif %}
+  <!-- Stats -->
+  <div class="stats-bar">
+    <div class="stat-card">
+      <span class="stat-label">Total</span>
+      <span class="stat-value total">{{ total }}</span>
+    </div>
+    <div class="stat-card">
+      <span class="stat-label">Published</span>
+      <span class="stat-value published">{{ published_count }}</span>
+    </div>
+    <div class="stat-card">
+      <span class="stat-label">Drafts</span>
+      <span class="stat-value draft">{{ draft_count }}</span>
+    </div>
+  </div>
+
+  {% if posts %}
+  <div class="post-list">
+    {% for post in posts %}
+    <div class="post-card">
+      <div class="post-card-main">
+        <div class="post-meta">
+          <span class="badge {% if post.published %}badge-published{% else %}badge-draft{% endif %}">
+            {% if post.published %}Published{% else %}Draft{% endif %}
+          </span>
+          <span class="post-date">{{ post.created_at }}</span>
+        </div>
+        <a href="/posts/{{ post.id }}/" style="display:block">
+          <div class="post-title">{{ post.title }}</div>
+          {% if post.excerpt %}
+          <div class="post-excerpt">{{ post.excerpt }}</div>
+          {% endif %}
+        </a>
+      </div>
+      <div class="post-card-actions">
+        {% if not post.published %}
+        <form method="post" action="/posts/{{ post.id }}/publish/">
+          <button type="submit" class="publish-btn">Publish</button>
+        </form>
+        {% endif %}
+        <form method="post" action="/posts/{{ post.id }}/delete/">
+          <button type="submit" class="icon-btn" title="Delete"
+            onclick="return confirm('Delete this post?')">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                 stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="3 6 5 6 21 6"/>
+              <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/>
+              <path d="M10 11v6M14 11v6"/>
+              <path d="M9 6V4h6v2"/>
+            </svg>
+          </button>
+        </form>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+  {% else %}
+  <div class="empty-state">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"
+         stroke-linecap="round" stroke-linejoin="round">
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+      <polyline points="14 2 14 8 20 8"/>
+      <line x1="16" y1="13" x2="8" y2="13"/>
+      <line x1="16" y1="17" x2="8" y2="17"/>
+    </svg>
+    <h3>No posts yet</h3>
+    <p><a href="/posts/new/">Create your first post</a></p>
+  </div>
+  {% endif %}
+
+</div>
 {% endblock %}
+
+{% block footer_extra %}{{ total }} post{{ total|pluralize }}{% endblock %}
 `;
 }
 

--- a/src/create/templates/unified/workers/urls_ts.ts
+++ b/src/create/templates/unified/workers/urls_ts.ts
@@ -17,12 +17,22 @@ export function generateWorkerUrlsTs(name: string): string {
  */
 
 import { path } from "@alexi/urls";
-import { HomeView, PostListView, PostCreateView } from "./views.ts";
+import {
+  HomeView,
+  PostListView,
+  PostDetailView,
+  PostCreateView,
+  PostPublishView,
+  PostDeleteView,
+} from "./views.ts";
 
 export const urlpatterns = [
   path("", HomeView.as_view(), { name: "home" }),
   path("posts/", PostListView.as_view(), { name: "post-list" }),
   path("posts/new/", PostCreateView.as_view(), { name: "post-create" }),
+  path("posts/:id/", PostDetailView.as_view(), { name: "post-detail" }),
+  path("posts/:id/publish/", PostPublishView.as_view(), { name: "post-publish" }),
+  path("posts/:id/delete/", PostDeleteView.as_view(), { name: "post-delete" }),
 ];
 `;
 }

--- a/src/create/templates/unified/workers/views_ts.ts
+++ b/src/create/templates/unified/workers/views_ts.ts
@@ -16,7 +16,7 @@ export function generateWorkerViewsTs(name: string): string {
  * @module ${name}/workers/${name}/views
  */
 
-import { ListView, TemplateView, View } from "@alexi/views";
+import { DetailView, ListView, TemplateView, View } from "@alexi/views";
 import { PostModel } from "./models.ts";
 
 /** Home page view. */
@@ -32,10 +32,37 @@ export class HomeView extends TemplateView {
   }
 }
 
-/** Displays the full list of posts. */
+/** Displays the full list of posts with stats. */
 export class PostListView extends ListView<typeof PostModel.prototype> {
   override model = PostModel;
   override templateName = "${name}/post_list.html";
+
+  override async getContextData(
+    request: Request,
+    params: Record<string, string>,
+  ): Promise<Record<string, unknown>> {
+    const base = await super.getContextData(request, params);
+    const posts = (base["post_list"] ?? []) as Record<string, unknown>[];
+    const total = posts.length;
+    const published_count = posts.filter((p) => p["published"]).length;
+    const draft_count = total - published_count;
+    return { ...base, posts, total, published_count, draft_count };
+  }
+}
+
+/** Displays a single post. */
+export class PostDetailView extends DetailView<typeof PostModel.prototype> {
+  override model = PostModel;
+  override templateName = "${name}/post_detail.html";
+  override pkUrlKwarg = "id";
+
+  override async getContextData(
+    request: Request,
+    params: Record<string, string>,
+  ): Promise<Record<string, unknown>> {
+    const base = await super.getContextData(request, params);
+    return { ...base, post: base["object"] };
+  }
 }
 
 /** Handles creating a new post via a GET form and a POST submission. */
@@ -49,7 +76,27 @@ export class PostCreateView extends View {
     const formData = await request.formData();
     const title = (formData.get("title") as string | null) ?? "";
     const content = (formData.get("content") as string | null) ?? "";
-    await PostModel.objects.create({ title, content, published: false });
+    const published = formData.get("published") === "true";
+    await PostModel.objects.create({ title, content, published });
+    return Response.redirect("/posts/", 303);
+  }
+}
+
+/** Publishes a draft post. */
+export class PostPublishView extends View {
+  async post(_request: Request, params: Record<string, string>): Promise<Response> {
+    const post = await PostModel.objects.get({ id: Number(params["id"]) });
+    post.published.set(true);
+    await post.save({ updateFields: ["published"] });
+    return Response.redirect("/posts/", 303);
+  }
+}
+
+/** Deletes a post. */
+export class PostDeleteView extends View {
+  async post(_request: Request, params: Record<string, string>): Promise<Response> {
+    const post = await PostModel.objects.get({ id: Number(params["id"]) });
+    await post.delete();
     return Response.redirect("/posts/", 303);
   }
 }

--- a/src/create/tests/scaffold_test.ts
+++ b/src/create/tests/scaffold_test.ts
@@ -431,6 +431,7 @@ Deno.test({
         `src/${project.name}/templates/${project.name}/index.html`,
         `src/${project.name}/templates/${project.name}/post_list.html`,
         `src/${project.name}/templates/${project.name}/post_form.html`,
+        `src/${project.name}/templates/${project.name}/post_detail.html`,
       ];
 
       for (const file of workerFiles) {
@@ -587,6 +588,75 @@ Deno.test({
         "post_form.html should contain a form element",
       );
     });
+
+    await t.step("post_detail.html extends base and shows post", async () => {
+      const content = await Deno.readTextFile(
+        `${project.path}/src/${project.name}/templates/${project.name}/post_detail.html`,
+      );
+      assertEquals(
+        content.includes(`extends "${project.name}/base.html"`),
+        true,
+        "post_detail.html should extend base.html",
+      );
+      assertEquals(
+        content.includes("{{ post.title }}"),
+        true,
+        "post_detail.html should render post title",
+      );
+      assertEquals(
+        content.includes("{{ post.content }}"),
+        true,
+        "post_detail.html should render post content",
+      );
+    });
+
+    await t.step(
+      "worker views.ts defines PostDetailView, PostPublishView, PostDeleteView",
+      async () => {
+        const content = await Deno.readTextFile(
+          `${project.path}/src/${project.name}/workers/${project.name}/views.ts`,
+        );
+        assertEquals(
+          content.includes("PostDetailView"),
+          true,
+          "views.ts should define PostDetailView",
+        );
+        assertEquals(
+          content.includes("PostPublishView"),
+          true,
+          "views.ts should define PostPublishView",
+        );
+        assertEquals(
+          content.includes("PostDeleteView"),
+          true,
+          "views.ts should define PostDeleteView",
+        );
+      },
+    );
+
+    await t.step(
+      "worker urls.ts includes detail/publish/delete routes",
+      async () => {
+        const content = await Deno.readTextFile(
+          `${project.path}/src/${project.name}/workers/${project.name}/urls.ts`,
+        );
+        assertEquals(
+          content.includes("posts/:id/"),
+          true,
+          "urls.ts should include posts/:id/ route",
+        );
+        assertEquals(
+          content.includes("posts/:id/publish/"),
+          true,
+          "urls.ts should include posts/:id/publish/ route",
+        );
+        assertEquals(
+          content.includes("posts/:id/delete/"),
+          true,
+          "urls.ts should include posts/:id/delete/ route",
+        );
+      },
+    );
 
     // ==========================================================================
     // No Old App Directories


### PR DESCRIPTION
## Summary

- Convert all function-based views to idiomatic class-based views (`TemplateView`, `ListView`, `DetailView`, `View`) on both server and Service Worker sides
- Upgrade all HTML templates to a dark theme, English UI, styled with a CSS design system (matches the Finnish reference templates in `./posts/`)
- Add `PostDetailView`, `PostPublishView`, and `PostDeleteView` with corresponding routes (`posts/:id/`, `posts/:id/publish/`, `posts/:id/delete/`)
- `PostListView.getContextData()` now provides `total`, `published_count`, and `draft_count` stats
- `PostCreateView.post()` reads the `published` checkbox from the form
- New `post_detail.html` template generator added
- Scaffold tests updated: `post_detail.html` in file list, 3 new test steps for detail template, new views, and new routes

Closes #368