### PR TITLE
fix(db): add ImageField and FileField to SQLite FIELD_TYPE_MAP

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,13 +1,20 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@db/sqlite@0.12": "0.12.0",
+    "jsr:@denosaurs/plug@1": "1.1.0",
     "jsr:@luca/esbuild-deno-loader@~0.11.1": "0.11.1",
     "jsr:@std/assert@*": "1.0.19",
+    "jsr:@std/assert@0.217": "0.217.0",
     "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/bytes@^1.0.2": "1.0.6",
+    "jsr:@std/encoding@1": "1.0.10",
     "jsr:@std/encoding@^1.0.5": "1.0.10",
+    "jsr:@std/fmt@1": "1.0.9",
+    "jsr:@std/fs@1": "1.0.23",
     "jsr:@std/fs@^1.0.19": "1.0.23",
     "jsr:@std/internal@^1.0.12": "1.0.12",
+    "jsr:@std/path@0.217": "0.217.0",
     "jsr:@std/path@1": "1.1.4",
     "jsr:@std/path@^1.0.6": "1.1.4",
     "jsr:@std/path@^1.1.2": "1.1.4",
@@ -20,13 +27,32 @@
     "npm:playwright@^1.48.0": "1.58.2"
   },
   "jsr": {
+    "@db/sqlite@0.12.0": {
+      "integrity": "dd1ef7f621ad50fc1e073a1c3609c4470bd51edc0994139c5bf9851de7a6d85f",
+      "dependencies": [
+        "jsr:@denosaurs/plug",
+        "jsr:@std/path@0.217"
+      ]
+    },
+    "@denosaurs/plug@1.1.0": {
+      "integrity": "eb2f0b7546c7bca2000d8b0282c54d50d91cf6d75cb26a80df25a6de8c4bc044",
+      "dependencies": [
+        "jsr:@std/encoding@1",
+        "jsr:@std/fmt",
+        "jsr:@std/fs@1",
+        "jsr:@std/path@1"
+      ]
+    },
     "@luca/esbuild-deno-loader@0.11.1": {
       "integrity": "dc020d16d75b591f679f6b9288b10f38bdb4f24345edb2f5732affa1d9885267",
       "dependencies": [
         "jsr:@std/bytes",
-        "jsr:@std/encoding",
+        "jsr:@std/encoding@^1.0.5",
         "jsr:@std/path@^1.0.6"
       ]
+    },
+    "@std/assert@0.217.0": {
+      "integrity": "c98e279362ca6982d5285c3b89517b757c1e3477ee9f14eb2fdf80a45aaa9642"
     },
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
@@ -40,6 +66,9 @@
     "@std/encoding@1.0.10": {
       "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
     },
+    "@std/fmt@1.0.9": {
+      "integrity": "2487343e8899fb2be5d0e3d35013e54477ada198854e52dd05ed0422eddcabe0"
+    },
     "@std/fs@1.0.23": {
       "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
       "dependencies": [
@@ -50,6 +79,12 @@
     "@std/internal@1.0.12": {
       "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
     },
+    "@std/path@0.217.0": {
+      "integrity": "1217cc25534bca9a2f672d7fe7c6f356e4027df400c0e85c0ef3e4343bc67d11",
+      "dependencies": [
+        "jsr:@std/assert@0.217"
+      ]
+    },
     "@std/path@1.1.4": {
       "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
       "dependencies": [
@@ -59,7 +94,7 @@
     "@webui/deno-webui@2.5.13": {
       "integrity": "6f03345e19b943177766a30ed728a0e16c228757b5469bceee6092a7e18a25f9",
       "dependencies": [
-        "jsr:@std/fs",
+        "jsr:@std/fs@^1.0.19",
         "jsr:@std/path@^1.1.2",
         "jsr:@zip-js/zip-js"
       ]

--- a/src/db/backends/sqlite/schema_editor.ts
+++ b/src/db/backends/sqlite/schema_editor.ts
@@ -143,7 +143,12 @@ export class SQLiteSchemaEditor implements SchemaEditor {
     let columnName = fieldName;
     let sqlType = FIELD_TYPE_MAP[fieldType];
 
-    if (!sqlType) return null;
+    if (!sqlType) {
+      console.warn(
+        `[alexi] buildColumnDefinition: unknown field type "${fieldType}" for column "${fieldName}" — column will be skipped. Add an entry to FIELD_TYPE_MAP or use executeRaw() to create the column manually.`,
+      );
+      return null;
+    }
 
     // ForeignKey and OneToOneField columns are stored as `fieldName_id INTEGER`.
     if (fieldType === "ForeignKey" || fieldType === "OneToOneField") {

--- a/src/db/backends/sqlite/types.ts
+++ b/src/db/backends/sqlite/types.ts
@@ -83,6 +83,8 @@ export const FIELD_TYPE_MAP: Record<string, string> = {
   UUIDField: "TEXT",
   JSONField: "TEXT", // JSON-serialized string
   BinaryField: "BLOB",
+  FileField: "TEXT", // stores file path or URL
+  ImageField: "TEXT", // stores file path or URL
   ForeignKey: "INTEGER",
   OneToOneField: "INTEGER UNIQUE",
 };

--- a/src/db/migrations/executor_integration_test.ts
+++ b/src/db/migrations/executor_integration_test.ts
@@ -35,6 +35,7 @@ import {
   Model,
   OnDelete,
 } from "../mod.ts";
+import { FileField, ImageField } from "../fields/mod.ts";
 import {
   getBackendByName,
   getBackendNames,
@@ -866,6 +867,91 @@ Deno.test({
       }
       await testCopy.destroyTestCopy();
       await originalBackend.disconnect();
+    }
+  },
+});
+
+// ============================================================================
+// fix #384 — SQLite FIELD_TYPE_MAP missing ImageField and FileField
+// ============================================================================
+
+/** Snapshot model with ImageField and FileField for fix #384 */
+class UserProfileModel384 extends Model {
+  id = new AutoField({ primaryKey: true });
+  username = new CharField({ maxLength: 150 });
+  avatar = new ImageField({ uploadTo: "avatars/", null: true, blank: true });
+  resume = new FileField({ uploadTo: "resumes/", null: true, blank: true });
+
+  static objects = new Manager(UserProfileModel384);
+  static override meta = { dbTable: "user_profiles_384" };
+}
+
+/** 0001 — create user_profiles_384 table with ImageField and FileField */
+class Migration384Create extends Migration {
+  name = "myapp384.0001_create";
+  override dependencies = [];
+
+  override async forwards(schema: MigrationSchemaEditor): Promise<void> {
+    await schema.createModel(UserProfileModel384);
+  }
+
+  override async backwards(schema: MigrationSchemaEditor): Promise<void> {
+    await schema.deprecateModel(UserProfileModel384);
+  }
+}
+
+Deno.test({
+  name:
+    "fix #384 — SQLite createTable includes ImageField and FileField columns",
+  async fn() {
+    const backend = new SQLiteBackend({ path: ":memory:" });
+    await backend.connect();
+
+    const loader = new MigrationLoader();
+    loader.register(new Migration384Create(), "myapp384");
+
+    const executor = new MigrationExecutor(backend, loader);
+
+    try {
+      // Apply forwards: CREATE TABLE must include avatar and resume columns
+      const fwdResults = await executor.migrate({ verbosity: 0 });
+      for (const r of fwdResults) {
+        assertEquals(r.success, true, `forwards failed: ${r.error}`);
+      }
+
+      // Inspect the created table columns
+      const db = (backend as unknown as {
+        _db: {
+          prepare: (s: string) => { all: () => Array<{ name: string }> };
+        };
+      })._db;
+      const cols: Array<{ name: string }> = db
+        .prepare(`PRAGMA table_info(user_profiles_384)`)
+        .all();
+      const colNames = cols.map((c) => c.name);
+
+      assertEquals(
+        colNames.includes("avatar"),
+        true,
+        "avatar (ImageField) column must exist in the table",
+      );
+      assertEquals(
+        colNames.includes("resume"),
+        true,
+        "resume (FileField) column must exist in the table",
+      );
+
+      // Verify the columns have TEXT affinity (file fields store paths/URLs)
+      const avatarCol = cols.find((c) => c.name === "avatar") as
+        | { name: string; type: string }
+        | undefined;
+      const resumeCol = cols.find((c) => c.name === "resume") as
+        | { name: string; type: string }
+        | undefined;
+      assertEquals(avatarCol?.type, "TEXT", "ImageField column must be TEXT");
+      assertEquals(resumeCol?.type, "TEXT", "FileField column must be TEXT");
+    } finally {
+      await backend.disconnect();
     }
   },
 });

--- a/src/db/migrations/schema/sqlite.ts
+++ b/src/db/migrations/schema/sqlite.ts
@@ -119,7 +119,12 @@ export class SQLiteMigrationSchemaEditor implements IBackendSchemaEditor {
     let columnName = fieldName;
     let sqlType = FIELD_TYPE_MAP[fieldType];
 
-    if (!sqlType) return null;
+    if (!sqlType) {
+      console.warn(
+        `[alexi] buildColumnDefinition: unknown field type "${fieldType}" for column "${fieldName}" — column will be skipped. Add an entry to FIELD_TYPE_MAP or use executeSQL() in the migration.`,
+      );
+      return null;
+    }
 
     // ForeignKey / OneToOneField: stored as `fieldName_id INTEGER`
     if (fieldType === "ForeignKey" || fieldType === "OneToOneField") {


### PR DESCRIPTION
## Summary

- Added `FileField: "TEXT"` and `ImageField: "TEXT"` to `FIELD_TYPE_MAP` in `src/db/backends/sqlite/types.ts` — both fields store file paths/URLs as strings
- Previously these entries were missing, so `buildColumnDefinition()` returned `null` and silently skipped the columns in `CREATE TABLE`; subsequent ORM `INSERT`s would then fail with `table <name> has no column named <field>`
- Added `console.warn()` to `buildColumnDefinition()` in both the migration schema editor (`src/db/migrations/schema/sqlite.ts`) and the backend schema editor (`src/db/backends/sqlite/schema_editor.ts`) so unknown field types produce an actionable diagnostic instead of silently dropping the column
- Added regression test that runs a migration creating a table with `ImageField` and `FileField` columns and asserts both columns exist with `TEXT` affinity

Closes #384