### PR TITLE
feat(create): add cover ImageField to scaffolded posts app

### DIFF
--- a/src/create/templates/project/settings_ts.ts
+++ b/src/create/templates/project/settings_ts.ts
@@ -53,6 +53,7 @@ import {
   errorHandlerMiddleware,
   loggingMiddleware,
 } from "@alexi/middleware";
+import { FileSystemStorage } from "@alexi/storage/backends/filesystem";
 
 // =============================================================================
 // Environment
@@ -84,6 +85,20 @@ export const DATABASES = {
     path: Deno.env.get("DENO_KV_PATH"),
   }),
 };
+
+// =============================================================================
+// File Storage
+// =============================================================================
+
+/**
+ * Default file storage backend.
+ * Files are stored in ./uploads/ and served at /uploads/.
+ * Swap for S3Storage or FirebaseStorage in production.
+ */
+export const DEFAULT_FILE_STORAGE = new FileSystemStorage({
+  location: "./uploads",
+  baseUrl: "/uploads/",
+});
 
 // =============================================================================
 // Installed Apps

--- a/src/create/templates/root/deno_jsonc.ts
+++ b/src/create/templates/root/deno_jsonc.ts
@@ -47,6 +47,13 @@ export function generateDenoJsonc(name: string, version: string): string {
       "@alexi/restframework": `jsr:@alexi/restframework@${versionRange}`,
       "@alexi/auth": `jsr:@alexi/auth@${versionRange}`,
       "@alexi/admin": `jsr:@alexi/admin@${versionRange}`,
+      "@alexi/storage": `jsr:@alexi/storage@${versionRange}`,
+      "@alexi/storage/backends/filesystem":
+        `jsr:@alexi/storage@${versionRange}/backends/filesystem`,
+      "@alexi/storage/backends/memory":
+        `jsr:@alexi/storage@${versionRange}/backends/memory`,
+      "@alexi/storage/backends/firebase":
+        `jsr:@alexi/storage@${versionRange}/backends/firebase`,
       "@alexi/types": `jsr:@alexi/types@${versionRange}`,
       "@alexi/webui": `jsr:@alexi/webui@${versionRange}`,
       "@alexi/capacitor": `jsr:@alexi/capacitor@${versionRange}`,

--- a/src/create/templates/unified/models_ts.ts
+++ b/src/create/templates/unified/models_ts.ts
@@ -22,6 +22,7 @@ import {
   BooleanField,
   CharField,
   DateTimeField,
+  ImageField,
   Manager,
   Model,
   TextField,
@@ -30,12 +31,14 @@ import {
 /**
  * Post model - represents a blog post
  *
- * A simple blog post with title, content, published flag, and timestamps.
+ * A simple blog post with title, content, optional cover image,
+ * published flag, and timestamps.
  */
 export class PostModel extends Model {
   id = new AutoField({ primaryKey: true });
   title = new CharField({ maxLength: 200 });
   content = new TextField({ blank: true });
+  cover = new ImageField({ uploadTo: "covers/", null: true, blank: true });
   published = new BooleanField({ default: false });
   createdAt = new DateTimeField({ autoNowAdd: true });
   updatedAt = new DateTimeField({ autoNow: true });

--- a/src/create/templates/unified/serializers_ts.ts
+++ b/src/create/templates/unified/serializers_ts.ts
@@ -25,7 +25,7 @@ import { PostModel } from "@${name}/models.ts";
 export class PostSerializer extends ModelSerializer {
   static override Meta = {
     model: PostModel,
-    fields: ["id", "title", "content", "published", "createdAt", "updatedAt"],
+    fields: ["id", "title", "content", "cover", "published", "createdAt", "updatedAt"],
     readOnlyFields: ["id", "createdAt", "updatedAt"],
   };
 }

--- a/src/create/templates/unified/urls_ts.ts
+++ b/src/create/templates/unified/urls_ts.ts
@@ -25,6 +25,7 @@ import {
   PostPublishView,
   PostDeleteView,
   healthView,
+  uploadsView,
 } from "@${name}/views.ts";
 
 // Create router and register viewsets
@@ -48,6 +49,8 @@ export const urlpatterns = [
   path("posts/:id/publish/", PostPublishView.as_view()),
   path("posts/:id/delete/", PostDeleteView.as_view()),
   path("api/", include(apiPatterns)),
+  // Serve uploaded files at /uploads/<path>
+  path("uploads/:path", uploadsView),
 ];
 `;
 }

--- a/src/create/templates/unified/views_ts.ts
+++ b/src/create/templates/unified/views_ts.ts
@@ -77,8 +77,9 @@ export class PostCreateView extends View {
     const formData = await request.formData();
     const title = (formData.get("title") as string | null) ?? "";
     const content = (formData.get("content") as string | null) ?? "";
+    const cover = (formData.get("cover") as File | null) ?? null;
     const published = formData.get("published") === "true";
-    await PostModel.objects.create({ title, content, published });
+    await PostModel.objects.create({ title, content, cover, published });
     return Response.redirect(new URL("/posts/", request.url), 303);
   }
 }
@@ -108,6 +109,30 @@ export function healthView(_request: Request): Response {
     status: "ok",
     timestamp: new Date().toISOString(),
   });
+}
+
+/** Serves uploaded media files from the ./uploads directory. */
+export async function uploadsView(
+  _request: Request,
+  params: Record<string, string>,
+): Promise<Response> {
+  const filePath = \`./uploads/\${params["path"]}\`;
+  try {
+    const file = await Deno.readFile(filePath);
+    const ext = filePath.split(".").pop()?.toLowerCase() ?? "";
+    const contentTypes: Record<string, string> = {
+      jpg: "image/jpeg",
+      jpeg: "image/jpeg",
+      png: "image/png",
+      gif: "image/gif",
+      webp: "image/webp",
+      svg: "image/svg+xml",
+    };
+    const contentType = contentTypes[ext] ?? "application/octet-stream";
+    return new Response(file, { headers: { "content-type": contentType } });
+  } catch {
+    return new Response("Not found", { status: 404 });
+  }
 }
 `;
 }

--- a/src/create/templates/unified/workers/post_form_html.ts
+++ b/src/create/templates/unified/workers/post_form_html.ts
@@ -28,7 +28,7 @@ export function generateWorkerPostFormHtml(name: string): string {
 
   <div class="form-card">
     <h2>New Post</h2>
-    <form method="post" action="/posts/new/">
+    <form method="post" action="/posts/new/" enctype="multipart/form-data">
       <div class="form-group">
         <label class="form-label" for="title">Title</label>
         <input class="form-input" type="text" id="title" name="title"
@@ -38,6 +38,11 @@ export function generateWorkerPostFormHtml(name: string): string {
         <label class="form-label" for="content">Content</label>
         <textarea class="form-textarea" id="content" name="content"
                   placeholder="Start writing…"></textarea>
+      </div>
+      <div class="form-group">
+        <label class="form-label" for="cover">Cover image</label>
+        <input class="form-input" type="file" id="cover" name="cover"
+               accept="image/*">
       </div>
       <label class="form-check">
         <input type="checkbox" name="published" value="true">

--- a/src/create/templates/unified/workers/views_ts.ts
+++ b/src/create/templates/unified/workers/views_ts.ts
@@ -76,8 +76,9 @@ export class PostCreateView extends View {
     const formData = await request.formData();
     const title = (formData.get("title") as string | null) ?? "";
     const content = (formData.get("content") as string | null) ?? "";
+    const cover = (formData.get("cover") as File | null) ?? null;
     const published = formData.get("published") === "true";
-    await PostModel.objects.create({ title, content, published });
+    await PostModel.objects.create({ title, content, cover, published });
     return Response.redirect("/posts/", 303);
   }
 }

--- a/src/create/tests/e2e_utils.ts
+++ b/src/create/tests/e2e_utils.ts
@@ -171,6 +171,8 @@ async function patchProjectForLocalAlexi(projectPath: string): Promise<void> {
     "@alexi/storage": `${alexiRoot}src/storage/mod.ts`,
     "@alexi/storage/backends/firebase":
       `${alexiRoot}src/storage/backends/firebase.ts`,
+    "@alexi/storage/backends/filesystem":
+      `${alexiRoot}src/storage/backends/filesystem.ts`,
     "@alexi/storage/backends/memory":
       `${alexiRoot}src/storage/backends/memory.ts`,
     "@alexi/capacitor": `${alexiRoot}src/capacitor/mod.ts`,

--- a/src/create/tests/posts_e2e_test.ts
+++ b/src/create/tests/posts_e2e_test.ts
@@ -255,6 +255,109 @@ Deno.test({
 });
 
 Deno.test({
+  name: "API: POST /api/posts/ creates a post with a cover image (multipart)",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    // Create a minimal 1×1 PNG as a cover image
+    const pngBytes = new Uint8Array([
+      137,
+      80,
+      78,
+      71,
+      13,
+      10,
+      26,
+      10, // PNG signature
+      0,
+      0,
+      0,
+      13,
+      73,
+      72,
+      68,
+      82, // IHDR chunk length + type
+      0,
+      0,
+      0,
+      1,
+      0,
+      0,
+      0,
+      1, // width=1, height=1
+      8,
+      2,
+      0,
+      0,
+      0,
+      144,
+      119,
+      83,
+      222, // bit depth, color type, etc.
+      0,
+      0,
+      0,
+      12,
+      73,
+      68,
+      65,
+      84, // IDAT chunk
+      8,
+      215,
+      99,
+      248,
+      207,
+      192,
+      0,
+      0,
+      0,
+      2,
+      0,
+      1,
+      226,
+      33,
+      188,
+      51, // IDAT data + CRC
+      0,
+      0,
+      0,
+      0,
+      73,
+      69,
+      78,
+      68,
+      174,
+      66,
+      96,
+      130, // IEND chunk
+    ]);
+    const coverFile = new File([pngBytes], "cover.png", { type: "image/png" });
+
+    const formData = new FormData();
+    formData.append("title", "Post with Cover");
+    formData.append("content", "This post has a cover image.");
+    formData.append("published", "false");
+    formData.append("cover", coverFile);
+
+    const response = await fetch(`${apiUrl}/posts/`, {
+      method: "POST",
+      body: formData,
+    });
+
+    assertEquals(response.status, 201);
+    const data = await response.json();
+    assertExists(data.id);
+    assertEquals(data.title, "Post with Cover");
+    assertExists(data.cover, "cover field must be present in response");
+    assertEquals(
+      typeof data.cover === "string" && data.cover.length > 0,
+      true,
+      "cover must be a non-empty string (file path)",
+    );
+  },
+});
+
+Deno.test({
   name: "API: DELETE /api/posts/:id/ deletes a post",
   sanitizeOps: false,
   sanitizeResources: false,

--- a/src/db/mod.ts
+++ b/src/db/mod.ts
@@ -81,7 +81,9 @@ export {
   DateField,
   DateTimeField,
   DecimalField,
+  FileField,
   FloatField,
+  ImageField,
   IntegerField,
   JSONField,
   TextField,
@@ -92,6 +94,7 @@ export type {
   CharFieldOptions,
   DateFieldOptions,
   DecimalFieldOptions,
+  FileFieldOptions,
 } from "./fields/mod.ts";
 
 // Relation fields


### PR DESCRIPTION
## Summary

- Add `ImageField` cover to `PostModel` template with `uploadTo: 'covers/'`
- Include `cover` in `PostSerializer.Meta.fields` and read it from `FormData` in server and worker `PostCreateView`
- Add `enctype="multipart/form-data"` and file input to the post form template
- Add `uploadsView` to serve `/uploads/:path` from the filesystem, wired at `path("uploads/:path", uploadsView)`
- Configure `FileSystemStorage` as `DEFAULT_FILE_STORAGE` in the project settings template
- Add `@alexi/storage` and `@alexi/storage/backends/filesystem` to generated `deno.jsonc` imports map
- Export `FileField`, `ImageField`, and `FileFieldOptions` from `@alexi/db` top-level `mod.ts`
- Add `@alexi/storage/backends/filesystem` to `e2e_utils.ts` `localImports` patch map
- Add e2e test for multipart cover image upload via `POST /api/posts/`

Closes #419