### PR TITLE
fix(auth): add REQUIRED_FIELDS support to createsuperuser

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -831,6 +831,44 @@ const hash = await UserModel.hashPassword("secret");
 const valid = await user.verifyPassword("secret"); // true | false
 ```
 
+#### REQUIRED_FIELDS
+
+Declare extra fields that `createsuperuser` must collect. Values are read from
+CLI args (`--<field>`), env vars (`ALEXI_SUPERUSER_<FIELD>`), or an interactive
+prompt — matching Django's behaviour.
+
+```typescript
+export class UserModel extends AbstractUser {
+  status = new CharField({ maxLength: 20, default: "active" });
+  department = new CharField({ maxLength: 100 });
+
+  // Tell createsuperuser to prompt for these fields
+  static override REQUIRED_FIELDS = ["status", "department"];
+
+  static objects = new Manager(UserModel);
+  static meta = { dbTable: "users" };
+}
+```
+
+```bash
+# Interactive
+deno run -A --unstable-kv manage.ts createsuperuser --settings ./project/settings.ts
+
+# Non-interactive via CLI args
+deno run -A --unstable-kv manage.ts createsuperuser \
+  --email admin@example.com --password secret \
+  --status active --department engineering \
+  --no-input --settings ./project/settings.ts
+
+# Non-interactive via environment variables
+ALEXI_SUPERUSER_EMAIL=admin@example.com \
+ALEXI_SUPERUSER_PASSWORD=secret \
+ALEXI_SUPERUSER_STATUS=active \
+ALEXI_SUPERUSER_DEPARTMENT=engineering \
+deno run -A --unstable-kv manage.ts createsuperuser --no-input \
+  --settings ./project/settings.ts
+```
+
 ### View Decorators
 
 ```typescript

--- a/src/auth/commands/createsuperuser.ts
+++ b/src/auth/commands/createsuperuser.ts
@@ -43,6 +43,11 @@ interface UserModelInterface {
   };
   /** Available when AUTH_USER_MODEL is an AbstractUser subclass. */
   hashPassword?: (password: string) => Promise<string>;
+  /**
+   * Extra fields the command must prompt for / accept as CLI arguments.
+   * Mirrors Django's `AbstractBaseUser.REQUIRED_FIELDS`.
+   */
+  REQUIRED_FIELDS?: string[];
 }
 
 /**
@@ -112,6 +117,21 @@ type HashPasswordFn = (password: string) => Promise<string>;
  *   --password secretpassword \
  *   --first-name Admin \
  *   --last-name User
+ * ```
+ *
+ * @example With extra REQUIRED_FIELDS
+ * ```bash
+ * # UserModel has REQUIRED_FIELDS = ["status"]
+ * # Interactive — prompts for "status":
+ * deno run -A --unstable-kv manage.ts createsuperuser --settings web
+ *
+ * # Non-interactive — supply via CLI or environment variable:
+ * deno run -A --unstable-kv manage.ts createsuperuser --settings web \
+ *   --no-input \
+ *   --email admin@example.com \
+ *   --password secret \
+ *   --status active
+ * # OR via env: ALEXI_SUPERUSER_STATUS=active
  * ```
  */
 export class CreateSuperuserCommand extends BaseCommand {
@@ -237,7 +257,7 @@ export class CreateSuperuserCommand extends BaseCommand {
       );
       return failure("DATABASES not configured");
     }
