### PR TITLE
fix(db): autoReverse() uses correct column name for ForeignKey/OneToOneField

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,13 +1,20 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@db/sqlite@0.12": "0.12.0",
+    "jsr:@denosaurs/plug@1": "1.1.0",
     "jsr:@luca/esbuild-deno-loader@~0.11.1": "0.11.1",
     "jsr:@std/assert@*": "1.0.19",
+    "jsr:@std/assert@0.217": "0.217.0",
     "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/bytes@^1.0.2": "1.0.6",
+    "jsr:@std/encoding@1": "1.0.10",
     "jsr:@std/encoding@^1.0.5": "1.0.10",
+    "jsr:@std/fmt@1": "1.0.9",
+    "jsr:@std/fs@1": "1.0.23",
     "jsr:@std/fs@^1.0.19": "1.0.23",
     "jsr:@std/internal@^1.0.12": "1.0.12",
+    "jsr:@std/path@0.217": "0.217.0",
     "jsr:@std/path@1": "1.1.4",
     "jsr:@std/path@^1.0.6": "1.1.4",
     "jsr:@std/path@^1.1.2": "1.1.4",
@@ -20,13 +27,32 @@
     "npm:playwright@^1.48.0": "1.58.2"
   },
   "jsr": {
+    "@db/sqlite@0.12.0": {
+      "integrity": "dd1ef7f621ad50fc1e073a1c3609c4470bd51edc0994139c5bf9851de7a6d85f",
+      "dependencies": [
+        "jsr:@denosaurs/plug",
+        "jsr:@std/path@0.217"
+      ]
+    },
+    "@denosaurs/plug@1.1.0": {
+      "integrity": "eb2f0b7546c7bca2000d8b0282c54d50d91cf6d75cb26a80df25a6de8c4bc044",
+      "dependencies": [
+        "jsr:@std/encoding@1",
+        "jsr:@std/fmt",
+        "jsr:@std/fs@1",
+        "jsr:@std/path@1"
+      ]
+    },
     "@luca/esbuild-deno-loader@0.11.1": {
       "integrity": "dc020d16d75b591f679f6b9288b10f38bdb4f24345edb2f5732affa1d9885267",
       "dependencies": [
         "jsr:@std/bytes",
-        "jsr:@std/encoding",
+        "jsr:@std/encoding@^1.0.5",
         "jsr:@std/path@^1.0.6"
       ]
+    },
+    "@std/assert@0.217.0": {
+      "integrity": "c98e279362ca6982d5285c3b89517b757c1e3477ee9f14eb2fdf80a45aaa9642"
     },
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
@@ -40,6 +66,9 @@
     "@std/encoding@1.0.10": {
       "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
     },
+    "@std/fmt@1.0.9": {
+      "integrity": "2487343e8899fb2be5d0e3d35013e54477ada198854e52dd05ed0422eddcabe0"
+    },
     "@std/fs@1.0.23": {
       "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
       "dependencies": [
@@ -50,6 +79,12 @@
     "@std/internal@1.0.12": {
       "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
     },
+    "@std/path@0.217.0": {
+      "integrity": "1217cc25534bca9a2f672d7fe7c6f356e4027df400c0e85c0ef3e4343bc67d11",
+      "dependencies": [
+        "jsr:@std/assert@0.217"
+      ]
+    },
     "@std/path@1.1.4": {
       "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
       "dependencies": [
@@ -59,7 +94,7 @@
     "@webui/deno-webui@2.5.13": {
       "integrity": "6f03345e19b943177766a30ed728a0e16c228757b5469bceee6092a7e18a25f9",
       "dependencies": [
-        "jsr:@std/fs",
+        "jsr:@std/fs@^1.0.19",
         "jsr:@std/path@^1.1.2",
         "jsr:@zip-js/zip-js"
       ]

--- a/src/db/migrations/executor_integration_test.ts
+++ b/src/db/migrations/executor_integration_test.ts
@@ -27,7 +27,14 @@ import { MigrationExecutor } from "./executor.ts";
 import { MigrationLoader } from "./loader.ts";
 import { DataMigration, Migration } from "./migration.ts";
 import type { MigrationSchemaEditor } from "./schema_editor.ts";
-import { AutoField, CharField, Manager, Model } from "../mod.ts";
+import {
+  AutoField,
+  CharField,
+  ForeignKey,
+  Manager,
+  Model,
+  OnDelete,
+} from "../mod.ts";
 import {
   getBackendByName,
   getBackendNames,
@@ -651,8 +658,137 @@ Deno.test({
 });
 
 // ============================================================================
-// Fix #380 — global registry must use testCopy during --test data migrations
+// Fix #382 — autoReverse() must use column name "field_id" for FK/OneToOne
 // ============================================================================
+
+class CategoryModel extends Model {
+  id = new AutoField({ primaryKey: true });
+  name = new CharField({ maxLength: 100 });
+
+  static objects = new Manager(CategoryModel);
+  static override meta = { dbTable: "categories" };
+}
+
+class ServiceModel extends Model {
+  id = new AutoField({ primaryKey: true });
+  name = new CharField({ maxLength: 200 });
+
+  static objects = new Manager(ServiceModel);
+  static override meta = { dbTable: "services" };
+}
+
+/** 0001 — create categories and services tables */
+class Migration382Base extends Migration {
+  name = "myapp382.0001_base";
+  override dependencies = [];
+
+  async forwards(schema: MigrationSchemaEditor): Promise<void> {
+    await schema.createModel(CategoryModel);
+    await schema.createModel(ServiceModel);
+  }
+}
+
+/** 0002 — add ForeignKey field "category" to services (column: category_id) */
+class Migration382AddFK extends Migration {
+  name = "myapp382.0002_add_fk";
+  override dependencies = ["myapp382.0001_base"];
+
+  async forwards(schema: MigrationSchemaEditor): Promise<void> {
+    await schema.addField(
+      ServiceModel,
+      "category",
+      new ForeignKey<CategoryModel>("CategoryModel", {
+        onDelete: OnDelete.SET_NULL,
+        null: true,
+        blank: true,
+      }),
+    );
+  }
+  // backwards() intentionally omitted — auto-generated via autoReverse()
+}
+
+Deno.test({
+  name:
+    "fix #382 — autoReverse() correctly uses category_id column for ForeignKey addField",
+  async fn() {
+    const backend = new SQLiteBackend({ path: ":memory:" });
+    await backend.connect();
+
+    const loader = new MigrationLoader();
+    loader.register(new Migration382Base(), "myapp382");
+    loader.register(new Migration382AddFK(), "myapp382");
+
+    const executor = new MigrationExecutor(backend, loader);
+
+    try {
+      // Apply forwards: creates tables + adds category_id column
+      const fwdResults = await executor.migrate({ verbosity: 0 });
+      for (const r of fwdResults) {
+        assertEquals(r.success, true, `forwards failed: ${r.error}`);
+      }
+
+      // Verify category_id column exists
+      const db = (backend as unknown as {
+        _db: {
+          prepare: (s: string) => { all: () => Array<{ name: string }> };
+        };
+      })._db;
+      const colsAfterFwd: Array<{ name: string }> = db
+        .prepare(`PRAGMA table_info(services)`)
+        .all();
+      const hasCategoryId = colsAfterFwd.some((c) => c.name === "category_id");
+      assertEquals(
+        hasCategoryId,
+        true,
+        "category_id column must exist after forwards()",
+      );
+
+      // Roll back only migration 0002: auto-reverse must deprecate category_id
+      // (not "category") — that is the exact bug in #382.
+      const bwdResults = await executor.migrate({
+        to: "myapp382.0001_base",
+        verbosity: 0,
+      });
+      for (const r of bwdResults) {
+        assertEquals(
+          r.success,
+          true,
+          `backwards failed (fix #382 — wrong column name?): ${r.error}`,
+        );
+      }
+
+      // The services table still exists (only 0002 was rolled back).
+      // Verify that category_id was deprecated (renamed) rather than failing.
+      const colsAfterBwd: Array<{ name: string }> = db
+        .prepare(`PRAGMA table_info(services)`)
+        .all();
+
+      // The original category_id column must be gone (renamed to _deprecated_*)
+      const hasCategoryIdAfterBwd = colsAfterBwd.some(
+        (c) => c.name === "category_id",
+      );
+      assertEquals(
+        hasCategoryIdAfterBwd,
+        false,
+        "category_id column must be renamed (deprecated) after backwards()",
+      );
+
+      // A deprecated column with the _id suffix must be present
+      const hasDeprecatedCategoryId = colsAfterBwd.some(
+        (c) =>
+          c.name.startsWith("_deprecated_") &&
+          c.name.endsWith("_category_id"),
+      );
+      assertEquals(
+        hasDeprecatedCategoryId,
+        true,
+        "deprecated category_id column must exist after backwards()",
+      );
+    } finally {
+      await backend.disconnect();
+    }
+  },
+});
 
 // Tracks which backend instance the ORM resolved when the data migration ran
 let resolvedBackendDuringTest: unknown = null;

--- a/src/db/migrations/schema_editor.ts
+++ b/src/db/migrations/schema_editor.ts
@@ -698,7 +698,10 @@ export class MigrationSchemaEditor {
           break;
 
         case "addField":
-          await this.deprecateField(op.model, op.fieldName);
+          await this.deprecateField(
+            op.model,
+            this._resolveColumnName(op.fieldName, op.field),
+          );
           break;
 
         case "deprecateField":
@@ -818,6 +821,23 @@ export class MigrationSchemaEditor {
       "Custom transform functions are not yet supported. " +
         "Use executeSQL() for complex transformations.",
     );
+  }
+
+  /**
+   * Resolve the actual database column name for a field.
+   *
+   * `ForeignKey` and `OneToOneField` are stored with an `_id` suffix
+   * (e.g. field name `"category"` → column `"category_id"`).
+   * All other fields use the field name directly.
+   */
+  private _resolveColumnName(fieldName: string, field: AnyField): string {
+    const typeName = (field as unknown as { _type?: string })._type ??
+      (field as unknown as { constructor?: { name?: string } }).constructor
+        ?.name;
+    if (typeName === "ForeignKey" || typeName === "OneToOneField") {
+      return `${fieldName}_id`;
+    }
+    return fieldName;
   }
 
   private _log(message: string): void {


### PR DESCRIPTION
## Summary

- `autoReverse()` was calling `deprecateField(model, fieldName)` with the bare field name (e.g. `"category"`) for `addField` operations, but the actual SQLite column is `<fieldName>_id` (e.g. `"category_id"`) for `ForeignKey` and `OneToOneField` fields
- Added private `_resolveColumnName(fieldName, field)` helper to `SchemaEditor` that appends `_id` for FK/O2O fields, mirroring the existing logic in `buildColumnDefinition()` in `schema/sqlite.ts`
- Added regression test that applies a migration adding a `ForeignKey` column, then rolls it back and asserts the `category_id` column is deprecated correctly

Closes #382