### PR TITLE
feat(auth): add AUTH_USER_MODEL support to AuthenticationMiddleware

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -845,6 +845,36 @@ const profileView = loginRequired(async (request, params) => {
 });
 ```
 
+### AuthenticationMiddleware with AUTH_USER_MODEL
+
+`AuthenticationMiddleware.configure({ userModel })` returns a configured
+subclass that fetches the full ORM instance from the database on every
+authenticated request. The instance is available via
+`getRequestUserInstance<T>()`.
+
+```typescript
+import { AuthenticationMiddleware, getRequestUserInstance } from "@alexi/auth";
+import { UserModel } from "@myapp/models";
+
+// settings.ts
+export const MIDDLEWARE = [
+  LoggingMiddleware,
+  CorsMiddleware,
+  AuthenticationMiddleware.configure({ userModel: UserModel }),
+  ErrorHandlerMiddleware,
+];
+
+// In a view
+export async function profileView(request: Request): Promise<Response> {
+  const user = getRequestUserInstance<typeof UserModel.prototype>(request);
+  if (!user) return Response.json({ detail: "Unauthorized" }, { status: 401 });
+  return Response.json({ firstName: user.firstName.get() });
+}
+```
+
+Without `configure()`, `AuthenticationMiddleware` still attaches the JWT payload
+via `getRequestUser()` (id, email, isAdmin) but does not hit the database.
+
 ### JWT Tokens
 
 ```typescript

--- a/src/auth/_auth_store.ts
+++ b/src/auth/_auth_store.ts
@@ -20,3 +20,13 @@ import type { AuthenticatedUser } from "./decorators.ts";
  * @internal
  */
 export const _requestUsers = new WeakMap<Request, AuthenticatedUser>();
+
+/**
+ * Maps each in-flight `Request` to the full ORM model instance fetched from
+ * the database when `AUTH_USER_MODEL` is configured on
+ * {@link AuthenticationMiddleware}.  Populated only when the middleware is
+ * configured with a `userModel` option.
+ *
+ * @internal
+ */
+export const _requestUserInstances = new WeakMap<Request, unknown>();

--- a/src/auth/decorators.ts
+++ b/src/auth/decorators.ts
@@ -11,7 +11,7 @@
 
 import type { TokenPayload } from "./jwt.ts";
 import { verifyToken } from "./jwt.ts";
-import { _requestUsers } from "./_auth_store.ts";
+import { _requestUserInstances, _requestUsers } from "./_auth_store.ts";
 
 // =============================================================================
 // Types
@@ -74,6 +74,47 @@ export function getRequestUser(
   request: Request,
 ): AuthenticatedUser | undefined {
   return _requestUsers.get(request);
+}
+
+/**
+ * Return the full ORM model instance attached to `request` by
+ * {@link AuthenticationMiddleware} when it is configured with a `userModel`.
+ *
+ * Returns `undefined` when the middleware was not configured with a
+ * `userModel`, when the request is anonymous, or when the user was not found
+ * in the database.
+ *
+ * Use a type parameter to cast the result to your project's user model type
+ * without importing it in this package:
+ *
+ * ```ts
+ * import { getRequestUserInstance } from "@alexi/auth";
+ * import type { UserModel } from "@myapp/models";
+ *
+ * const user = getRequestUserInstance<UserModel>(request);
+ * ```
+ *
+ * @param request - The current HTTP request.
+ * @returns The ORM instance, or `undefined` if not available.
+ *
+ * @example
+ * ```ts
+ * import { getRequestUserInstance } from "@alexi/auth";
+ * import type { UserModel } from "@myapp/models";
+ *
+ * export async function profileView(request: Request): Promise<Response> {
+ *   const user = getRequestUserInstance<UserModel>(request);
+ *   if (!user) return Response.json({ detail: "Unauthorized" }, { status: 401 });
+ *   return Response.json({ name: user.firstName.get() });
+ * }
+ * ```
+ *
+ * @category Decorators
+ */
+export function getRequestUserInstance<T = unknown>(
+  request: Request,
+): T | undefined {
+  return _requestUserInstances.get(request) as T | undefined;
 }
 
 /**

--- a/src/auth/middleware.ts
+++ b/src/auth/middleware.ts
@@ -12,7 +12,7 @@
  * `MIDDLEWARE` setting to make authentication available in plain views, other
  * middleware, and service-worker handlers — not just in ViewSets.
  *
- * @example
+ * @example Basic usage (JWT payload only)
  * ```ts
  * import { AuthenticationMiddleware } from "@alexi/auth";
  * import { LoggingMiddleware, CorsMiddleware, ErrorHandlerMiddleware } from "@alexi/middleware";
@@ -25,14 +25,69 @@
  * ];
  * ```
  *
+ * @example With AUTH_USER_MODEL — full ORM instance via getRequestUserInstance()
+ * ```ts
+ * import { AuthenticationMiddleware } from "@alexi/auth";
+ * import { UserModel } from "@myapp/models";
+ *
+ * export const MIDDLEWARE = [
+ *   AuthenticationMiddleware.configure({ userModel: UserModel }),
+ * ];
+ * ```
+ *
  * @module
  */
 
 import { BaseMiddleware } from "@alexi/middleware";
 import type { NextFunction } from "@alexi/middleware";
 import { verifyToken } from "./jwt.ts";
