### PR TITLE
fix(db): add SQLiteMigrationRecorder and SQLiteDeprecationRecorder

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,13 +1,20 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@db/sqlite@0.12": "0.12.0",
+    "jsr:@denosaurs/plug@1": "1.1.0",
     "jsr:@luca/esbuild-deno-loader@~0.11.1": "0.11.1",
     "jsr:@std/assert@*": "1.0.19",
+    "jsr:@std/assert@0.217": "0.217.0",
     "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/bytes@^1.0.2": "1.0.6",
+    "jsr:@std/encoding@1": "1.0.10",
     "jsr:@std/encoding@^1.0.5": "1.0.10",
+    "jsr:@std/fmt@1": "1.0.9",
+    "jsr:@std/fs@1": "1.0.23",
     "jsr:@std/fs@^1.0.19": "1.0.23",
     "jsr:@std/internal@^1.0.12": "1.0.12",
+    "jsr:@std/path@0.217": "0.217.0",
     "jsr:@std/path@1": "1.1.4",
     "jsr:@std/path@^1.0.6": "1.1.4",
     "jsr:@std/path@^1.1.2": "1.1.4",
@@ -20,13 +27,32 @@
     "npm:playwright@^1.48.0": "1.58.2"
   },
   "jsr": {
+    "@db/sqlite@0.12.0": {
+      "integrity": "dd1ef7f621ad50fc1e073a1c3609c4470bd51edc0994139c5bf9851de7a6d85f",
+      "dependencies": [
+        "jsr:@denosaurs/plug",
+        "jsr:@std/path@0.217"
+      ]
+    },
+    "@denosaurs/plug@1.1.0": {
+      "integrity": "eb2f0b7546c7bca2000d8b0282c54d50d91cf6d75cb26a80df25a6de8c4bc044",
+      "dependencies": [
+        "jsr:@std/encoding@1",
+        "jsr:@std/fmt",
+        "jsr:@std/fs@1",
+        "jsr:@std/path@1"
+      ]
+    },
     "@luca/esbuild-deno-loader@0.11.1": {
       "integrity": "dc020d16d75b591f679f6b9288b10f38bdb4f24345edb2f5732affa1d9885267",
       "dependencies": [
         "jsr:@std/bytes",
-        "jsr:@std/encoding",
+        "jsr:@std/encoding@^1.0.5",
         "jsr:@std/path@^1.0.6"
       ]
+    },
+    "@std/assert@0.217.0": {
+      "integrity": "c98e279362ca6982d5285c3b89517b757c1e3477ee9f14eb2fdf80a45aaa9642"
     },
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
@@ -40,6 +66,9 @@
     "@std/encoding@1.0.10": {
       "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
     },
+    "@std/fmt@1.0.9": {
+      "integrity": "2487343e8899fb2be5d0e3d35013e54477ada198854e52dd05ed0422eddcabe0"
+    },
     "@std/fs@1.0.23": {
       "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
       "dependencies": [
@@ -50,6 +79,12 @@
     "@std/internal@1.0.12": {
       "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
     },
+    "@std/path@0.217.0": {
+      "integrity": "1217cc25534bca9a2f672d7fe7c6f356e4027df400c0e85c0ef3e4343bc67d11",
+      "dependencies": [
+        "jsr:@std/assert@0.217"
+      ]
+    },
     "@std/path@1.1.4": {
       "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
       "dependencies": [
@@ -59,7 +94,7 @@
     "@webui/deno-webui@2.5.13": {
       "integrity": "6f03345e19b943177766a30ed728a0e16c228757b5469bceee6092a7e18a25f9",
       "dependencies": [
-        "jsr:@std/fs",
+        "jsr:@std/fs@^1.0.19",
         "jsr:@std/path@^1.1.2",
         "jsr:@zip-js/zip-js"
       ]
@@ -318,8 +353,73 @@
     }
   },
   "remote": {
+    "https://deno.land/std@0.208.0/assert/_constants.ts": "8a9da298c26750b28b326b297316cdde860bc237533b07e1337c021379e6b2a9",
+    "https://deno.land/std@0.208.0/assert/_diff.ts": "58e1461cc61d8eb1eacbf2a010932bf6a05b79344b02ca38095f9b805795dc48",
+    "https://deno.land/std@0.208.0/assert/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
+    "https://deno.land/std@0.208.0/assert/assert.ts": "9a97dad6d98c238938e7540736b826440ad8c1c1e54430ca4c4e623e585607ee",
+    "https://deno.land/std@0.208.0/assert/assert_almost_equals.ts": "e15ca1f34d0d5e0afae63b3f5d975cbd18335a132e42b0c747d282f62ad2cd6c",
+    "https://deno.land/std@0.208.0/assert/assert_array_includes.ts": "6856d7f2c3544bc6e62fb4646dfefa3d1df5ff14744d1bca19f0cbaf3b0d66c9",
+    "https://deno.land/std@0.208.0/assert/assert_equals.ts": "d8ec8a22447fbaf2fc9d7c3ed2e66790fdb74beae3e482855d75782218d68227",
+    "https://deno.land/std@0.208.0/assert/assert_exists.ts": "407cb6b9fb23a835cd8d5ad804e2e2edbbbf3870e322d53f79e1c7a512e2efd7",
+    "https://deno.land/std@0.208.0/assert/assert_false.ts": "0ccbcaae910f52c857192ff16ea08bda40fdc79de80846c206bfc061e8c851c6",
+    "https://deno.land/std@0.208.0/assert/assert_greater.ts": "ae2158a2d19313bf675bf7251d31c6dc52973edb12ac64ac8fc7064152af3e63",
+    "https://deno.land/std@0.208.0/assert/assert_greater_or_equal.ts": "1439da5ebbe20855446cac50097ac78b9742abe8e9a43e7de1ce1426d556e89c",
+    "https://deno.land/std@0.208.0/assert/assert_instance_of.ts": "3aedb3d8186e120812d2b3a5dea66a6e42bf8c57a8bd927645770bd21eea554c",
+    "https://deno.land/std@0.208.0/assert/assert_is_error.ts": "c21113094a51a296ffaf036767d616a78a2ae5f9f7bbd464cd0197476498b94b",
+    "https://deno.land/std@0.208.0/assert/assert_less.ts": "aec695db57db42ec3e2b62e97e1e93db0063f5a6ec133326cc290ff4b71b47e4",
+    "https://deno.land/std@0.208.0/assert/assert_less_or_equal.ts": "5fa8b6a3ffa20fd0a05032fe7257bf985d207b85685fdbcd23651b70f928c848",
+    "https://deno.land/std@0.208.0/assert/assert_match.ts": "c4083f80600bc190309903c95e397a7c9257ff8b5ae5c7ef91e834704e672e9b",
+    "https://deno.land/std@0.208.0/assert/assert_not_equals.ts": "9f1acab95bd1f5fc9a1b17b8027d894509a745d91bac1718fdab51dc76831754",
+    "https://deno.land/std@0.208.0/assert/assert_not_instance_of.ts": "0c14d3dfd9ab7a5276ed8ed0b18c703d79a3d106102077ec437bfe7ed912bd22",
+    "https://deno.land/std@0.208.0/assert/assert_not_match.ts": "3796a5b0c57a1ce6c1c57883dd4286be13a26f715ea662318ab43a8491a13ab0",
+    "https://deno.land/std@0.208.0/assert/assert_not_strict_equals.ts": "4cdef83df17488df555c8aac1f7f5ec2b84ad161b6d0645ccdbcc17654e80c99",
+    "https://deno.land/std@0.208.0/assert/assert_object_match.ts": "d8fc2867cfd92eeacf9cea621e10336b666de1874a6767b5ec48988838370b54",
+    "https://deno.land/std@0.208.0/assert/assert_rejects.ts": "45c59724de2701e3b1f67c391d6c71c392363635aad3f68a1b3408f9efca0057",
+    "https://deno.land/std@0.208.0/assert/assert_strict_equals.ts": "b1f538a7ea5f8348aeca261d4f9ca603127c665e0f2bbfeb91fa272787c87265",
+    "https://deno.land/std@0.208.0/assert/assert_string_includes.ts": "b821d39ebf5cb0200a348863c86d8c4c4b398e02012ce74ad15666fc4b631b0c",
+    "https://deno.land/std@0.208.0/assert/assert_throws.ts": "63784e951475cb7bdfd59878cd25a0931e18f6dc32a6077c454b2cd94f4f4bcd",
+    "https://deno.land/std@0.208.0/assert/assertion_error.ts": "4d0bde9b374dfbcbe8ac23f54f567b77024fb67dbb1906a852d67fe050d42f56",
+    "https://deno.land/std@0.208.0/assert/equal.ts": "9f1a46d5993966d2596c44e5858eec821859b45f783a5ee2f7a695dfc12d8ece",
+    "https://deno.land/std@0.208.0/assert/fail.ts": "c36353d7ae6e1f7933d45f8ea51e358c8c4b67d7e7502028598fe1fea062e278",
+    "https://deno.land/std@0.208.0/assert/mod.ts": "37c49a26aae2b254bbe25723434dc28cd7532e444cf0b481a97c045d110ec085",
+    "https://deno.land/std@0.208.0/assert/unimplemented.ts": "d56fbeecb1f108331a380f72e3e010a1f161baa6956fd0f7cf3e095ae1a4c75a",
+    "https://deno.land/std@0.208.0/assert/unreachable.ts": "4600dc0baf7d9c15a7f7d234f00c23bca8f3eba8b140286aaca7aa998cf9a536",
+    "https://deno.land/std@0.208.0/fmt/colors.ts": "34b3f77432925eb72cf0bfb351616949746768620b8e5ead66da532f93d10ba2",
     "https://deno.land/std@0.208.0/testing/_test_suite.ts": "30f018feeb3835f12ab198d8a518f9089b1bcb2e8c838a8b615ab10d5005465c",
-    "https://deno.land/std@0.208.0/testing/bdd.ts": "c41f019786c4a9112aadb7e5a7bbcc711f58429ac5904b3855fa248ba5fa0ba6"
+    "https://deno.land/std@0.208.0/testing/bdd.ts": "c41f019786c4a9112aadb7e5a7bbcc711f58429ac5904b3855fa248ba5fa0ba6",
+    "https://deno.land/std@0.224.0/assert/_constants.ts": "a271e8ef5a573f1df8e822a6eb9d09df064ad66a4390f21b3e31f820a38e0975",
+    "https://deno.land/std@0.224.0/assert/assert.ts": "09d30564c09de846855b7b071e62b5974b001bb72a4b797958fe0660e7849834",
+    "https://deno.land/std@0.224.0/assert/assert_almost_equals.ts": "9e416114322012c9a21fa68e187637ce2d7df25bcbdbfd957cd639e65d3cf293",
+    "https://deno.land/std@0.224.0/assert/assert_array_includes.ts": "14c5094471bc8e4a7895fc6aa5a184300d8a1879606574cb1cd715ef36a4a3c7",
+    "https://deno.land/std@0.224.0/assert/assert_equals.ts": "3bbca947d85b9d374a108687b1a8ba3785a7850436b5a8930d81f34a32cb8c74",
+    "https://deno.land/std@0.224.0/assert/assert_exists.ts": "43420cf7f956748ae6ed1230646567b3593cb7a36c5a5327269279c870c5ddfd",
+    "https://deno.land/std@0.224.0/assert/assert_false.ts": "3e9be8e33275db00d952e9acb0cd29481a44fa0a4af6d37239ff58d79e8edeff",
+    "https://deno.land/std@0.224.0/assert/assert_greater.ts": "5e57b201fd51b64ced36c828e3dfd773412c1a6120c1a5a99066c9b261974e46",
+    "https://deno.land/std@0.224.0/assert/assert_greater_or_equal.ts": "9870030f997a08361b6f63400273c2fb1856f5db86c0c3852aab2a002e425c5b",
+    "https://deno.land/std@0.224.0/assert/assert_instance_of.ts": "e22343c1fdcacfaea8f37784ad782683ec1cf599ae9b1b618954e9c22f376f2c",
+    "https://deno.land/std@0.224.0/assert/assert_is_error.ts": "f856b3bc978a7aa6a601f3fec6603491ab6255118afa6baa84b04426dd3cc491",
+    "https://deno.land/std@0.224.0/assert/assert_less.ts": "60b61e13a1982865a72726a5fa86c24fad7eb27c3c08b13883fb68882b307f68",
+    "https://deno.land/std@0.224.0/assert/assert_less_or_equal.ts": "d2c84e17faba4afe085e6c9123a63395accf4f9e00150db899c46e67420e0ec3",
+    "https://deno.land/std@0.224.0/assert/assert_match.ts": "ace1710dd3b2811c391946954234b5da910c5665aed817943d086d4d4871a8b7",
+    "https://deno.land/std@0.224.0/assert/assert_not_equals.ts": "78d45dd46133d76ce624b2c6c09392f6110f0df9b73f911d20208a68dee2ef29",
+    "https://deno.land/std@0.224.0/assert/assert_not_instance_of.ts": "3434a669b4d20cdcc5359779301a0588f941ffdc2ad68803c31eabdb4890cf7a",
+    "https://deno.land/std@0.224.0/assert/assert_not_match.ts": "df30417240aa2d35b1ea44df7e541991348a063d9ee823430e0b58079a72242a",
+    "https://deno.land/std@0.224.0/assert/assert_not_strict_equals.ts": "37f73880bd672709373d6dc2c5f148691119bed161f3020fff3548a0496f71b8",
+    "https://deno.land/std@0.224.0/assert/assert_object_match.ts": "411450fd194fdaabc0089ae68f916b545a49d7b7e6d0026e84a54c9e7eed2693",
+    "https://deno.land/std@0.224.0/assert/assert_rejects.ts": "4bee1d6d565a5b623146a14668da8f9eb1f026a4f338bbf92b37e43e0aa53c31",
+    "https://deno.land/std@0.224.0/assert/assert_strict_equals.ts": "b4f45f0fd2e54d9029171876bd0b42dd9ed0efd8f853ab92a3f50127acfa54f5",
+    "https://deno.land/std@0.224.0/assert/assert_string_includes.ts": "496b9ecad84deab72c8718735373feb6cdaa071eb91a98206f6f3cb4285e71b8",
+    "https://deno.land/std@0.224.0/assert/assert_throws.ts": "c6508b2879d465898dab2798009299867e67c570d7d34c90a2d235e4553906eb",
+    "https://deno.land/std@0.224.0/assert/assertion_error.ts": "ba8752bd27ebc51f723702fac2f54d3e94447598f54264a6653d6413738a8917",
+    "https://deno.land/std@0.224.0/assert/equal.ts": "bddf07bb5fc718e10bb72d5dc2c36c1ce5a8bdd3b647069b6319e07af181ac47",
+    "https://deno.land/std@0.224.0/assert/fail.ts": "0eba674ffb47dff083f02ced76d5130460bff1a9a68c6514ebe0cdea4abadb68",
+    "https://deno.land/std@0.224.0/assert/mod.ts": "48b8cb8a619ea0b7958ad7ee9376500fe902284bb36f0e32c598c3dc34cbd6f3",
+    "https://deno.land/std@0.224.0/assert/unimplemented.ts": "8c55a5793e9147b4f1ef68cd66496b7d5ba7a9e7ca30c6da070c1a58da723d73",
+    "https://deno.land/std@0.224.0/assert/unreachable.ts": "5ae3dbf63ef988615b93eb08d395dda771c96546565f9e521ed86f6510c29e19",
+    "https://deno.land/std@0.224.0/fmt/colors.ts": "508563c0659dd7198ba4bbf87e97f654af3c34eb56ba790260f252ad8012e1c5",
+    "https://deno.land/std@0.224.0/internal/diff.ts": "6234a4b493ebe65dc67a18a0eb97ef683626a1166a1906232ce186ae9f65f4e6",
+    "https://deno.land/std@0.224.0/internal/format.ts": "0a98ee226fd3d43450245b1844b47003419d34d210fa989900861c79820d21c2",
+    "https://deno.land/std@0.224.0/internal/mod.ts": "534125398c8e7426183e12dc255bb635d94e06d0f93c60a297723abe69d3b22e"
   },
   "workspace": {
     "dependencies": [

--- a/src/db/migrations/recorders/factory.ts
+++ b/src/db/migrations/recorders/factory.ts
@@ -12,6 +12,8 @@ import { PostgresMigrationRecorder } from "./postgres_migration.ts";
 import { PostgresDeprecationRecorder } from "./postgres_deprecation.ts";
 import { DenoKVMigrationRecorder } from "./denokv_migration.ts";
 import { DenoKVDeprecationRecorder } from "./denokv_deprecation.ts";
+import { SQLiteMigrationRecorder } from "./sqlite_migration.ts";
+import { SQLiteDeprecationRecorder } from "./sqlite_deprecation.ts";
 
 // ============================================================================
 // Backend Type Detection
@@ -26,6 +28,13 @@ function isDenoKVBackend(
   return "kv" in backend && backend.kv !== undefined;
 }
 
+/**
+ * Check if backend is a SQLite backend
+ */
+function isSQLiteBackend(backend: DatabaseBackend): boolean {
+  return backend.config?.engine === "sqlite";
+}
+
 // ============================================================================
 // Factory Functions
 // ============================================================================
@@ -35,6 +44,7 @@ function isDenoKVBackend(
  *
  * Automatically selects the appropriate implementation based on backend type:
  * - DenoKV backends → DenoKVMigrationRecorder
+ * - SQLite backends → SQLiteMigrationRecorder
  * - SQL backends (PostgreSQL, etc.) → PostgresMigrationRecorder
  *
  * @param backend - The database backend
@@ -53,6 +63,10 @@ export function createMigrationRecorder(
     return new DenoKVMigrationRecorder(backend.kv);
   }
 
+  if (isSQLiteBackend(backend)) {
+    return new SQLiteMigrationRecorder(backend);
+  }
+
   // Default to PostgreSQL recorder for SQL-based backends
   return new PostgresMigrationRecorder(backend);
 }
@@ -62,6 +76,7 @@ export function createMigrationRecorder(
  *
  * Automatically selects the appropriate implementation based on backend type:
  * - DenoKV backends → DenoKVDeprecationRecorder
+ * - SQLite backends → SQLiteDeprecationRecorder
  * - SQL backends (PostgreSQL, etc.) → PostgresDeprecationRecorder
  *
  * @param backend - The database backend
@@ -85,6 +100,10 @@ export function createDeprecationRecorder(
 ): IDeprecationRecorder {
   if (isDenoKVBackend(backend)) {
     return new DenoKVDeprecationRecorder(backend.kv);
+  }
+
+  if (isSQLiteBackend(backend)) {
+    return new SQLiteDeprecationRecorder(backend);
   }
 
   // Default to PostgreSQL recorder for SQL-based backends

--- a/src/db/migrations/recorders/mod.ts
+++ b/src/db/migrations/recorders/mod.ts
@@ -18,6 +18,10 @@ export type {
 export { PostgresMigrationRecorder } from "./postgres_migration.ts";
 export { PostgresDeprecationRecorder } from "./postgres_deprecation.ts";
 
+// SQLite implementations
+export { SQLiteMigrationRecorder } from "./sqlite_migration.ts";
+export { SQLiteDeprecationRecorder } from "./sqlite_deprecation.ts";
+
 // DenoKV implementations
 export { DenoKVMigrationRecorder } from "./denokv_migration.ts";
 export { DenoKVDeprecationRecorder } from "./denokv_deprecation.ts";

--- a/src/db/migrations/recorders/sqlite_deprecation.ts
+++ b/src/db/migrations/recorders/sqlite_deprecation.ts
@@ -1,0 +1,313 @@
+/**
+ * SQLite Deprecation Recorder
+ *
+ * Tracks deprecated models and fields in the database.
+ * Uses the `_alexi_deprecations` table to store deprecation history.
+ *
+ * @module
+ */
+
+import type { DatabaseBackend } from "../../backends/backend.ts";
+import type { DeprecationInfo } from "../schema_editor.ts";
+import type { DeprecationRecord, IDeprecationRecorder } from "./interfaces.ts";
+
+// ============================================================================
+// SQLite Deprecation Recorder
+// ============================================================================
+
+/**
+ * SQLite Deprecation Recorder
+ *
+ * Tracks deprecated tables and columns in `_alexi_deprecations`.
+ * Mirrors {@link PostgresDeprecationRecorder} but uses SQLite-compatible SQL
+ * syntax (`?` placeholders, `INTEGER` for booleans,
+ * `INTEGER PRIMARY KEY AUTOINCREMENT`).
+ *
+ * @example
+ * ```ts
+ * const recorder = new SQLiteDeprecationRecorder(backend);
+ *
+ * // Record a deprecation
+ * await recorder.record({
+ *   type: "field",
+ *   originalName: "email",
+ *   deprecatedName: "_deprecated_0001_email",
+ *   migrationName: "0001_initial",
+ *   tableName: "users",
+ *   deprecatedAt: new Date(),
+ * });
+ *
+ * // Get all deprecations
+ * const deprecations = await recorder.getAll();
+ *
+ * // Mark as cleaned up
+ * await recorder.markCleanedUp("_deprecated_0001_email");
+ * ```
+ */
+export class SQLiteDeprecationRecorder implements IDeprecationRecorder {
+  private _backend: DatabaseBackend;
+  private _tableName = "_alexi_deprecations";
+  private _tableCreated = false;
+
+  /** @param backend - The SQLite database backend. */
+  constructor(backend: DatabaseBackend) {
+    this._backend = backend;
+  }
+
+  // ==========================================================================
+  // Table Management
+  // ==========================================================================
+
+  /**
+   * Ensure the deprecations tracking table exists.
+   */
+  async ensureTable(): Promise<void> {
+    if (this._tableCreated) return;
+
+    const exists = await this._backend.tableExists(this._tableName);
+    if (!exists) {
+      await this._createTable();
+    }
+
+    this._tableCreated = true;
+  }
+
+  /** @ignore */
+  private async _createTable(): Promise<void> {
+    const sql = `
+      CREATE TABLE IF NOT EXISTS "${this._tableName}" (
+        "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+        "type" VARCHAR(20) NOT NULL,
+        "original_name" VARCHAR(255) NOT NULL,
+        "deprecated_name" VARCHAR(255) NOT NULL,
+        "migration_name" VARCHAR(255) NOT NULL,
+        "table_name" VARCHAR(255) NOT NULL,
+        "deprecated_at" TIMESTAMP NOT NULL,
+        "cleaned_up" INTEGER NOT NULL DEFAULT 0,
+        "cleaned_up_at" TIMESTAMP NULL
+      )
+    `;
+    await this._backend.executeRaw(sql);
+  }
+
+  // ==========================================================================
+  // Recording
+  // ==========================================================================
+
+  /**
+   * Record a deprecation.
+   *
+   * @param info - Deprecation information
+   */
+  async record(info: DeprecationInfo): Promise<void> {
+    await this.ensureTable();
+
+    await this._backend.executeRaw(
+      `INSERT INTO "${this._tableName}"
+       ("type", "original_name", "deprecated_name", "migration_name", "table_name", "deprecated_at")
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [
+        info.type,
+        info.originalName,
+        info.deprecatedName,
+        info.migrationName,
+        info.tableName,
+        info.deprecatedAt.toISOString(),
+      ],
+    );
+  }
+
+  /**
+   * Record multiple deprecations.
+   *
+   * @param infos - Array of deprecation information
+   */
+  async recordMany(infos: DeprecationInfo[]): Promise<void> {
+    for (const info of infos) {
+      await this.record(info);
+    }
+  }
+
+  /**
+   * Remove a deprecation record (for rollback).
+   *
+   * @param deprecatedName - The deprecated name to remove
+   */
+  async remove(deprecatedName: string): Promise<void> {
+    await this.ensureTable();
+
+    await this._backend.executeRaw(
+      `DELETE FROM "${this._tableName}" WHERE "deprecated_name" = ?`,
+      [deprecatedName],
+    );
+  }
+
+  // ==========================================================================
+  // Querying
+  // ==========================================================================
+
+  /** @ignore */
+  private _mapRow(row: {
+    id: number;
+    type: string;
+    original_name: string;
+    deprecated_name: string;
+    migration_name: string;
+    table_name: string;
+    deprecated_at: string;
+    cleaned_up: number;
+    cleaned_up_at: string | null;
+  }): DeprecationRecord {
+    return {
+      id: row.id,
+      type: row.type as "model" | "field",
+      originalName: row.original_name,
+      deprecatedName: row.deprecated_name,
+      migrationName: row.migration_name,
+      tableName: row.table_name,
+      deprecatedAt: new Date(row.deprecated_at),
+      cleanedUp: row.cleaned_up !== 0,
+      cleanedUpAt: row.cleaned_up_at ? new Date(row.cleaned_up_at) : null,
+    };
+  }
+
+  /**
+   * Get all deprecations.
+   *
+   * @param includeCleanedUp - Whether to include cleaned up deprecations
+   */
+  async getAll(includeCleanedUp = false): Promise<DeprecationRecord[]> {
+    await this.ensureTable();
+
+    const whereClause = includeCleanedUp ? "" : 'WHERE "cleaned_up" = 0';
+
+    const results = await this._backend.executeRaw<{
+      id: number;
+      type: string;
+      original_name: string;
+      deprecated_name: string;
+      migration_name: string;
+      table_name: string;
+      deprecated_at: string;
+      cleaned_up: number;
+      cleaned_up_at: string | null;
+    }>(
+      `SELECT * FROM "${this._tableName}" ${whereClause} ORDER BY "deprecated_at" ASC`,
+    );
+
+    return results.map((row) => this._mapRow(row));
+  }
+
+  /**
+   * Get deprecations for a specific migration.
+   *
+   * @param migrationName - Migration name
+   */
+  async getForMigration(migrationName: string): Promise<DeprecationRecord[]> {
+    await this.ensureTable();
+
+    const results = await this._backend.executeRaw<{
+      id: number;
+      type: string;
+      original_name: string;
+      deprecated_name: string;
+      migration_name: string;
+      table_name: string;
+      deprecated_at: string;
+      cleaned_up: number;
+      cleaned_up_at: string | null;
+    }>(
+      `SELECT * FROM "${this._tableName}" WHERE "migration_name" = ? ORDER BY "deprecated_at" ASC`,
+      [migrationName],
+    );
+
+    return results.map((row) => this._mapRow(row));
+  }
+
+  /**
+   * Get deprecations for a specific table.
+   *
+   * @param tableName - Table name
+   */
+  async getForTable(tableName: string): Promise<DeprecationRecord[]> {
+    await this.ensureTable();
+
+    const results = await this._backend.executeRaw<{
+      id: number;
+      type: string;
+      original_name: string;
+      deprecated_name: string;
+      migration_name: string;
+      table_name: string;
+      deprecated_at: string;
+      cleaned_up: number;
+      cleaned_up_at: string | null;
+    }>(
+      `SELECT * FROM "${this._tableName}" WHERE "table_name" = ? ORDER BY "deprecated_at" ASC`,
+      [tableName],
+    );
+
+    return results.map((row) => this._mapRow(row));
+  }
+
+  // ==========================================================================
+  // Cleanup
+  // ==========================================================================
+
+  /**
+   * Mark a deprecation as cleaned up.
+   *
+   * @param deprecatedName - The deprecated name
+   */
+  async markCleanedUp(deprecatedName: string): Promise<void> {
+    await this.ensureTable();
+
+    await this._backend.executeRaw(
+      `UPDATE "${this._tableName}"
+       SET "cleaned_up" = 1, "cleaned_up_at" = CURRENT_TIMESTAMP
+       WHERE "deprecated_name" = ?`,
+      [deprecatedName],
+    );
+  }
+
+  /**
+   * Get pending deprecations that can be cleaned up.
+   *
+   * Only returns deprecations older than the specified number of days.
+   *
+   * @param minAgeDays - Minimum age in days (default: 30)
+   */
+  async getPendingCleanup(minAgeDays = 30): Promise<DeprecationRecord[]> {
+    await this.ensureTable();
+
+    const cutoffDate = new Date();
+    cutoffDate.setDate(cutoffDate.getDate() - minAgeDays);
+
+    const results = await this._backend.executeRaw<{
+      id: number;
+      type: string;
+      original_name: string;
+      deprecated_name: string;
+      migration_name: string;
+      table_name: string;
+      deprecated_at: string;
+      cleaned_up: number;
+      cleaned_up_at: string | null;
+    }>(
+      `SELECT * FROM "${this._tableName}"
+       WHERE "cleaned_up" = 0 AND "deprecated_at" < ?
+       ORDER BY "deprecated_at" ASC`,
+      [cutoffDate.toISOString()],
+    );
+
+    return results.map((row) => this._mapRow(row));
+  }
+
+  /**
+   * Clear all deprecation records (for testing).
+   */
+  async clear(): Promise<void> {
+    await this.ensureTable();
+    await this._backend.executeRaw(`DELETE FROM "${this._tableName}"`);
+  }
+}

--- a/src/db/migrations/recorders/sqlite_migration.ts
+++ b/src/db/migrations/recorders/sqlite_migration.ts
@@ -1,0 +1,212 @@
+/**
+ * SQLite Migration Recorder
+ *
+ * Tracks which migrations have been applied to the database.
+ * Uses the `_alexi_migrations` table to store migration history.
+ *
+ * @module
+ */
+
+import type { DatabaseBackend } from "../../backends/backend.ts";
+import type { IMigrationRecorder, MigrationRecord } from "./interfaces.ts";
+
+// ============================================================================
+// SQLite Migration Recorder
+// ============================================================================
+
+/**
+ * SQLite Migration Recorder
+ *
+ * Tracks applied migrations in the `_alexi_migrations` table in the SQLite
+ * database. Mirrors {@link PostgresMigrationRecorder} but uses SQLite-compatible
+ * SQL syntax (`?` placeholders, `INTEGER PRIMARY KEY AUTOINCREMENT`).
+ *
+ * @example
+ * ```ts
+ * const recorder = new SQLiteMigrationRecorder(backend);
+ *
+ * // Ensure table exists
+ * await recorder.ensureTable();
+ *
+ * // Check if a migration was applied
+ * const applied = await recorder.isApplied("users.0001_initial");
+ *
+ * // Record a migration
+ * await recorder.recordApplied("users.0001_initial", "users");
+ *
+ * // Remove a migration record (for rollback)
+ * await recorder.recordUnapplied("users.0001_initial");
+ * ```
+ */
+export class SQLiteMigrationRecorder implements IMigrationRecorder {
+  private _backend: DatabaseBackend;
+  private _tableName = "_alexi_migrations";
+  private _tableCreated = false;
+
+  /** @param backend - The SQLite database backend. */
+  constructor(backend: DatabaseBackend) {
+    this._backend = backend;
+  }
+
+  // ==========================================================================
+  // Table Management
+  // ==========================================================================
+
+  /**
+   * Ensure the migrations tracking table exists.
+   */
+  async ensureTable(): Promise<void> {
+    if (this._tableCreated) return;
+
+    const exists = await this._backend.tableExists(this._tableName);
+    if (!exists) {
+      await this._createTable();
+    }
+
+    this._tableCreated = true;
+  }
+
+  /** @ignore */
+  private async _createTable(): Promise<void> {
+    const sql = `
+      CREATE TABLE IF NOT EXISTS "${this._tableName}" (
+        "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+        "name" VARCHAR(255) NOT NULL UNIQUE,
+        "app_label" VARCHAR(255) NOT NULL,
+        "applied_at" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+      )
+    `;
+    await this._backend.executeRaw(sql);
+  }
+
+  // ==========================================================================
+  // Migration Tracking
+  // ==========================================================================
+
+  /**
+   * Check if a migration has been applied.
+   *
+   * @param fullName - Full migration name (e.g., "users.0001_initial")
+   */
+  async isApplied(fullName: string): Promise<boolean> {
+    await this.ensureTable();
+
+    const results = await this._backend.executeRaw<{ count: number }>(
+      `SELECT COUNT(*) as count FROM "${this._tableName}" WHERE "name" = ?`,
+      [fullName],
+    );
+
+    return results.length > 0 && results[0].count > 0;
+  }
+
+  /**
+   * Get all applied migrations.
+   */
+  async getAppliedMigrations(): Promise<MigrationRecord[]> {
+    await this.ensureTable();
+
+    const results = await this._backend.executeRaw<{
+      name: string;
+      app_label: string;
+      applied_at: string;
+    }>(
+      `SELECT "name", "app_label", "applied_at" FROM "${this._tableName}" ORDER BY "applied_at" ASC`,
+    );
+
+    return results.map((row) => ({
+      name: row.name,
+      appLabel: row.app_label,
+      appliedAt: new Date(row.applied_at),
+    }));
+  }
+
+  /**
+   * Get applied migrations for a specific app.
+   *
+   * @param appLabel - App label to filter by
+   */
+  async getAppliedForApp(appLabel: string): Promise<MigrationRecord[]> {
+    await this.ensureTable();
+
+    const results = await this._backend.executeRaw<{
+      name: string;
+      app_label: string;
+      applied_at: string;
+    }>(
+      `SELECT "name", "app_label", "applied_at" FROM "${this._tableName}"
+       WHERE "app_label" = ? ORDER BY "applied_at" ASC`,
+      [appLabel],
+    );
+
+    return results.map((row) => ({
+      name: row.name,
+      appLabel: row.app_label,
+      appliedAt: new Date(row.applied_at),
+    }));
+  }
+
+  /**
+   * Record that a migration has been applied.
+   *
+   * @param fullName - Full migration name
+   * @param appLabel - App label
+   */
+  async recordApplied(fullName: string, appLabel: string): Promise<void> {
+    await this.ensureTable();
+
+    await this._backend.executeRaw(
+      `INSERT INTO "${this._tableName}" ("name", "app_label", "applied_at")
+       VALUES (?, ?, CURRENT_TIMESTAMP)`,
+      [fullName, appLabel],
+    );
+  }
+
+  /**
+   * Record that a migration has been unapplied (rolled back).
+   *
+   * @param fullName - Full migration name
+   */
+  async recordUnapplied(fullName: string): Promise<void> {
+    await this.ensureTable();
+
+    await this._backend.executeRaw(
+      `DELETE FROM "${this._tableName}" WHERE "name" = ?`,
+      [fullName],
+    );
+  }
+
+  /**
+   * Get the latest applied migration for an app.
+   *
+   * @param appLabel - App label
+   */
+  async getLatestForApp(appLabel: string): Promise<MigrationRecord | null> {
+    await this.ensureTable();
+
+    const results = await this._backend.executeRaw<{
+      name: string;
+      app_label: string;
+      applied_at: string;
+    }>(
+      `SELECT "name", "app_label", "applied_at" FROM "${this._tableName}"
+       WHERE "app_label" = ? ORDER BY "applied_at" DESC LIMIT 1`,
+      [appLabel],
+    );
+
+    if (results.length === 0) return null;
+
+    return {
+      name: results[0].name,
+      appLabel: results[0].app_label,
+      appliedAt: new Date(results[0].applied_at),
+    };
+  }
+
+  /**
+   * Clear all migration records (for testing).
+   */
+  async clear(): Promise<void> {
+    await this.ensureTable();
+    await this._backend.executeRaw(`DELETE FROM "${this._tableName}"`);
+  }
+}


### PR DESCRIPTION
## Summary

- Add `SQLiteMigrationRecorder` that stores migration state in a `_alexi_migrations` table in the SQLite database using SQLite-compatible SQL syntax (`?` placeholders, `INTEGER PRIMARY KEY AUTOINCREMENT`, `INTEGER` for booleans)
- Add `SQLiteDeprecationRecorder` that stores deprecation records in `_alexi_deprecations` using the same SQLite-compatible approach
- Update `MigrationRecorderFactory` to detect `SQLiteBackend` via `backend.config?.engine === "sqlite"` and return the correct recorder instead of falling through to `PostgresMigrationRecorder`

Closes #437