### PR TITLE
feat(auth): add AuthenticationMiddleware for request-level user resolution

### DIFF
--- a/src/auth/_auth_store.ts
+++ b/src/auth/_auth_store.ts
@@ -1,0 +1,22 @@
+/**
+ * Internal shared store for authenticated users attached to in-flight requests.
+ *
+ * Both {@link loginRequired}/{@link permissionRequired} decorators and
+ * {@link AuthenticationMiddleware} write to this store; {@link getRequestUser}
+ * reads from it.  Sharing the same `WeakMap` instance guarantees that a user
+ * set by middleware is visible inside decorated views, and vice-versa.
+ *
+ * @module
+ * @internal
+ */
+
+import type { AuthenticatedUser } from "./decorators.ts";
+
+/**
+ * Maps each in-flight `Request` to the authenticated user attached during
+ * authentication.  Uses a `WeakMap` so entries are collected automatically
+ * when the request object is GC'd.
+ *
+ * @internal
+ */
+export const _requestUsers = new WeakMap<Request, AuthenticatedUser>();

--- a/src/auth/decorators.ts
+++ b/src/auth/decorators.ts
@@ -11,14 +11,15 @@
 
 import type { TokenPayload } from "./jwt.ts";
 import { verifyToken } from "./jwt.ts";
+import { _requestUsers } from "./_auth_store.ts";
 
 // =============================================================================
 // Types
 // =============================================================================
 
 /**
- * An authenticated user attached to a request by {@link loginRequired} or
- * {@link permissionRequired}.
+ * An authenticated user attached to a request by {@link loginRequired},
+ * {@link permissionRequired}, or {@link AuthenticationMiddleware}.
  *
  * @category Decorators
  */
@@ -40,19 +41,6 @@ export type ViewFunction = (
   request: Request,
   params: Record<string, string>,
 ) => Promise<Response>;
-
-// =============================================================================
-// Internal request → user map
-// =============================================================================
-
-/**
- * Maps each in-flight `Request` to the authenticated user attached during
- * decoration.  Uses a `WeakMap` so entries are collected automatically when
- * the request object is GC'd.
- *
- * @internal
- */
-const _requestUsers = new WeakMap<Request, AuthenticatedUser>();
 
 // =============================================================================
 // Public API