-import { _requestUsers } from "./_auth_store.ts";
+import { _requestUserInstances, _requestUsers } from "./_auth_store.ts";
 import type { AuthenticatedUser } from "./decorators.ts";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Minimal interface for a user model class that can be passed to
+ * {@link AuthenticationMiddleware.configure}.
+ *
+ * Any `AbstractUser` subclass satisfies this interface automatically.
+ *
+ * @category Middleware
+ */
+export interface UserModelClass {
+  /** ORM manager — must support `.filter({ id }).first()`. */
+  objects: {
+    filter(query: Record<string, unknown>): {
+      first(): Promise<unknown>;
+    };
+  };
+}
+
+/**
+ * Configuration options for {@link AuthenticationMiddleware.configure}.
+ *
+ * @category Middleware
+ */
+export interface AuthenticationMiddlewareOptions {
+  /**
+   * The user model class to use for database look-ups.
+   *
+   * When provided, the middleware fetches a full ORM instance from the
+   * database for every authenticated request.  The instance is then available
+   * via {@link getRequestUserInstance}.
+   *
+   * Pass the same class as `AUTH_USER_MODEL` in your project settings:
+   *
+   * ```ts
+   * import { UserModel } from "@myapp/models";
+   *
+   * AuthenticationMiddleware.configure({ userModel: UserModel });
+   * ```
+   */
+  userModel: UserModelClass;
+}
 
 // =============================================================================
 // AuthenticationMiddleware
@@ -46,6 +101,10 @@ import type { AuthenticatedUser } from "./decorators.ts";
  * the request.  The user is then available via {@link getRequestUser} anywhere
  * downstream — in views, other middleware, and ViewSet permission checks.
  *
+ * When configured with a `userModel` via {@link AuthenticationMiddleware.configure},
+ * the middleware additionally fetches the full ORM instance from the database
+ * and stores it so it can be retrieved with {@link getRequestUserInstance}.
+ *
  * Anonymous requests (missing or invalid token) pass through unchanged with no
  * user attached.  The middleware never rejects a request on its own; use
  * {@link loginRequired}, {@link permissionRequired}, or ViewSet
@@ -54,7 +113,7 @@ import type { AuthenticatedUser } from "./decorators.ts";
  * Place this middleware **after** logging/CORS middleware and **before** any
  * middleware or view that needs to know who the user is.
  *
- * @example Add to MIDDLEWARE in settings
+ * @example Add to MIDDLEWARE in settings (JWT payload only)
  * ```ts
  * import { AuthenticationMiddleware } from "@alexi/auth";
  * import { LoggingMiddleware, CorsMiddleware, ErrorHandlerMiddleware } from "@alexi/middleware";
@@ -64,6 +123,16 @@ import type { AuthenticatedUser } from "./decorators.ts";
  *   CorsMiddleware,
  *   AuthenticationMiddleware,
  *   ErrorHandlerMiddleware,
+ * ];
+ * ```
+ *
+ * @example Add to MIDDLEWARE with AUTH_USER_MODEL
+ * ```ts
+ * import { AuthenticationMiddleware } from "@alexi/auth";
+ * import { UserModel } from "@myapp/models";
+ *
+ * export const MIDDLEWARE = [
+ *   AuthenticationMiddleware.configure({ userModel: UserModel }),
  * ];
  * ```
  *
