### PR TITLE
fix(staticfiles): virtual entry uses original filename so [name] resolves correctly

### DIFF
--- a/src/staticfiles/commands/bundle.ts
+++ b/src/staticfiles/commands/bundle.ts
@@ -583,7 +583,7 @@ export async function buildSWBundle(
   // Deno plugins must come last
   plugins.push(...denoPlugins({ configPath }));
 
-  let effectiveEntryPoint = entryPoint;
+  let effectiveEntryPoint: string | { in: string; out: string } = entryPoint;
   if (templates.length > 0) {
     // Use an absolute file:// URL so deno-resolver handles it correctly on all
     // platforms.  A relative path fails on Windows because deno-resolver
@@ -602,16 +602,30 @@ export async function buildSWBundle(
     };\n`;
 
     const cwdNorm = cwd.replace(/\\/g, "/");
-    const virtualEntryPath = "__alexi_sw_entry__.ts";
+    // Name the virtual entry after the original source file so that esbuild
+    // derives the correct [name] token when entryNames contains "[name]".
+    // Using "__alexi_sw_entry__" here would cause esbuild to produce output
+    // like `__alexi_sw_entry__-<hash>.js` instead of `<original>-<hash>.js`.
+    // See https://github.com/atzufuki/alexi/issues/399
+    //
+    // We use esbuild's `{ in, out }` entryPoints form: the `in` value is a
+    // uniquely-prefixed virtual path (preventing filesystem collisions with a
+    // real file of the same name in absWorkingDir) while `out` is the bare
+    // original stem, which esbuild substitutes for [name] in entryNames.
+    const originalBasename = entryPoint
+      .replace(/^.*[\\/]/, "") // strip directory (works for both paths and file:// URLs)
+      .replace(/\.[^.]+$/, "") // strip extension
+      .replace(/[^a-zA-Z0-9_\-]/g, "_"); // sanitise for use as a filename
+    const virtualEntryIn = `__alexi_virtual__${originalBasename}.ts`;
     const virtualEntryNamespace = "alexi-sw-entry-virtual";
 
     plugins.unshift({
       name: "alexi-sw-entry",
       setup(build) {
         build.onResolve(
-          { filter: /^__alexi_sw_entry__\.ts$/ },
+          { filter: /^__alexi_virtual__/ },
           (args) => ({
-            path: virtualEntryPath,
+            path: args.path,
             namespace: virtualEntryNamespace,
             pluginData: args,
           }),
@@ -627,11 +641,13 @@ export async function buildSWBundle(
       },
     });
 
-    effectiveEntryPoint = "__alexi_sw_entry__.ts";
+    effectiveEntryPoint = { in: virtualEntryIn, out: originalBasename };
   }
 
   const result = await esbuild.build({
-    entryPoints: [effectiveEntryPoint],
+    entryPoints: [effectiveEntryPoint] as
+      | [string]
+      | [{ in: string; out: string }],
     bundle: true,
     splitting: true,
     format: "esm",

--- a/src/staticfiles/commands/bundle_test.ts
+++ b/src/staticfiles/commands/bundle_test.ts
@@ -907,3 +907,70 @@ Deno.test({
     }
   },
 });
+
+// =============================================================================
+// buildSWBundle — virtual entry name regression (#399)
+//
+// When templates are embedded, the virtual esbuild entry must be named after
+// the original source file so that esbuild resolves [name] correctly in
+// entryNames.  Previously the virtual entry was always called
+// "__alexi_sw_entry__", causing output like `__alexi_sw_entry__-<hash>.js`
+// instead of `<original>-<hash>.js`.
+// =============================================================================
+
+Deno.test({
+  name:
+    "buildSWBundle: [name] token resolves to original filename when templates are embedded (regression #399)",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  async fn() {
+    const tmpDir = await Deno.makeTempDir();
+    try {
+      // Non-SW entry named "myapp.ts"
+      const entryPath = join(tmpDir, "myapp.ts");
+      await Deno.writeTextFile(
+        entryPath,
+        `export const APP_VERSION = "1";\n`,
+      );
+
+      const outputDir = join(tmpDir, "dist", "my-app");
+      await Deno.mkdir(outputDir, { recursive: true });
+      const outputPath = join(outputDir, "myapp.js").replace(/\\/g, "/");
+
+      const configPath = join(Deno.cwd(), "deno.json");
+      const entryUrl = toFileUrl(entryPath).href;
+
+      await buildSWBundle({
+        entryPoint: entryUrl,
+        outputPath,
+        minify: false,
+        templates: [
+          { name: "my-app/index.html", source: "<h1>Hello</h1>" },
+        ],
+        cwd: tmpDir,
+        configPath,
+        entryNames: "[name]-[hash]",
+      });
+
+      // The manifest must map the logical key to a hashed file whose stem is
+      // "myapp", NOT "__alexi_sw_entry__".
+      const manifestPath = join(tmpDir, "dist", "staticfiles.json");
+      const raw = await Deno.readTextFile(manifestPath);
+      const parsed = JSON.parse(raw);
+
+      const hashedValue: string = parsed.files["my-app/myapp.js"];
+      assertStringIncludes(
+        hashedValue,
+        "myapp-",
+        `Expected hashed filename to start with "myapp-", got: ${hashedValue}`,
+      );
+      assertEquals(
+        hashedValue.includes("__alexi_sw_entry__"),
+        false,
+        `Output filename must not contain "__alexi_sw_entry__", got: ${hashedValue}`,
+      );
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+});


### PR DESCRIPTION
## Summary

- Replace the hard-coded `__alexi_sw_entry__.ts` virtual entrypoint name with esbuild's `{ in, out }` entryPoints form
- `in` uses a uniquely-prefixed name (`__alexi_virtual__<original>.ts`) to avoid filesystem collisions with a real file of the same name in `absWorkingDir`
- `out` is set to the bare original stem so esbuild substitutes it correctly for `[name]` in `entryNames`
- Adds regression test: `buildSWBundle: [name] token resolves to original filename when templates are embedded (regression #399)`

Closes #399