--- a/src/auth/middleware.ts
+++ b/src/auth/middleware.ts
@@ -1,0 +1,141 @@
+/**
+ * Authentication middleware for Alexi.
+ *
+ * Provides {@link AuthenticationMiddleware}, a Django-style class-based
+ * middleware that runs on every request and resolves the authenticated user
+ * from a JWT bearer token.  The resolved user is attached to the request via
+ * the shared auth store and can be retrieved anywhere in the request lifecycle
+ * with {@link getRequestUser}.
+ *
+ * This is the Alexi equivalent of Django's
+ * `django.contrib.auth.middleware.AuthenticationMiddleware`.  Add it to the
+ * `MIDDLEWARE` setting to make authentication available in plain views, other
+ * middleware, and service-worker handlers — not just in ViewSets.
+ *
+ * @example
+ * ```ts
+ * import { AuthenticationMiddleware } from "@alexi/auth";
+ * import { LoggingMiddleware, CorsMiddleware, ErrorHandlerMiddleware } from "@alexi/middleware";
+ *
+ * export const MIDDLEWARE = [
+ *   LoggingMiddleware,
+ *   CorsMiddleware,
+ *   AuthenticationMiddleware,   // populates request.user for all downstream handlers
+ *   ErrorHandlerMiddleware,
+ * ];
+ * ```
+ *
+ * @module
+ */
+
+import { BaseMiddleware } from "@alexi/middleware";
+import type { NextFunction } from "@alexi/middleware";
+import { verifyToken } from "./jwt.ts";
+import { _requestUsers } from "./_auth_store.ts";
+import type { AuthenticatedUser } from "./decorators.ts";
+
+// =============================================================================
+// AuthenticationMiddleware
+// =============================================================================
+
+/**
+ * Django-style middleware that resolves the authenticated user on every request.
+ *
+ * Reads the `Authorization: Bearer <token>` header, verifies the JWT using
+ * {@link verifyToken}, and attaches the resolved {@link AuthenticatedUser} to
+ * the request.  The user is then available via {@link getRequestUser} anywhere
+ * downstream — in views, other middleware, and ViewSet permission checks.
+ *
+ * Anonymous requests (missing or invalid token) pass through unchanged with no
+ * user attached.  The middleware never rejects a request on its own; use
+ * {@link loginRequired}, {@link permissionRequired}, or ViewSet
+ * `permission_classes` to enforce access control.
+ *
+ * Place this middleware **after** logging/CORS middleware and **before** any
+ * middleware or view that needs to know who the user is.
+ *
+ * @example Add to MIDDLEWARE in settings
+ * ```ts
+ * import { AuthenticationMiddleware } from "@alexi/auth";
+ * import { LoggingMiddleware, CorsMiddleware, ErrorHandlerMiddleware } from "@alexi/middleware";
+ *
+ * export const MIDDLEWARE = [
+ *   LoggingMiddleware,
+ *   CorsMiddleware,
+ *   AuthenticationMiddleware,
+ *   ErrorHandlerMiddleware,
+ * ];
+ * ```
+ *
+ * @example Read the authenticated user in a plain view
+ * ```ts
+ * import { getRequestUser } from "@alexi/auth";
+ *
+ * export async function profileView(request: Request): Promise<Response> {
+ *   const user = getRequestUser(request);
+ *   if (!user) return Response.json({ detail: "Unauthorized" }, { status: 401 });
+ *   return Response.json({ id: user.id, email: user.email });
+ * }
+ * ```
+ *
+ * @category Middleware
+ */
+export class AuthenticationMiddleware extends BaseMiddleware {
+  /**
+   * Create a new AuthenticationMiddleware instance.
+   *
+   * @param getResponse - The next layer in the middleware chain.
+   */
+  constructor(getResponse: NextFunction) {
+    super(getResponse);
+  }
+
+  /**
+   * Resolve the authenticated user and attach it to the request, then pass
+   * the request to the next middleware or view.
+   *
+   * @param request - The incoming HTTP request.
+   * @returns The HTTP response from the next layer.
+   */
+  override async call(request: Request): Promise<Response> {
+    const user = await _resolveUser(request);
+    if (user) {
+      _requestUsers.set(request, user);
+    }
+    return this.getResponse(request);
+  }
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Extract and verify the JWT bearer token from the `Authorization` header.
+ *
+ * @param request - Incoming HTTP request.
+ * @returns The decoded {@link AuthenticatedUser}, or `null` if the token is
+ *   absent or invalid.
+ *
+ * @internal
+ */
+async function _resolveUser(
+  request: Request,
+): Promise<AuthenticatedUser | null> {
+  const authHeader = request.headers.get("Authorization") ?? "";
+  const match = /^Bearer\s+(.+)$/i.exec(authHeader);
+  if (!match) return null;
+
+  const token = match[1];
+  const payload = await verifyToken(token);
+  if (!payload) return null;
+
+  const userId = payload.userId ?? (payload as Record<string, unknown>).sub;
+  if (userId == null) return null;
+
+  return {
+    id: userId as number | string,
+    email: payload.email,
+    isAdmin: payload.isAdmin ?? false,
+  };
+}

--- a/src/auth/middleware_test.ts
+++ b/src/auth/middleware_test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests for AuthenticationMiddleware.
+ */
+
+import { assertEquals } from "jsr:@std/assert@1";
+import { AuthenticationMiddleware } from "./middleware.ts";
+import { getRequestUser } from "./decorators.ts";
+import { createTokenPair } from "./jwt.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a Request with a valid JWT bearer token for the given user. */
+async function requestWithToken(
+  userId: number,
+  email: string,
+  isAdmin = false,
+): Promise<Request> {
+  const { accessToken } = await createTokenPair(userId, email, isAdmin);
+  return new Request("http://localhost/test", {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+}
+
+/** Create a middleware instance wrapping a simple 200 OK handler. */
+function makeMiddleware(): AuthenticationMiddleware {
+  const handler = async (_request?: Request): Promise<Response> =>
+    new Response("ok", { status: 200 });
+  return new AuthenticationMiddleware(handler);
+}
+
+// ---------------------------------------------------------------------------
+// AuthenticationMiddleware: pass-through behaviour
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "AuthenticationMiddleware: passes request to next handler",
+  async () => {
+    const mw = makeMiddleware();
+    const request = new Request("http://localhost/test");
+    const response = await mw.call(request);
+    assertEquals(response.status, 200);
+  },
+);
+
+Deno.test(
+  "AuthenticationMiddleware: does not reject anonymous request",
+  async () => {
+    const mw = makeMiddleware();
+    const request = new Request("http://localhost/test");
+    const response = await mw.call(request);
+    // Anonymous requests pass through — middleware never rejects on its own
+    assertEquals(response.status, 200);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// AuthenticationMiddleware: user resolution
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "AuthenticationMiddleware: attaches user for valid token",
+  async () => {
+    const request = await requestWithToken(1, "alice@example.com", false);
+
+    let capturedUser: ReturnType<typeof getRequestUser>;
+    const mw = new AuthenticationMiddleware(async (req?) => {
+      capturedUser = getRequestUser(req!);
+      return new Response("ok");
+    });
+
+    await mw.call(request);
+
+    assertEquals(capturedUser?.id, 1);
+    assertEquals(capturedUser?.email, "alice@example.com");
+    assertEquals(capturedUser?.isAdmin, false);
+  },
+);
+
+Deno.test(
+  "AuthenticationMiddleware: attaches admin user for valid admin token",
+  async () => {
+    const request = await requestWithToken(99, "admin@example.com", true);
+
+    let capturedUser: ReturnType<typeof getRequestUser>;
+    const mw = new AuthenticationMiddleware(async (req?) => {
+      capturedUser = getRequestUser(req!);
+      return new Response("ok");
+    });
+
+    await mw.call(request);
+
+    assertEquals(capturedUser?.id, 99);
+    assertEquals(capturedUser?.isAdmin, true);
+  },
+);
+
+Deno.test(
+  "AuthenticationMiddleware: no user for missing Authorization header",
+  async () => {
+    const request = new Request("http://localhost/test");
+
+    let capturedUser: ReturnType<typeof getRequestUser>;
+    const mw = new AuthenticationMiddleware(async (req?) => {
+      capturedUser = getRequestUser(req!);
+      return new Response("ok");
+    });
+
+    await mw.call(request);
+
+    assertEquals(capturedUser, undefined);
+  },
+);
+
+Deno.test(
+  "AuthenticationMiddleware: no user for invalid token",
+  async () => {
+    const request = new Request("http://localhost/test", {
+      headers: { Authorization: "Bearer not.a.valid.token" },
+    });
+
+    let capturedUser: ReturnType<typeof getRequestUser>;
+    const mw = new AuthenticationMiddleware(async (req?) => {
+      capturedUser = getRequestUser(req!);
+      return new Response("ok");
+    });
+
+    await mw.call(request);
+
+    assertEquals(capturedUser, undefined);
+  },
+);
+
+Deno.test(
+  "AuthenticationMiddleware: no user for non-Bearer scheme",
+  async () => {
+    const request = new Request("http://localhost/test", {
+      headers: { Authorization: "Token abc123" },
+    });
+
+    let capturedUser: ReturnType<typeof getRequestUser>;
+    const mw = new AuthenticationMiddleware(async (req?) => {
+      capturedUser = getRequestUser(req!);
+      return new Response("ok");
+    });
+
+    await mw.call(request);
+
+    assertEquals(capturedUser, undefined);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Integration: middleware + loginRequired interoperability
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "AuthenticationMiddleware: user set by middleware is visible via getRequestUser",
+  async () => {
+    // Verify the shared WeakMap: user set by middleware should be readable
+    // by getRequestUser called outside the middleware chain (e.g. in views).
+    const request = await requestWithToken(42, "bob@example.com", false);
+
+    const mw = new AuthenticationMiddleware(async (_req?) =>
+      new Response("ok")
+    );
+    await mw.call(request);
+
+    // getRequestUser reads the same WeakMap that middleware writes to
+    const user = getRequestUser(request);
+    assertEquals(user?.id, 42);
+    assertEquals(user?.email, "bob@example.com");
+  },
+);

--- a/src/auth/mod.ts
+++ b/src/auth/mod.ts
@@ -2,8 +2,9 @@
  * Alexi's authentication package.
  *
  * `@alexi/auth` provides the framework's authentication app configuration,
- * its Django-style `AbstractUser` base model, and JWT utilities for issuing
- * and verifying signed access and refresh tokens.
+ * its Django-style `AbstractUser` base model, JWT utilities for issuing and
+ * verifying signed access and refresh tokens, and
+ * {@link AuthenticationMiddleware} for automatic request-level user resolution.
  *
  * Most projects import `AbstractUser` from this package, extend it with
  * application-specific fields, and register the resulting model in settings as
@@ -48,6 +49,19 @@
  *   return Response.json({ id: user.id, email: user.email });
  * });
  * ```
+ *
+ * @example Use AuthenticationMiddleware for automatic user resolution
+ * ```ts
+ * import { AuthenticationMiddleware } from "@alexi/auth";
+ * import { LoggingMiddleware, CorsMiddleware, ErrorHandlerMiddleware } from "@alexi/middleware";
+ *
+ * export const MIDDLEWARE = [
+ *   LoggingMiddleware,
+ *   CorsMiddleware,
+ *   AuthenticationMiddleware,
+ *   ErrorHandlerMiddleware,
+ * ];
+ * ```
  */
 
 // =============================================================================
@@ -73,5 +87,10 @@ export {
   permissionRequired,
 } from "./decorators.ts";
 export type { AuthenticatedUser, ViewFunction } from "./decorators.ts";
+
+// Authentication middleware
+export { AuthenticationMiddleware } from "./middleware.ts";
+export { BaseMiddleware } from "@alexi/middleware";
+export type { NextFunction } from "@alexi/middleware";
 
 // Commands are loaded dynamically via app.ts commandsModule


### PR DESCRIPTION
## Summary

- Adds `AuthenticationMiddleware` to `@alexi/auth` that automatically resolves JWT tokens for every request
- Extracts shared `_requestUsers` WeakMap into `_auth_store.ts` so that `getRequestUser()` works with both middleware-set and decorator-set users
- Re-exports `BaseMiddleware` and `NextFunction` from `@alexi/auth/mod.ts` for convenience
- Includes 8 tests covering authenticated, unauthenticated, and invalid-token scenarios

Closes #387