@@ -78,9 +147,30 @@ import type { AuthenticatedUser } from "./decorators.ts";
  * }
  * ```
  *
+ * @example Read the full ORM instance (requires configure({ userModel }))
+ * ```ts
+ * import { getRequestUser, getRequestUserInstance } from "@alexi/auth";
+ * import type { UserModel } from "@myapp/models";
+ *
+ * export async function profileView(request: Request): Promise<Response> {
+ *   const user = getRequestUser(request);
+ *   if (!user) return Response.json({ detail: "Unauthorized" }, { status: 401 });
+ *   const instance = getRequestUserInstance<UserModel>(request);
+ *   return Response.json({ name: instance?.firstName.get() });
+ * }
+ * ```
+ *
  * @category Middleware
  */
 export class AuthenticationMiddleware extends BaseMiddleware {
+  /**
+   * Optional user model used for database look-ups.
+   * Set by {@link configure} on the subclass; `null` on the base class.
+   *
+   * @internal
+   */
+  protected static _userModel: UserModelClass | null = null;
+
   /**
    * Create a new AuthenticationMiddleware instance.
    *
@@ -88,6 +178,41 @@ export class AuthenticationMiddleware extends BaseMiddleware {
    */
   constructor(getResponse: NextFunction) {
     super(getResponse);
+  }
+
+  /**
+   * Return a configured subclass of `AuthenticationMiddleware` that fetches a
+   * full ORM user instance on every authenticated request.
+   *
+   * Use this factory when you want the middleware to load the complete user
+   * object from the database, not just the JWT payload.  The fetched instance
+   * is stored alongside the JWT payload and can be retrieved with
+   * {@link getRequestUserInstance}.
+   *
+   * @param options - Configuration options, including the `userModel` class.
+   * @returns A new middleware class (not an instance) ready to be included in
+   *   the `MIDDLEWARE` setting.
+   *
+   * @example
+   * ```ts
+   * import { AuthenticationMiddleware } from "@alexi/auth";
+   * import { UserModel } from "@myapp/models";
+   *
+   * export const MIDDLEWARE = [
+   *   AuthenticationMiddleware.configure({ userModel: UserModel }),
+   * ];
+   * ```
+   *
+   * @category Middleware
+   */
+  static configure(
+    options: AuthenticationMiddlewareOptions,
+  ): typeof AuthenticationMiddleware {
+    class ConfiguredAuthenticationMiddleware extends AuthenticationMiddleware {
+      protected static override _userModel: UserModelClass | null =
+        options.userModel;
+    }
+    return ConfiguredAuthenticationMiddleware;
   }
 
   /**
@@ -101,6 +226,18 @@ export class AuthenticationMiddleware extends BaseMiddleware {
     const user = await _resolveUser(request);
     if (user) {
       _requestUsers.set(request, user);
+
+      // If a userModel is configured, fetch the full ORM instance.
+      const userModel = (this.constructor as typeof AuthenticationMiddleware)
+        ._userModel;
+      if (userModel) {
+        const instance = await userModel.objects
+          .filter({ id: user.id })
+          .first();
+        if (instance != null) {
+          _requestUserInstances.set(request, instance);
+        }
+      }
     }
     return this.getResponse(request);
   }

--- a/src/auth/middleware_test.ts
+++ b/src/auth/middleware_test.ts
@@ -4,7 +4,7 @@
 
 import { assertEquals } from "jsr:@std/assert@1";
 import { AuthenticationMiddleware } from "./middleware.ts";
-import { getRequestUser } from "./decorators.ts";
+import { getRequestUser, getRequestUserInstance } from "./decorators.ts";
 import { createTokenPair } from "./jwt.ts";
 
 // ---------------------------------------------------------------------------
@@ -171,5 +171,131 @@ Deno.test(
     const user = getRequestUser(request);
     assertEquals(user?.id, 42);
     assertEquals(user?.email, "bob@example.com");
+  },
+);
+
+// ---------------------------------------------------------------------------
+// AuthenticationMiddleware.configure: userModel integration
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "AuthenticationMiddleware.configure: fetches user instance from userModel",
+  async () => {
+    const request = await requestWithToken(7, "carol@example.com", false);
+
+    // Minimal fake user model that returns a stub instance for id=7
+    const fakeInstance = { id: 7, name: "Carol" };
+    const FakeUserModel = {
+      objects: {
+        filter(query: Record<string, unknown>) {
+          return {
+            async first() {
+              if (query["id"] === 7) return fakeInstance;
+              return null;
+            },
+          };
+        },
+      },
+    };
+
+    const ConfiguredMW = AuthenticationMiddleware.configure({
+      userModel: FakeUserModel,
+    });
+
+    let capturedInstance: unknown;
+    const mw = new ConfiguredMW(async (req?) => {
+      capturedInstance = getRequestUserInstance(req!);
+      return new Response("ok");
+    });
+
+    await mw.call(request);
+
+    assertEquals(capturedInstance, fakeInstance);
+  },
+);
+
+Deno.test(
+  "AuthenticationMiddleware.configure: no instance for anonymous request",
+  async () => {
+    const request = new Request("http://localhost/test");
+
+    const FakeUserModel = {
+      objects: {
+        filter(_query: Record<string, unknown>) {
+          return {
+            async first() {
+              return null;
+            },
+          };
+        },
+      },
+    };
+
+    const ConfiguredMW = AuthenticationMiddleware.configure({
+      userModel: FakeUserModel,
+    });
+
+    let capturedInstance: unknown = "sentinel";
+    const mw = new ConfiguredMW(async (req?) => {
+      capturedInstance = getRequestUserInstance(req!);
+      return new Response("ok");
+    });
+
+    await mw.call(request);
+
+    assertEquals(capturedInstance, undefined);
+  },
+);
+
+Deno.test(
+  "AuthenticationMiddleware.configure: no instance when user not found in DB",
+  async () => {
+    const request = await requestWithToken(999, "ghost@example.com", false);
+
+    // Always returns null — user 999 doesn't exist
+    const FakeUserModel = {
+      objects: {
+        filter(_query: Record<string, unknown>) {
+          return {
+            async first() {
+              return null;
+            },
+          };
+        },
+      },
+    };
+
+    const ConfiguredMW = AuthenticationMiddleware.configure({
+      userModel: FakeUserModel,
+    });
+
+    let capturedInstance: unknown = "sentinel";
+    const mw = new ConfiguredMW(async (req?) => {
+      capturedInstance = getRequestUserInstance(req!);
+      return new Response("ok");
+    });
+
+    await mw.call(request);
+
+    assertEquals(capturedInstance, undefined);
+  },
+);
+
+Deno.test(
+  "AuthenticationMiddleware.configure: base class still works without userModel",
+  async () => {
+    // Ensure configure() doesn't affect the undecorated base class
+    const request = await requestWithToken(5, "dave@example.com", false);
+
+    let capturedInstance: unknown = "sentinel";
+    const mw = new AuthenticationMiddleware(async (req?) => {
+      capturedInstance = getRequestUserInstance(req!);
+      return new Response("ok");
+    });
+
+    await mw.call(request);
+
+    // Base class has no userModel → instance should always be undefined
+    assertEquals(capturedInstance, undefined);
   },
 );

--- a/src/auth/mod.ts
+++ b/src/auth/mod.ts
@@ -84,6 +84,7 @@ export type { TokenPair, TokenPayload } from "./jwt.ts";
 // View decorators
 export {
   getRequestUser,
+  getRequestUserInstance,
   loginRequired,
   permissionRequired,
 } from "./decorators.ts";
@@ -91,5 +92,9 @@ export type { AuthenticatedUser, ViewFunction } from "./decorators.ts";
 
 // Authentication middleware
 export { AuthenticationMiddleware } from "./middleware.ts";
+export type {
+  AuthenticationMiddlewareOptions,
+  UserModelClass,
+} from "./middleware.ts";
 
 // Commands are loaded dynamically via app.ts commandsModule


### PR DESCRIPTION
## Summary

- Adds `AuthenticationMiddleware.configure({ userModel })` static factory that returns a configured subclass fetching the full ORM instance from the database on every authenticated request
- Adds `getRequestUserInstance<T>()` helper to retrieve the ORM instance from a request
- Adds `UserModelClass` and `AuthenticationMiddlewareOptions` exported interfaces
- Extends internal `_auth_store` with a second `WeakMap` for ORM instances
- 4 new tests covering all `configure()` scenarios
- Documents the new API in `AGENTS.md`

Closes #389