-    await setup({ DATABASES: databases });
+    await this.runSetup({ DATABASES: databases });
 
     try {
       // Get user details
@@ -291,7 +311,47 @@ export class CreateSuperuserCommand extends BaseCommand {
         isActive: true,
       };
 
-      // Add extra fields from settings if defined
+      // Collect values for REQUIRED_FIELDS defined on the model (Django parity).
+      // Each field is read from:
+      //   1. --<field-name> CLI argument, or
+      //   2. ALEXI_SUPERUSER_<FIELD_NAME> environment variable, or
+      //   3. interactive prompt (when not --no-input).
+      const requiredFields: string[] =
+        (UserModel as unknown as { REQUIRED_FIELDS?: string[] })
+          .REQUIRED_FIELDS ?? [];
+
+      for (const fieldName of requiredFields) {
+        const cliKey = fieldName.replace(
+          /([A-Z])/g,
+          (m) => `-${m.toLowerCase()}`,
+        );
+        const envKey = `ALEXI_SUPERUSER_${fieldName.toUpperCase()}`;
+
+        let value: string | undefined =
+          (options.args[cliKey] as string | undefined) ??
+            (options.args[fieldName] as string | undefined) ??
+            Deno.env.get(envKey);
+
+        if (!value) {
+          if (noInput) {
+            this.error(
+              `--${cliKey} is required when using --no-input (or set ${envKey}).`,
+            );
+            return failure(`Missing required field: ${fieldName}`);
+          }
+          const prompted = prompt(`${fieldName}:`);
+          if (!prompted || prompted.trim() === "") {
+            this.error(`${fieldName} is required.`);
+            return failure(`Missing required field: ${fieldName}`);
+          }
+          value = prompted.trim();
+        }
+
+        userData[fieldName] = value;
+      }
+
+      // Legacy escape hatch — still supported for backwards compatibility.
+      // Prefer REQUIRED_FIELDS on the model instead.
       const extraFields = settings.AUTH_USER_EXTRA_FIELDS as
         | Record<string, unknown>
         | undefined;
@@ -332,6 +392,20 @@ export class CreateSuperuserCommand extends BaseCommand {
   // ===========================================================================
   // Settings and Model Loading
   // ===========================================================================
+
+  /**
+   * Initialize the database backends from settings.
+   *
+   * Extracted as a protected method so tests can override it without a real
+   * database connection.
+   *
+   * @param config - The databases configuration to pass to `setup()`.
+   */
+  protected async runSetup(
+    config: { DATABASES: DatabasesConfig },
+  ): Promise<void> {
+    await setup(config);
+  }
 
   /**
    * Load project settings.

--- a/src/auth/commands/createsuperuser_test.ts
+++ b/src/auth/commands/createsuperuser_test.ts
@@ -1,0 +1,277 @@
+/**
+ * Tests for the createsuperuser management command — specifically the
+ * REQUIRED_FIELDS handling added to fix issue #431.
+ *
+ * @module
+ */
+
+import { assertEquals, assertStringIncludes } from "jsr:@std/assert@1";
+import { CreateSuperuserCommand } from "./createsuperuser.ts";
+import type { CommandOptions, IConsole } from "@alexi/core/management";
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+class MockConsole implements IConsole {
+  logs: string[] = [];
+  errors: string[] = [];
+  infos: string[] = [];
+  warns: string[] = [];
+
+  log(...args: unknown[]): void {
+    this.logs.push(args.map(String).join(" "));
+  }
+  error(...args: unknown[]): void {
+    this.errors.push(args.map(String).join(" "));
+  }
+  info(...args: unknown[]): void {
+    this.infos.push(args.map(String).join(" "));
+  }
+  warn(...args: unknown[]): void {
+    this.warns.push(args.map(String).join(" "));
+  }
+}
+
+// Helper: build a CommandOptions from a partial args map.
+function makeOptions(args: Record<string, unknown>): CommandOptions {
+  return {
+    args: { _: [], ...args },
+    rawArgs: [],
+    debug: false,
+  };
+}
+
+Deno.test(
+  "createsuperuser: REQUIRED_FIELDS values collected from CLI args",
+  async () => {
+    // Track what objects.create() is called with.
+    const calls: Record<string, unknown>[] = [];
+
+    const fakeModel = {
+      REQUIRED_FIELDS: ["status", "phone"],
+      hashPassword: async (p: string) => `hashed:${p}`,
+      objects: {
+        filter: (_: unknown) => ({ first: async () => null }),
+        create: async (data: Record<string, unknown>) => {
+          calls.push(data);
+          return { id: { get: () => 1 } };
+        },
+      },
+    };
+
+    const fakeSettings = {
+      AUTH_USER_MODEL: fakeModel,
+      DATABASES: {},
+    };
+
+    const cmd = new CreateSuperuserCommand();
+    const out = new MockConsole();
+    cmd.setConsole(out);
+
+    // Patch private loadSettings and setup so we don't need real files/DB.
+    // deno-lint-ignore no-explicit-any
+    (cmd as any).loadSettings = async () => fakeSettings;
+    // deno-lint-ignore no-explicit-any
+    (cmd as any).loadUserModel = async () => ({
+      UserModel: fakeModel,
+      hashPassword: fakeModel.hashPassword,
+    });
+    // deno-lint-ignore no-explicit-any
+    (cmd as any).runSetup = async () => {};
+
+    // Mock DB setup — no-op.
+    const originalSetup = (await import("@alexi/core")).setup;
+    void originalSetup;
+
+    const result = await cmd.handle(makeOptions({
+      settings: "test",
+      email: "admin@example.com",
+      password: "password123",
+      "first-name": "Admin",
+      "last-name": "User",
+      "no-input": true,
+      status: "active", // REQUIRED_FIELDS[0]
+      phone: "+358501234567", // REQUIRED_FIELDS[1]
+    }));
+
+    // Restore (not strictly needed for isolated test, but good practice)
+    void originalSetup;
+
+    assertEquals(result.exitCode, 0, "command should succeed");
+    assertEquals(calls.length, 1, "objects.create should be called once");
+
+    const created = calls[0];
+    assertEquals(created["email"], "admin@example.com");
+    assertEquals(created["isAdmin"], true);
+    assertEquals(created["status"], "active");
+    assertEquals(created["phone"], "+358501234567");
+  },
+);
+
+// =============================================================================
+// REQUIRED_FIELDS — environment variable path
+// =============================================================================
+
+Deno.test(
+  "createsuperuser: REQUIRED_FIELDS values collected from env vars",
+  async () => {
+    const calls: Record<string, unknown>[] = [];
+
+    const fakeModel = {
+      REQUIRED_FIELDS: ["status"],
+      hashPassword: async (p: string) => `hashed:${p}`,
+      objects: {
+        filter: (_: unknown) => ({ first: async () => null }),
+        create: async (data: Record<string, unknown>) => {
+          calls.push(data);
+          return { id: { get: () => 2 } };
+        },
+      },
+    };
+
+    const fakeSettings = {
+      AUTH_USER_MODEL: fakeModel,
+      DATABASES: {},
+    };
+
+    const cmd = new CreateSuperuserCommand();
+    const out = new MockConsole();
+    cmd.setConsole(out);
+
+    // deno-lint-ignore no-explicit-any
+    (cmd as any).loadSettings = async () => fakeSettings;
+    // deno-lint-ignore no-explicit-any
+    (cmd as any).loadUserModel = async () => ({
+      UserModel: fakeModel,
+      hashPassword: fakeModel.hashPassword,
+    });
+    // deno-lint-ignore no-explicit-any
+    (cmd as any).runSetup = async () => {};
+
+    // Inject env variable
+    Deno.env.set("ALEXI_SUPERUSER_STATUS", "pending");
+
+    try {
+      const result = await cmd.handle(makeOptions({
+        settings: "test",
+        email: "user@example.com",
+        password: "password123",
+        "no-input": true,
+        // status NOT provided via CLI — should be picked up from env
+      }));
+
+      assertEquals(result.exitCode, 0);
+      assertEquals(calls[0]["status"], "pending");
+    } finally {
+      Deno.env.delete("ALEXI_SUPERUSER_STATUS");
+    }
+  },
+);
+
+// =============================================================================
+// REQUIRED_FIELDS — missing in --no-input mode → failure
+// =============================================================================
+
+Deno.test(
+  "createsuperuser: missing REQUIRED_FIELDS in --no-input mode returns failure",
+  async () => {
+    const fakeModel = {
+      REQUIRED_FIELDS: ["status"],
+      hashPassword: async (p: string) => `hashed:${p}`,
+      objects: {
+        filter: (_: unknown) => ({ first: async () => null }),
+        create: async () => ({ id: { get: () => 3 } }),
+      },
+    };
+
+    const fakeSettings = {
+      AUTH_USER_MODEL: fakeModel,
+      DATABASES: {},
+    };
+
+    const cmd = new CreateSuperuserCommand();
+    const out = new MockConsole();
+    cmd.setConsole(out);
+
+    // deno-lint-ignore no-explicit-any
+    (cmd as any).loadSettings = async () => fakeSettings;
+    // deno-lint-ignore no-explicit-any
+    (cmd as any).loadUserModel = async () => ({
+      UserModel: fakeModel,
+      hashPassword: fakeModel.hashPassword,
+    });
+    // deno-lint-ignore no-explicit-any
+    (cmd as any).runSetup = async () => {};
+
+    const result = await cmd.handle(makeOptions({
+      settings: "test",
+      email: "user@example.com",
+      password: "password123",
+      "no-input": true,
+      // status intentionally omitted
+    }));
+
+    assertEquals(
+      result.exitCode,
+      1,
+      "should fail when required field is missing",
+    );
+    const errorText = out.errors.join(" ");
+    assertStringIncludes(errorText, "status");
+  },
+);
+
+// =============================================================================
+// REQUIRED_FIELDS — empty list (plain AbstractUser subclass)
+// =============================================================================
+
+Deno.test(
+  "createsuperuser: empty REQUIRED_FIELDS works as before",
+  async () => {
+    const calls: Record<string, unknown>[] = [];
+
+    const fakeModel = {
+      REQUIRED_FIELDS: [],
+      hashPassword: async (p: string) => `hashed:${p}`,
+      objects: {
+        filter: (_: unknown) => ({ first: async () => null }),
+        create: async (data: Record<string, unknown>) => {
+          calls.push(data);
+          return { id: { get: () => 4 } };
+        },
+      },
+    };
+
+    const fakeSettings = {
+      AUTH_USER_MODEL: fakeModel,
+      DATABASES: {},
+    };
+
+    const cmd = new CreateSuperuserCommand();
+    const out = new MockConsole();
+    cmd.setConsole(out);
+
+    // deno-lint-ignore no-explicit-any
+    (cmd as any).loadSettings = async () => fakeSettings;
+    // deno-lint-ignore no-explicit-any
+    (cmd as any).loadUserModel = async () => ({
+      UserModel: fakeModel,
+      hashPassword: fakeModel.hashPassword,
+    });
+    // deno-lint-ignore no-explicit-any
+    (cmd as any).runSetup = async () => {};
+
+    const result = await cmd.handle(makeOptions({
+      settings: "test",
+      email: "simple@example.com",
+      password: "password123",
+      "no-input": true,
+    }));
+
+    assertEquals(result.exitCode, 0);
+    assertEquals(calls.length, 1);
+    assertEquals(calls[0]["email"], "simple@example.com");
+    assertEquals(calls[0]["isAdmin"], true);
+  },
+);

--- a/src/auth/models/abstract_user.ts
+++ b/src/auth/models/abstract_user.ts
@@ -144,8 +144,59 @@ async function pbkdf2Verify(plain: string, stored: string): Promise<boolean> {
  * Mirrors Django's `AbstractUser` — subclass it and add a concrete `Manager`
  * and `meta.dbTable` to get a fully functional user model with built-in
  * password hashing.
+ *
+ * ### Extra fields and `createsuperuser`
+ *
+ * If your concrete user model adds fields that are required at creation time
+ * (especially `NOT NULL` fields without a database default), list them in
+ * `REQUIRED_FIELDS`.  The `createsuperuser` management command will then
+ * prompt for — or accept via `--<field-name>` CLI argument — each of those
+ * fields before calling `objects.create()`.
+ *
+ * ```typescript
+ * export class UserModel extends AbstractUser {
+ *   phone  = new CharField({ maxLength: 32, blank: true, default: "" });
+ *   status = new CharField({ maxLength: 20 });   // NOT NULL
+ *
+ *   // createsuperuser will prompt for "status"
+ *   static override REQUIRED_FIELDS = ["status"];
+ *
+ *   static objects = new Manager(UserModel);
+ *   static override meta = { dbTable: "users" };
+ * }
+ * ```
+ *
+ * Fields that already have a `default` value (or `blank: true`) do **not**
+ * need to appear in `REQUIRED_FIELDS` — the ORM / database will supply the
+ * default automatically.
  */
 export abstract class AbstractUser extends Model {
+  /**
+   * Extra fields that the `createsuperuser` management command must prompt
+   * for (or accept as `--<field-name>` CLI arguments) in addition to the
+   * built-in `email` / `password` / `firstName` / `lastName` fields.
+   *
+   * Mirrors Django's `AbstractBaseUser.REQUIRED_FIELDS`.  Subclasses should
+   * override this with the names of any `NOT NULL` fields (or other fields
+   * that must be supplied at account-creation time) that are not already
+   * handled by the base command.
+   *
+   * @default []
+   *
+   * @example
+   * ```typescript
+   * export class UserModel extends AbstractUser {
+   *   status = new CharField({ maxLength: 20 });
+   *
+   *   static override REQUIRED_FIELDS = ["status"];
+   *   static objects = new Manager(UserModel);
+   *   static override meta = { dbTable: "users" };
+   * }
+   * ```
+   */
+  static REQUIRED_FIELDS: string[] = [];
+
+  /** Auto-incrementing primary key. */
   id = new AutoField({ primaryKey: true });
 
   /** Login identifier — used as the username equivalent. */
@@ -157,7 +208,10 @@ export abstract class AbstractUser extends Model {
    */
   password = new CharField({ maxLength: 256, blank: true });
 
+  /** The user's first (given) name. */
   firstName = new CharField({ maxLength: 150, blank: true });
+
+  /** The user's last (family) name. */
   lastName = new CharField({ maxLength: 150, blank: true });
 
   /** Grants access to the admin panel when `true`. */
@@ -166,7 +220,10 @@ export abstract class AbstractUser extends Model {
   /** Inactive users cannot log in. */
   isActive = new BooleanField({ default: true });
 
+  /** Timestamp of when the account was created. Set automatically on insert. */
   dateJoined = new DateTimeField({ autoNowAdd: true });
+
+  /** Timestamp of the user's most recent login. `null` if never logged in. */
   lastLogin = new DateTimeField({ null: true, blank: true });
 
   // ---------------------------------------------------------------------------

--- a/src/auth/models/abstract_user_test.ts
+++ b/src/auth/models/abstract_user_test.ts
@@ -99,6 +99,30 @@ Deno.test("AbstractUser.verifyPassword: hash from different password returns fal
 // Round-trip via ORM (hashPassword → create → fetch → verifyPassword)
 // =============================================================================
 
+// =============================================================================
+// REQUIRED_FIELDS
+// =============================================================================
+
+Deno.test("AbstractUser.REQUIRED_FIELDS: defaults to empty array", () => {
+  assertEquals(TestUser.REQUIRED_FIELDS, []);
+});
+
+Deno.test("AbstractUser.REQUIRED_FIELDS: subclass can override", () => {
+  class ExtendedUser extends AbstractUser {
+    static objects = new Manager(ExtendedUser);
+    static override meta = { dbTable: "extended_users" };
+    static override REQUIRED_FIELDS = ["status", "phone"];
+  }
+
+  assertEquals(ExtendedUser.REQUIRED_FIELDS, ["status", "phone"]);
+  // Base class unchanged
+  assertEquals(TestUser.REQUIRED_FIELDS, []);
+});
+
+// =============================================================================
+// Round-trip via ORM (hashPassword → create → fetch → verifyPassword)
+// =============================================================================
+
 Deno.test({
   name: "AbstractUser: round-trip create/fetch/verify via ORM",
   async fn() {


### PR DESCRIPTION
## Summary

- Adds `static REQUIRED_FIELDS: string[] = []` to `AbstractUser` — subclasses declare extra fields the `createsuperuser` command must collect (mirrors Django's `AbstractBaseUser.REQUIRED_FIELDS`)
- Updates `createsuperuser` to collect extra field values from CLI args (`--<field>`), env vars (`ALEXI_SUPERUSER_<FIELD>`), or interactive prompt; fails with a clear error in `--no-input` mode if a required field is missing
- Adds JSDoc for `AbstractUser` fields (`id`, `firstName`, `lastName`, `dateJoined`, `lastLogin`) that were previously undocumented
- Updates `AGENTS.md` with usage examples for `REQUIRED_FIELDS`
- Adds 6 new tests (2 in `abstract_user_test.ts`, 4 in new `createsuperuser_test.ts`)

Closes #431