### PR TITLE
docs(storage): document file and image upload features

### DIFF
--- a/docs/db/models.md
+++ b/docs/db/models.md
@@ -130,6 +130,73 @@ birthDate = new DateField();
 dueDate = new DateField({ null: true });
 ```
 
+### FileField
+
+Stores the storage-relative path of an uploaded file. The file itself is
+persisted via the configured `@alexi/storage` backend.
+
+```typescript
+import { FileField } from "@alexi/db";
+import { getStorage } from "@alexi/storage";
+
+export class DocumentModel extends Model {
+  id = new AutoField({ primaryKey: true });
+  name = new CharField({ maxLength: 255 });
+  file = new FileField({ uploadTo: "documents/" });
+
+  static objects = new Manager(DocumentModel);
+  static meta = { dbTable: "documents" };
+}
+
+// Saving an uploaded file
+const storage = getStorage();
+const uploadPath = doc.file.getUploadPath(file.name);
+const savedName = await storage.save(uploadPath, file);
+doc.file.set(savedName);
+await doc.save();
+
+// Retrieving the public URL
+const url = await storage.url(doc.file.get());
+```
+
+Options:
+
+- `uploadTo` — Upload directory or callback: `"documents/"` or
+  `(instance, filename) => \`users/${instance.id}/${filename}\``
+- `maxSize` — Maximum file size in bytes
+- `allowedExtensions` — Allowed file extensions, e.g. `[".pdf", ".docx"]`
+- `allowedMimeTypes` — Allowed MIME types, e.g. `["application/pdf"]`
+
+`FileField` defaults to `blank: true` because the stored value is populated
+after upload.
+
+### ImageField
+
+Extends `FileField` with image-specific extension and MIME type validation
+pre-configured (`jpg`, `jpeg`, `png`, `gif`, `webp`, `svg`).
+
+```typescript
+import { ImageField } from "@alexi/db";
+
+export class PostModel extends Model {
+  id = new AutoField({ primaryKey: true });
+  title = new CharField({ maxLength: 200 });
+  cover = new ImageField({
+    uploadTo: "covers/",
+    maxSize: 5 * 1024 * 1024, // 5 MB
+    null: true,
+    blank: true,
+  });
+
+  static objects = new Manager(PostModel);
+  static meta = { dbTable: "posts" };
+}
+```
+
+Options are the same as `FileField`. The `allowedExtensions` and
+`allowedMimeTypes` default to common image formats; pass your own values to
+override them.
+
 ### ForeignKey
 
 Relationship to another model:

--- a/docs/django-comparison.md
+++ b/docs/django-comparison.md
@@ -165,7 +165,7 @@ differences, and features unique to Alexi.
 | Storage API       | ✅               | ✅           | Django-style interface |
 | FileField         | ✅               | ✅           | File upload field      |
 | ImageField        | ✅               | ✅           | Image-specific field   |
-| FileSystemStorage | ✅               | ❌ (planned) | Local filesystem       |
+| FileSystemStorage | ✅               | ✅           | Local filesystem       |
 | S3Storage         | ✅ (via package) | ❌ (planned) | AWS S3                 |
 | Firebase Storage  | ❌               | ✅           | Firebase Cloud Storage |
 | MemoryStorage     | ❌               | ✅           | In-memory for testing  |

--- a/docs/restframework/serializers.md
+++ b/docs/restframework/serializers.md
@@ -293,6 +293,27 @@ metadata = new JSONField();
 settings = new JSONField({ required: false });
 ```
 
+### FileField / ImageField
+
+Serializes a `FileField` or `ImageField` value as a string (the storage-relative
+file path). When included in `ModelSerializer.Meta.fields`, the field is
+automatically derived from the model.
+
+```typescript
+class PostSerializer extends ModelSerializer {
+  static Meta = {
+    model: PostModel,
+    fields: ["id", "title", "cover"],
+    readOnlyFields: ["id"],
+  };
+}
+// Serialized output: { id: 1, title: "Hello", cover: "covers/photo.png" }
+```
+
+For write operations the serializer accepts the raw string path (already
+uploaded). File upload itself must be handled in the view before calling the
+serializer — see [File Uploads in ViewSets](./viewsets.md#file-uploads).
+
 ### PrimaryKeyRelatedField
 
 Related object by primary key:

--- a/docs/restframework/viewsets.md
+++ b/docs/restframework/viewsets.md
@@ -444,9 +444,117 @@ export const urlpatterns = router.urls;
 // POST   /api/projects/                  # Create a project
 // GET    /api/projects/:id/              # Get a project
 // PUT    /api/projects/:id/              # Update a project
-// PATCH  /api/projects/:id/              # Partial update
+// PATCH  /api/projects/:id/             # Partial update
 // DELETE /api/projects/:id/              # Delete a project
 // POST   /api/projects/:id/archive/      # Archive a project
 // GET    /api/projects/:id/stats/        # Get project stats
 // POST   /api/projects/activate_all/     # Activate all projects
 ```
