### PR TITLE
fix(mail): add missing trailing CRLF to SMTP DATA terminator

### DIFF
--- a/src/mail/backends/smtp.ts
+++ b/src/mail/backends/smtp.ts
@@ -323,7 +323,7 @@ class SmtpSession {
     await this._readResponse(354);
 
     const rawMsg = msg.message().replace(/\n\./g, "\n.."); // dot-stuffing
-    await this._send(rawMsg + "\r\n.");
+    await this._send(rawMsg + "\r\n.\r\n");
     await this._readResponse(250);
   }
 


### PR DESCRIPTION
## Summary

- The DATA terminator was `\r\n.` instead of the RFC 5321-mandated `\r\n.\r\n`, so the SMTP server never recognised the end of the message body and `send()` hung indefinitely

Closes #443