### PR TITLE
feat(restframework): support multipart/form-data uploads in ModelViewSet

### DIFF
--- a/src/restframework/mod.ts
+++ b/src/restframework/mod.ts
@@ -111,6 +111,7 @@ export {
   // ViewSet classes
   ModelViewSet,
   NotFoundError,
+  parseRequestData,
   ReadOnlyModelViewSet,
   RetrieveModelMixin,
   UpdateModelMixin,

--- a/src/restframework/viewsets/mod.ts
+++ b/src/restframework/viewsets/mod.ts
@@ -56,6 +56,8 @@ export {
   ModelViewSet,
   // Errors
   NotFoundError,
+  // Utilities
+  parseRequestData,
   // Read-only variant
   ReadOnlyModelViewSet,
   RetrieveModelMixin,

--- a/src/restframework/viewsets/model_viewset.ts
+++ b/src/restframework/viewsets/model_viewset.ts
@@ -529,6 +529,10 @@ export abstract class ModelViewSet extends ViewSet
   /**
    * Create a new object (POST /).
    *
+   * Accepts both `application/json` and `multipart/form-data` request bodies.
+   * File fields included in a multipart body are passed as {@link File}
+   * instances to the serializer.
+   *
    * @param context Current request context.
    * @returns `201 Created` response with the serialized object, or `400` when
    * request validation fails.
@@ -537,10 +541,10 @@ export abstract class ModelViewSet extends ViewSet
     let data: Record<string, unknown>;
 
     try {
-      data = await context.request.json();
+      data = await parseRequestData(context.request);
     } catch {
       return Response.json(
-        { error: "Invalid JSON in request body" },
+        { error: "Invalid request body" },
         { status: 400 },
       );
     }
@@ -649,10 +653,10 @@ export abstract class ModelViewSet extends ViewSet
 
     let data: Record<string, unknown>;
     try {
-      data = await context.request.json();
+      data = await parseRequestData(context.request);
     } catch {
       return Response.json(
-        { error: "Invalid JSON in request body" },
+        { error: "Invalid request body" },
         { status: 400 },
       );
     }
@@ -760,6 +764,43 @@ export abstract class ModelViewSet extends ViewSet
 // ============================================================================
 // Errors
 // ============================================================================
+
+/**
+ * Parse the request body as either JSON or multipart/form-data.
+ *
+ * - Requests with `Content-Type: application/json` (or no content type) are
+ *   parsed with `request.json()`.
+ * - Requests with `Content-Type: multipart/form-data` are parsed with
+ *   `request.formData()`.  Each entry is included in the returned object:
+ *   string fields are kept as strings, {@link File} objects are kept as `File`
+ *   instances so that serializer {@link FileField} / {@link ImageField} fields
+ *   can validate and upload them.
+ *
+ * @param request The incoming HTTP request.
+ * @returns A plain object suitable for passing as `data` to a serializer.
+ * @throws {SyntaxError} If the JSON body is malformed.
+ * @throws {Error} If parsing the multipart body fails.
+ *
+ * @category ViewSets
+ */
+export async function parseRequestData(
+  request: Request,
+): Promise<Record<string, unknown>> {
+  const contentType = request.headers.get("content-type") ?? "";
+
+  if (contentType.includes("multipart/form-data")) {
+    const formData = await request.formData();
+    const data: Record<string, unknown> = {};
+    for (const [key, value] of formData.entries()) {
+      // Keep File objects as-is so serializer FileField can handle them
+      data[key] = value;
+    }
+    return data;
+  }
+
+  // Default: parse as JSON (covers application/json and empty content-type)
+  return request.json() as Promise<Record<string, unknown>>;
+}
 
 /**
  * Error thrown when a detail lookup does not match any object.

--- a/src/restframework/viewsets/model_viewset_test.ts
+++ b/src/restframework/viewsets/model_viewset_test.ts
@@ -3,11 +3,12 @@
  *
  * Tests for `ModelViewSet.getQueryset(context)` — verifying that the context
  * is correctly passed to overrides so that user-scoped filtering works.
+ * Also tests `parseRequestData()` for JSON and multipart/form-data requests.
  *
  * @module @alexi/restframework/viewsets/model_viewset_test
  */
 
-import { assertEquals } from "jsr:@std/assert@1";
+import { assertEquals, assertInstanceOf } from "jsr:@std/assert@1";
 import { setup } from "@alexi/core";
 import {
   AutoField,
@@ -21,7 +22,7 @@ import { DenoKVBackend } from "@alexi/db/backends/denokv";
 import { Serializer } from "../serializers/serializer.ts";
 import type { SerializerClass } from "./model_viewset.ts";
 import type { ViewSetContext } from "./viewset.ts";
-import { ModelViewSet } from "./model_viewset.ts";
+import { ModelViewSet, parseRequestData } from "./model_viewset.ts";
 
 // =============================================================================
 // Test model
@@ -185,5 +186,77 @@ Deno.test({
     } finally {
       await teardown(backend);
     }
+  },
+});
+
+// =============================================================================
+// parseRequestData tests
+// =============================================================================
+
+Deno.test({
+  name: "parseRequestData: parses application/json body",
+  async fn() {
+    const request = new Request("http://localhost/api/notes/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ body: "Hello", authorId: 1 }),
+    });
+
+    const data = await parseRequestData(request);
+    assertEquals(data, { body: "Hello", authorId: 1 });
+  },
+});
+
+Deno.test({
+  name: "parseRequestData: parses multipart/form-data body with string fields",
+  async fn() {
+    const formData = new FormData();
+    formData.append("body", "Hello multipart");
+    formData.append("authorId", "42");
+
+    const request = new Request("http://localhost/api/notes/", {
+      method: "POST",
+      body: formData,
+    });
+
+    const data = await parseRequestData(request);
+    assertEquals(data["body"], "Hello multipart");
+    assertEquals(data["authorId"], "42");
+  },
+});
+
+Deno.test({
+  name: "parseRequestData: keeps File objects from multipart/form-data",
+  async fn() {
+    const formData = new FormData();
+    formData.append("title", "My upload");
+    const file = new File(["hello world"], "test.txt", {
+      type: "text/plain",
+    });
+    formData.append("attachment", file);
+
+    const request = new Request("http://localhost/api/upload/", {
+      method: "POST",
+      body: formData,
+    });
+
+    const data = await parseRequestData(request);
+    assertEquals(data["title"], "My upload");
+    assertInstanceOf(data["attachment"], File);
+    const attachment = data["attachment"] as File;
+    assertEquals(attachment.name, "test.txt");
+  },
+});
+
+Deno.test({
+  name: "parseRequestData: falls back to JSON when no content-type header",
+  async fn() {
+    const request = new Request("http://localhost/api/notes/", {
+      method: "POST",
+      body: JSON.stringify({ body: "No content-type" }),
+    });
+
+    const data = await parseRequestData(request);
+    assertEquals(data["body"], "No content-type");
   },
 });


### PR DESCRIPTION
## Summary

- Adds `parseRequestData()` helper that detects `Content-Type` and parses either `application/json` or `multipart/form-data` request bodies
- Replaces unconditional `request.json()` calls in `create()` and `performUpdateAction()` with `parseRequestData()`
- `File` objects from multipart bodies are kept as-is so serializer `FileField`/`ImageField` fields can validate and upload them
- Exports `parseRequestData` from `@alexi/restframework` for use in custom viewsets
- Adds 4 unit tests covering JSON, multipart string fields, multipart file fields, and missing content-type

Closes #407