+
+## File Uploads
+
+ViewSets handle file uploads by reading `multipart/form-data` from the request,
+saving the file via the storage backend, and then passing the stored path to the
+serializer.
+
+### Model with ImageField
+
+```typescript
+// models.ts
+import { AutoField, CharField, ImageField, Manager, Model } from "@alexi/db";
+
+export class PostModel extends Model {
+  id = new AutoField({ primaryKey: true });
+  title = new CharField({ maxLength: 200 });
+  cover = new ImageField({ uploadTo: "covers/", null: true, blank: true });
+
+  static objects = new Manager(PostModel);
+  static meta = { dbTable: "posts" };
+}
+```
+
+### Serializer
+
+Include the file field by name — `ModelSerializer` maps it to a string field
+automatically:
+
+```typescript
+// serializers.ts
+import { ModelSerializer } from "@alexi/restframework";
+import { PostModel } from "./models.ts";
+
+export class PostSerializer extends ModelSerializer {
+  static override Meta = {
+    model: PostModel,
+    fields: ["id", "title", "cover"],
+    readOnlyFields: ["id"],
+  };
+}
+```
+
+### ViewSet with file upload handling
+
+Override `create()` (and optionally `update()`) to extract the file from
+`FormData`, save it, and inject the path into the validated data before calling
+`super.create()`:
+
+```typescript
+// viewsets.ts
+import { getStorage } from "@alexi/storage";
+import { ModelViewSet } from "@alexi/restframework";
+import type { ViewSetContext } from "@alexi/restframework";
+import { PostModel } from "./models.ts";
+import { PostSerializer } from "./serializers.ts";
+
+export class PostViewSet extends ModelViewSet {
+  override model = PostModel;
+  override serializer_class = PostSerializer;
+
+  override async create(context: ViewSetContext): Promise<Response> {
+    const formData = await context.request.formData();
+
+    // Extract scalar fields
+    const data: Record<string, unknown> = {
+      title: formData.get("title"),
+    };
+
+    // Handle file upload
+    const coverFile = formData.get("cover") as File | null;
+    if (coverFile && coverFile.size > 0) {
+      const storage = getStorage();
+      const instance = new PostModel();
+      const uploadPath = instance.cover.getUploadPath(coverFile.name);
+      data.cover = await storage.save(uploadPath, coverFile);
+    }
+
+    const serializer = new PostSerializer({ data });
+    if (!serializer.isValid()) {
+      return Response.json({ errors: serializer.errors }, { status: 400 });
+    }
+
+    const post = await serializer.save();
+    return Response.json(
+      await new PostSerializer({ instance: post }).toRepresentation(post),
+      { status: 201 },
+    );
+  }
+}
+```
+
+### HTML form
+
+Forms that include file inputs must set `enctype="multipart/form-data"`:
+
+```html
+<form method="POST" action="/api/posts/" enctype="multipart/form-data">
+  <input type="text" name="title" required />
+  <input type="file" name="cover" accept="image/*" />
+  <button type="submit">Create Post</button>
+</form>
+```
+
+### Serving uploaded files
+
+Add a route that reads from the storage backend and streams the file back. See
+[File Storage — FileSystemStorage](../storage/storage.md#filesystemstorage) for
+a complete example.

--- a/docs/storage/storage.md
+++ b/docs/storage/storage.md
@@ -1,0 +1,293 @@
+# File Storage
+
+Alexi provides a Django-style file storage abstraction through the
+`@alexi/storage` package. It defines a unified `Storage` API that works across
+different backends — local filesystem, in-memory, Firebase Cloud Storage, and
+more.
+
+## Overview
+
+The storage system has two parts:
+
+1. **`@alexi/storage`** — the `Storage` abstract base class, setup helpers
+   (`setStorage`, `getStorage`), and shared types.
+2. **Backend subpaths** — concrete implementations imported from
+   `@alexi/storage/backends/<name>`.
+
+```typescript
+import { getStorage, setStorage } from "@alexi/storage";
+import { FileSystemStorage } from "@alexi/storage/backends/filesystem";
+
+setStorage(
+  new FileSystemStorage({ location: "./uploads", baseUrl: "/uploads/" }),
+);
+
+const storage = getStorage();
+const file = new File(["Hello"], "hello.txt", { type: "text/plain" });
+const savedName = await storage.save("documents/hello.txt", file);
+const url = await storage.url(savedName);
+// url === "/uploads/documents/hello.txt"
+```
+
+## Configuration
+
+### DEFAULT_FILE_STORAGE setting
+
+Configure the default storage backend in `settings.ts`:
+
+```typescript
+// project/settings.ts
+import { FileSystemStorage } from "@alexi/storage/backends/filesystem";
+
+export const DEFAULT_FILE_STORAGE = new FileSystemStorage({
+  location: "./uploads",
+  baseUrl: "/uploads/",
+});
+```
+
+`@alexi/core` will call `setStorage(DEFAULT_FILE_STORAGE)` automatically during
+application startup.
+
+### Manual setup
+
+Call `setStorage()` directly for custom initialization:
+
+```typescript
+import { setStorage } from "@alexi/storage";
+import { MemoryStorage } from "@alexi/storage/backends/memory";
+
+setStorage(new MemoryStorage());
+```
+
+## Storage API
+
+All backends implement the `Storage` abstract class.
+
+### save()
+
+Save a file to storage. Returns the final storage-relative name (may differ from
+the requested name if a collision is resolved).
+
+```typescript
+const file = new File(["content"], "report.pdf", { type: "application/pdf" });
+const savedName = await storage.save("reports/report.pdf", file);
+```
+
+### open()
+
+Open a file for reading, returning a `ReadableStream`:
+
+```typescript
+const stream = await storage.open("reports/report.pdf");
+const response = new Response(stream, {
+  headers: { "Content-Type": "application/pdf" },
+});
+```
+
+### delete()
+
+Delete a file from storage:
+
+```typescript
+await storage.delete("reports/old-report.pdf");
+```
+
+### exists()
+
+Check if a file exists:
+
+```typescript
+if (await storage.exists("reports/report.pdf")) {
+  // File exists
+}
+```
+
+### url()
+
+Get the public URL for a file:
+
+```typescript
+const url = await storage.url("reports/report.pdf");
+// "/uploads/reports/report.pdf"
+```
+
+### size()
+
+Get the file size in bytes:
+
+```typescript
+const bytes = await storage.size("reports/report.pdf");
+console.log(`${bytes} bytes`);
+```
+
+### listdir()
+
+List directory contents:
+
+```typescript
+const { dirs, files } = await storage.listdir("reports/");
+console.log("Subdirectories:", dirs);
+console.log("Files:", files);
+```
+
+### getMetadata()
+
+Get file metadata (size, content type, timestamps):
+
+```typescript
+const meta = await storage.getMetadata("reports/report.pdf");
+// { name, size, contentType, updatedAt, createdAt? }
+```
+
+### signedUrl()
+
+Generate a temporary signed URL (backends that support it; falls back to the
+regular URL otherwise):
+
+```typescript
+const url = await storage.signedUrl("private/file.pdf", { expiresIn: 3600 });
+```
+
+## Backends
+
+### FileSystemStorage
+
+Local filesystem storage — suitable for development and self-hosted deployments.
+
+```typescript
+import { FileSystemStorage } from "@alexi/storage/backends/filesystem";
+
+const storage = new FileSystemStorage({
+  location: "./uploads", // directory on disk (created automatically)
+  baseUrl: "/uploads/", // URL prefix for generated public URLs
+  allowOverwrite: false, // append unique suffix on collision (default)
+});
+```
+
+| Option           | Type      | Default     | Description                                    |
+| ---------------- | --------- | ----------- | ---------------------------------------------- |
+| `location`       | `string`  | —           | Path to root upload directory (required)       |
+| `baseUrl`        | `string`  | `"/media/"` | URL prefix for `storage.url()`                 |
+| `allowOverwrite` | `boolean` | `false`     | When `true`, overwrite existing files silently |
+
+**Serving uploaded files** — add a route that reads from the upload directory:
+
+```typescript
+// views.ts
+import { getStorage } from "@alexi/storage";
+
+export async function uploadsView(
+  _request: Request,
+  params: Record<string, string>,
+): Promise<Response> {
+  const storage = getStorage();
+  const name = params["path"];
+
+  if (!(await storage.exists(name))) {
+    return new Response("Not Found", { status: 404 });
+  }
+
+  const stream = await storage.open(name);
+  const meta = await storage.getMetadata(name);
+  return new Response(stream, {
+    headers: { "Content-Type": meta.contentType },
+  });
+}
+
+// urls.ts
+import { path } from "@alexi/urls";
+
+export const urlpatterns = [
+  path("uploads/:path", uploadsView),
+];
+```
+
+### MemoryStorage
+
+In-memory storage — intended for testing. Data is lost when the process ends.
+
+```typescript
+import { MemoryStorage } from "@alexi/storage/backends/memory";
+
+const storage = new MemoryStorage();
+```
+
+### FirebaseStorage
+
+Firebase Cloud Storage backend for production browser and server applications.
+
+```typescript
+import { FirebaseStorage } from "@alexi/storage/backends/firebase";
+
+setStorage(
+  new FirebaseStorage({
+    bucket: "my-project.appspot.com",
+    basePath: "uploads/",
+    getAuthToken: async () =>
+      await firebase.auth().currentUser?.getIdToken() ?? "",
+  }),
+);
+```
+
+## File Upload Pattern
+
+A typical server-side file upload handler reads the file from `FormData`, saves
+it via the storage backend, and stores the resulting path on the model:
+
+```typescript
+import { getStorage } from "@alexi/storage";
+import { PostModel } from "./models.ts";
+
+export async function postCreateView(request: Request): Promise<Response> {
+  const formData = await request.formData();
+  const title = formData.get("title") as string;
+  const coverFile = formData.get("cover") as File | null;
+
+  const post = new PostModel();
+  post.title.set(title);
+
+  if (coverFile && coverFile.size > 0) {
+    const storage = getStorage();
+    const uploadPath = post.cover.getUploadPath(coverFile.name);
+    const savedName = await storage.save(uploadPath, coverFile);
+    post.cover.set(savedName);
+  }
+
+  await post.save();
+  return Response.redirect("/posts/");
+}
+```
+
+The HTML form must use `enctype="multipart/form-data"`:
+
+```html
+<form method="POST" enctype="multipart/form-data">
+  <input type="text" name="title" />
+  <input type="file" name="cover" accept="image/*" />
+  <button type="submit">Create</button>
+</form>
+```
+
+## Testing with MemoryStorage
+
+Use `MemoryStorage` in tests to avoid touching the filesystem:
+
+```typescript
+import { resetStorage, setStorage } from "@alexi/storage";
+import { MemoryStorage } from "@alexi/storage/backends/memory";
+
+Deno.test("upload cover image", async () => {
+  setStorage(new MemoryStorage());
+
+  try {
+    const storage = getStorage();
+    const file = new File(["img"], "photo.png", { type: "image/png" });
+    const name = await storage.save("covers/photo.png", file);
+
+    assertEquals(await storage.exists(name), true);
+    assertEquals(await storage.url(name), `/media/${name}`);
+  } finally {
+    resetStorage();
+  }
+});
+```


### PR DESCRIPTION
## Summary

- Add `docs/storage/storage.md` documenting `@alexi/storage`: Storage API, all backends (FileSystemStorage, MemoryStorage, FirebaseStorage), DEFAULT_FILE_STORAGE setting, file upload pattern, and testing with MemoryStorage
- Update `docs/db/models.md` — add FileField and ImageField sections with options and usage examples
- Update `docs/restframework/serializers.md` — add FileField/ImageField serialization note
- Update `docs/restframework/viewsets.md` — add "File Uploads" section with model, serializer, ViewSet, and HTML form examples
- Update `docs/django-comparison.md` — mark FileSystemStorage as ✅ (was ❌ planned)

Closes #420