### PR TITLE
feat(db): add schema-based test isolation for PostgresBackend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -450,6 +450,31 @@ Key design principles:
 | `IndexedDBBackend` | `@alexi/db/backends/indexeddb` | Browser     | Local browser storage          |
 | `RestBackend`      | `@alexi/db/backends/rest`      | Browser     | Maps ORM calls to REST API     |
 
+#### `PostgresBackend` — `testIsolation` option
+
+`migrate --test` requires an isolated copy of the database. `PostgresBackend`
+supports two strategies, configured via `testIsolation`:
+
+| Value                    | How it works                                              | Privilege required               |
+| ------------------------ | --------------------------------------------------------- | -------------------------------- |
+| `"database"` _(default)_ | `CREATE DATABASE … TEMPLATE`                              | `CREATEDB`                       |
+| `"schema"`               | `CREATE SCHEMA test_<timestamp>` inside the same database | Normal table-creation privileges |
+
+Use `"schema"` on managed PostgreSQL services (Deno Deploy, Supabase, Railway,
+etc.) where `CREATEDB` is not available:
+
+```typescript
+// settings.ts
+export const DATABASES = {
+  default: new PostgresBackend({
+    engine: "postgres",
+    name: "myapp",
+    connectionString: Deno.env.get("DATABASE_URL"),
+    testIsolation: "schema",
+  }),
+};
+```
+
 ---
 
 ## REST Framework

--- a/deno.lock
+++ b/deno.lock
@@ -1,13 +1,20 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@db/sqlite@0.12": "0.12.0",
+    "jsr:@denosaurs/plug@1": "1.1.0",
     "jsr:@luca/esbuild-deno-loader@~0.11.1": "0.11.1",
     "jsr:@std/assert@*": "1.0.19",
+    "jsr:@std/assert@0.217": "0.217.0",
     "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/bytes@^1.0.2": "1.0.6",
+    "jsr:@std/encoding@1": "1.0.10",
     "jsr:@std/encoding@^1.0.5": "1.0.10",
+    "jsr:@std/fmt@1": "1.0.9",
+    "jsr:@std/fs@1": "1.0.23",
     "jsr:@std/fs@^1.0.19": "1.0.23",
     "jsr:@std/internal@^1.0.12": "1.0.12",
+    "jsr:@std/path@0.217": "0.217.0",
     "jsr:@std/path@1": "1.1.4",
     "jsr:@std/path@^1.0.6": "1.1.4",
     "jsr:@std/path@^1.1.2": "1.1.4",
@@ -20,13 +27,32 @@
     "npm:playwright@^1.48.0": "1.58.2"
   },
   "jsr": {
+    "@db/sqlite@0.12.0": {
+      "integrity": "dd1ef7f621ad50fc1e073a1c3609c4470bd51edc0994139c5bf9851de7a6d85f",
+      "dependencies": [
+        "jsr:@denosaurs/plug",
+        "jsr:@std/path@0.217"
+      ]
+    },
+    "@denosaurs/plug@1.1.0": {
+      "integrity": "eb2f0b7546c7bca2000d8b0282c54d50d91cf6d75cb26a80df25a6de8c4bc044",
+      "dependencies": [
+        "jsr:@std/encoding@1",
+        "jsr:@std/fmt",
+        "jsr:@std/fs@1",
+        "jsr:@std/path@1"
+      ]
+    },
     "@luca/esbuild-deno-loader@0.11.1": {
       "integrity": "dc020d16d75b591f679f6b9288b10f38bdb4f24345edb2f5732affa1d9885267",
       "dependencies": [
         "jsr:@std/bytes",
-        "jsr:@std/encoding",
+        "jsr:@std/encoding@^1.0.5",
         "jsr:@std/path@^1.0.6"
       ]
+    },
+    "@std/assert@0.217.0": {
+      "integrity": "c98e279362ca6982d5285c3b89517b757c1e3477ee9f14eb2fdf80a45aaa9642"
     },
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
@@ -40,6 +66,9 @@
     "@std/encoding@1.0.10": {
       "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
     },
+    "@std/fmt@1.0.9": {
+      "integrity": "2487343e8899fb2be5d0e3d35013e54477ada198854e52dd05ed0422eddcabe0"
+    },
     "@std/fs@1.0.23": {
       "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
       "dependencies": [
@@ -50,6 +79,12 @@
     "@std/internal@1.0.12": {
       "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
     },
+    "@std/path@0.217.0": {
+      "integrity": "1217cc25534bca9a2f672d7fe7c6f356e4027df400c0e85c0ef3e4343bc67d11",
+      "dependencies": [
+        "jsr:@std/assert@0.217"
+      ]
+    },
     "@std/path@1.1.4": {
       "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
       "dependencies": [
@@ -59,7 +94,7 @@
     "@webui/deno-webui@2.5.13": {
       "integrity": "6f03345e19b943177766a30ed728a0e16c228757b5469bceee6092a7e18a25f9",
       "dependencies": [
-        "jsr:@std/fs",
+        "jsr:@std/fs@^1.0.19",
         "jsr:@std/path@^1.1.2",
         "jsr:@zip-js/zip-js"
       ]
@@ -318,8 +353,73 @@
     }
   },
   "remote": {
+    "https://deno.land/std@0.208.0/assert/_constants.ts": "8a9da298c26750b28b326b297316cdde860bc237533b07e1337c021379e6b2a9",
+    "https://deno.land/std@0.208.0/assert/_diff.ts": "58e1461cc61d8eb1eacbf2a010932bf6a05b79344b02ca38095f9b805795dc48",
+    "https://deno.land/std@0.208.0/assert/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
+    "https://deno.land/std@0.208.0/assert/assert.ts": "9a97dad6d98c238938e7540736b826440ad8c1c1e54430ca4c4e623e585607ee",
+    "https://deno.land/std@0.208.0/assert/assert_almost_equals.ts": "e15ca1f34d0d5e0afae63b3f5d975cbd18335a132e42b0c747d282f62ad2cd6c",
+    "https://deno.land/std@0.208.0/assert/assert_array_includes.ts": "6856d7f2c3544bc6e62fb4646dfefa3d1df5ff14744d1bca19f0cbaf3b0d66c9",
+    "https://deno.land/std@0.208.0/assert/assert_equals.ts": "d8ec8a22447fbaf2fc9d7c3ed2e66790fdb74beae3e482855d75782218d68227",
+    "https://deno.land/std@0.208.0/assert/assert_exists.ts": "407cb6b9fb23a835cd8d5ad804e2e2edbbbf3870e322d53f79e1c7a512e2efd7",
+    "https://deno.land/std@0.208.0/assert/assert_false.ts": "0ccbcaae910f52c857192ff16ea08bda40fdc79de80846c206bfc061e8c851c6",
+    "https://deno.land/std@0.208.0/assert/assert_greater.ts": "ae2158a2d19313bf675bf7251d31c6dc52973edb12ac64ac8fc7064152af3e63",
+    "https://deno.land/std@0.208.0/assert/assert_greater_or_equal.ts": "1439da5ebbe20855446cac50097ac78b9742abe8e9a43e7de1ce1426d556e89c",
+    "https://deno.land/std@0.208.0/assert/assert_instance_of.ts": "3aedb3d8186e120812d2b3a5dea66a6e42bf8c57a8bd927645770bd21eea554c",
+    "https://deno.land/std@0.208.0/assert/assert_is_error.ts": "c21113094a51a296ffaf036767d616a78a2ae5f9f7bbd464cd0197476498b94b",
+    "https://deno.land/std@0.208.0/assert/assert_less.ts": "aec695db57db42ec3e2b62e97e1e93db0063f5a6ec133326cc290ff4b71b47e4",
+    "https://deno.land/std@0.208.0/assert/assert_less_or_equal.ts": "5fa8b6a3ffa20fd0a05032fe7257bf985d207b85685fdbcd23651b70f928c848",
+    "https://deno.land/std@0.208.0/assert/assert_match.ts": "c4083f80600bc190309903c95e397a7c9257ff8b5ae5c7ef91e834704e672e9b",
+    "https://deno.land/std@0.208.0/assert/assert_not_equals.ts": "9f1acab95bd1f5fc9a1b17b8027d894509a745d91bac1718fdab51dc76831754",
+    "https://deno.land/std@0.208.0/assert/assert_not_instance_of.ts": "0c14d3dfd9ab7a5276ed8ed0b18c703d79a3d106102077ec437bfe7ed912bd22",
+    "https://deno.land/std@0.208.0/assert/assert_not_match.ts": "3796a5b0c57a1ce6c1c57883dd4286be13a26f715ea662318ab43a8491a13ab0",
+    "https://deno.land/std@0.208.0/assert/assert_not_strict_equals.ts": "4cdef83df17488df555c8aac1f7f5ec2b84ad161b6d0645ccdbcc17654e80c99",
+    "https://deno.land/std@0.208.0/assert/assert_object_match.ts": "d8fc2867cfd92eeacf9cea621e10336b666de1874a6767b5ec48988838370b54",
+    "https://deno.land/std@0.208.0/assert/assert_rejects.ts": "45c59724de2701e3b1f67c391d6c71c392363635aad3f68a1b3408f9efca0057",
+    "https://deno.land/std@0.208.0/assert/assert_strict_equals.ts": "b1f538a7ea5f8348aeca261d4f9ca603127c665e0f2bbfeb91fa272787c87265",
+    "https://deno.land/std@0.208.0/assert/assert_string_includes.ts": "b821d39ebf5cb0200a348863c86d8c4c4b398e02012ce74ad15666fc4b631b0c",
+    "https://deno.land/std@0.208.0/assert/assert_throws.ts": "63784e951475cb7bdfd59878cd25a0931e18f6dc32a6077c454b2cd94f4f4bcd",
+    "https://deno.land/std@0.208.0/assert/assertion_error.ts": "4d0bde9b374dfbcbe8ac23f54f567b77024fb67dbb1906a852d67fe050d42f56",
+    "https://deno.land/std@0.208.0/assert/equal.ts": "9f1a46d5993966d2596c44e5858eec821859b45f783a5ee2f7a695dfc12d8ece",
+    "https://deno.land/std@0.208.0/assert/fail.ts": "c36353d7ae6e1f7933d45f8ea51e358c8c4b67d7e7502028598fe1fea062e278",
+    "https://deno.land/std@0.208.0/assert/mod.ts": "37c49a26aae2b254bbe25723434dc28cd7532e444cf0b481a97c045d110ec085",
+    "https://deno.land/std@0.208.0/assert/unimplemented.ts": "d56fbeecb1f108331a380f72e3e010a1f161baa6956fd0f7cf3e095ae1a4c75a",
+    "https://deno.land/std@0.208.0/assert/unreachable.ts": "4600dc0baf7d9c15a7f7d234f00c23bca8f3eba8b140286aaca7aa998cf9a536",
+    "https://deno.land/std@0.208.0/fmt/colors.ts": "34b3f77432925eb72cf0bfb351616949746768620b8e5ead66da532f93d10ba2",
     "https://deno.land/std@0.208.0/testing/_test_suite.ts": "30f018feeb3835f12ab198d8a518f9089b1bcb2e8c838a8b615ab10d5005465c",
-    "https://deno.land/std@0.208.0/testing/bdd.ts": "c41f019786c4a9112aadb7e5a7bbcc711f58429ac5904b3855fa248ba5fa0ba6"
+    "https://deno.land/std@0.208.0/testing/bdd.ts": "c41f019786c4a9112aadb7e5a7bbcc711f58429ac5904b3855fa248ba5fa0ba6",
+    "https://deno.land/std@0.224.0/assert/_constants.ts": "a271e8ef5a573f1df8e822a6eb9d09df064ad66a4390f21b3e31f820a38e0975",
+    "https://deno.land/std@0.224.0/assert/assert.ts": "09d30564c09de846855b7b071e62b5974b001bb72a4b797958fe0660e7849834",
+    "https://deno.land/std@0.224.0/assert/assert_almost_equals.ts": "9e416114322012c9a21fa68e187637ce2d7df25bcbdbfd957cd639e65d3cf293",
+    "https://deno.land/std@0.224.0/assert/assert_array_includes.ts": "14c5094471bc8e4a7895fc6aa5a184300d8a1879606574cb1cd715ef36a4a3c7",
+    "https://deno.land/std@0.224.0/assert/assert_equals.ts": "3bbca947d85b9d374a108687b1a8ba3785a7850436b5a8930d81f34a32cb8c74",
+    "https://deno.land/std@0.224.0/assert/assert_exists.ts": "43420cf7f956748ae6ed1230646567b3593cb7a36c5a5327269279c870c5ddfd",
+    "https://deno.land/std@0.224.0/assert/assert_false.ts": "3e9be8e33275db00d952e9acb0cd29481a44fa0a4af6d37239ff58d79e8edeff",
+    "https://deno.land/std@0.224.0/assert/assert_greater.ts": "5e57b201fd51b64ced36c828e3dfd773412c1a6120c1a5a99066c9b261974e46",
+    "https://deno.land/std@0.224.0/assert/assert_greater_or_equal.ts": "9870030f997a08361b6f63400273c2fb1856f5db86c0c3852aab2a002e425c5b",
+    "https://deno.land/std@0.224.0/assert/assert_instance_of.ts": "e22343c1fdcacfaea8f37784ad782683ec1cf599ae9b1b618954e9c22f376f2c",
+    "https://deno.land/std@0.224.0/assert/assert_is_error.ts": "f856b3bc978a7aa6a601f3fec6603491ab6255118afa6baa84b04426dd3cc491",
+    "https://deno.land/std@0.224.0/assert/assert_less.ts": "60b61e13a1982865a72726a5fa86c24fad7eb27c3c08b13883fb68882b307f68",
+    "https://deno.land/std@0.224.0/assert/assert_less_or_equal.ts": "d2c84e17faba4afe085e6c9123a63395accf4f9e00150db899c46e67420e0ec3",
+    "https://deno.land/std@0.224.0/assert/assert_match.ts": "ace1710dd3b2811c391946954234b5da910c5665aed817943d086d4d4871a8b7",
+    "https://deno.land/std@0.224.0/assert/assert_not_equals.ts": "78d45dd46133d76ce624b2c6c09392f6110f0df9b73f911d20208a68dee2ef29",
+    "https://deno.land/std@0.224.0/assert/assert_not_instance_of.ts": "3434a669b4d20cdcc5359779301a0588f941ffdc2ad68803c31eabdb4890cf7a",
+    "https://deno.land/std@0.224.0/assert/assert_not_match.ts": "df30417240aa2d35b1ea44df7e541991348a063d9ee823430e0b58079a72242a",
+    "https://deno.land/std@0.224.0/assert/assert_not_strict_equals.ts": "37f73880bd672709373d6dc2c5f148691119bed161f3020fff3548a0496f71b8",
+    "https://deno.land/std@0.224.0/assert/assert_object_match.ts": "411450fd194fdaabc0089ae68f916b545a49d7b7e6d0026e84a54c9e7eed2693",
+    "https://deno.land/std@0.224.0/assert/assert_rejects.ts": "4bee1d6d565a5b623146a14668da8f9eb1f026a4f338bbf92b37e43e0aa53c31",
+    "https://deno.land/std@0.224.0/assert/assert_strict_equals.ts": "b4f45f0fd2e54d9029171876bd0b42dd9ed0efd8f853ab92a3f50127acfa54f5",
+    "https://deno.land/std@0.224.0/assert/assert_string_includes.ts": "496b9ecad84deab72c8718735373feb6cdaa071eb91a98206f6f3cb4285e71b8",
+    "https://deno.land/std@0.224.0/assert/assert_throws.ts": "c6508b2879d465898dab2798009299867e67c570d7d34c90a2d235e4553906eb",
+    "https://deno.land/std@0.224.0/assert/assertion_error.ts": "ba8752bd27ebc51f723702fac2f54d3e94447598f54264a6653d6413738a8917",
+    "https://deno.land/std@0.224.0/assert/equal.ts": "bddf07bb5fc718e10bb72d5dc2c36c1ce5a8bdd3b647069b6319e07af181ac47",
+    "https://deno.land/std@0.224.0/assert/fail.ts": "0eba674ffb47dff083f02ced76d5130460bff1a9a68c6514ebe0cdea4abadb68",
+    "https://deno.land/std@0.224.0/assert/mod.ts": "48b8cb8a619ea0b7958ad7ee9376500fe902284bb36f0e32c598c3dc34cbd6f3",
+    "https://deno.land/std@0.224.0/assert/unimplemented.ts": "8c55a5793e9147b4f1ef68cd66496b7d5ba7a9e7ca30c6da070c1a58da723d73",
+    "https://deno.land/std@0.224.0/assert/unreachable.ts": "5ae3dbf63ef988615b93eb08d395dda771c96546565f9e521ed86f6510c29e19",
+    "https://deno.land/std@0.224.0/fmt/colors.ts": "508563c0659dd7198ba4bbf87e97f654af3c34eb56ba790260f252ad8012e1c5",
+    "https://deno.land/std@0.224.0/internal/diff.ts": "6234a4b493ebe65dc67a18a0eb97ef683626a1166a1906232ce186ae9f65f4e6",
+    "https://deno.land/std@0.224.0/internal/format.ts": "0a98ee226fd3d43450245b1844b47003419d34d210fa989900861c79820d21c2",
+    "https://deno.land/std@0.224.0/internal/mod.ts": "534125398c8e7426183e12dc255bb635d94e06d0f93c60a297723abe69d3b22e"
   },
   "workspace": {
     "dependencies": [

--- a/src/db/backends/postgres/backend.ts
+++ b/src/db/backends/postgres/backend.ts
@@ -130,6 +130,7 @@ export class PostgresBackend extends DatabaseBackend {
   private _pool: Pool | null = null;
   private _schema: string;
   private _debug: boolean;
+  private _testIsolation: "database" | "schema";
 
   constructor(config: PostgresConfig) {
     super({
@@ -144,10 +145,12 @@ export class PostgresBackend extends DatabaseBackend {
         ssl: config.ssl,
         pool: config.pool,
         schema: config.schema,
+        testIsolation: config.testIsolation,
       },
     });
     this._schema = config.schema ?? "public";
     this._debug = config.debug ?? false;
+    this._testIsolation = config.testIsolation ?? "database";
   }
 
   /**
@@ -254,26 +257,91 @@ export class PostgresBackend extends DatabaseBackend {
   /**
    * Create an isolated copy of this PostgreSQL database for `migrate --test`.
    *
-   * Uses PostgreSQL's native `CREATE DATABASE "<temp>" TEMPLATE "<original>"`
-   * to produce an identical copy in a single server-side operation.  A new,
-   * connected {@link PostgresBackend} pointing at the temp database is
-   * returned.
+   * The isolation strategy is controlled by the `testIsolation` config option:
    *
-   * The temporary database name is `<original>_test_<timestamp>` (e.g.
-   * `myapp_test_1700000000000`).
+   * - `"database"` *(default)* — uses `CREATE DATABASE "<temp>" TEMPLATE
+   *   "<original>"` to produce an identical copy.  Requires the `CREATEDB`
+   *   privilege and zero active sessions on the source database at call time.
+   *   This method temporarily disconnects the original backend, creates the
+   *   copy via a maintenance connection to the `postgres` system database, then
+   *   reconnects.
    *
-   * **Important:** `CREATE DATABASE … TEMPLATE` requires that no other
-   * sessions are connected to the template database at the time of the call.
-   * This method disconnects from the original backend, creates the copy via a
-   * maintenance connection to the `postgres` system database, then reconnects
-   * the original backend.
+   * - `"schema"` — creates a temporary schema inside the **same** database
+   *   (`CREATE SCHEMA "test_<timestamp>"`).  Only requires normal
+   *   table-creation privileges and works on managed environments such as
+   *   Deno Deploy, Supabase, and Railway.  The returned backend shares the same
+   *   connection pool but points at the new schema.
    *
-   * @returns A new connected backend backed by the temporary database.
-   * @throws {Error} If the backend uses a `connectionString` (the individual
-   *   host/user/password parameters are required to build the maintenance
-   *   connection).
+   * @returns A new connected backend backed by the temporary database/schema.
    */
   override async copyForTest(): Promise<PostgresBackend> {
+    if (this._testIsolation === "schema") {
+      return this._copyForTestSchema();
+    }
+    return this._copyForTestDatabase();
+  }
+
+  /**
+   * Schema-based test isolation: `CREATE SCHEMA "test_<timestamp>"`.
+   *
+   * Requires only normal table-creation privileges.  Works on all managed
+   * PostgreSQL environments.
+   */
+  private async _copyForTestSchema(): Promise<PostgresBackend> {
+    this.ensureConnected();
+
+    const tempSchema = `test_${Date.now()}`;
+
+    await this._pool!.query(`CREATE SCHEMA "${tempSchema}"`);
+
+    if (this._debug) {
+      console.log(
+        `[PostgresBackend] Created test schema: ${tempSchema}`,
+      );
+    }
+
+    const config = this._config;
+    const options = config.options as {
+      connectionString?: string;
+      ssl?: boolean | object;
+      pool?: Record<string, unknown>;
+      testIsolation?: "database" | "schema";
+    };
+
+    const tempConfig: PostgresConfig = {
+      engine: "postgres",
+      name: config.name,
+      host: config.host,
+      port: config.port,
+      user: config.user,
+      password: config.password,
+      schema: tempSchema,
+      debug: this._debug,
+      testIsolation: "schema",
+    };
+
+    if (options?.connectionString) {
+      tempConfig.connectionString = options.connectionString;
+    }
+
+    if (options?.ssl !== undefined) {
+      tempConfig.ssl = options.ssl as PostgresConfig["ssl"];
+    }
+
+    const copy = new PostgresBackend(tempConfig);
+    await copy.connect();
+    (copy as PostgresBackend & { _tempSchemaName?: string })._tempSchemaName =
+      tempSchema;
+    return copy;
+  }
+
+  /**
+   * Database-based test isolation: `CREATE DATABASE "<temp>" TEMPLATE "<original>"`.
+   *
+   * Requires the `CREATEDB` privilege.  Not available on most managed
+   * PostgreSQL services — use `testIsolation: "schema"` in those environments.
+   */
+  private async _copyForTestDatabase(): Promise<PostgresBackend> {
     const config = this._config;
     const options = config.options as {
       connectionString?: string;
@@ -292,7 +360,6 @@ export class PostgresBackend extends DatabaseBackend {
 
     if (options?.connectionString) {
       // Rewrite the database portion of the connection string to 'postgres'.
-      // We replace the last path segment before any query string.
       const url = new URL(options.connectionString);
       url.pathname = "/postgres";
       maintenancePoolConfig.connectionString = url.toString();
@@ -315,7 +382,6 @@ export class PostgresBackend extends DatabaseBackend {
     try {
       const client = await maintenancePool.connect();
       try {
-        // identifiers are double-quoted to handle mixed-case names
         await client.query(
           `CREATE DATABASE "${tempName}" TEMPLATE "${originalName}"`,
         );
@@ -358,18 +424,46 @@ export class PostgresBackend extends DatabaseBackend {
     (copy as PostgresBackend & { _tempDbName?: string })._tempDbName = tempName;
     (copy as PostgresBackend & {
       _maintenancePoolConfig?: Record<string, unknown>;
-    })
-      ._maintenancePoolConfig = maintenancePoolConfig;
+    })._maintenancePoolConfig = maintenancePoolConfig;
     return copy;
   }
 
   /**
-   * Destroy the temporary database created by {@link copyForTest}.
+   * Destroy the temporary database or schema created by {@link copyForTest}.
    *
-   * Disconnects and runs `DROP DATABASE "<temp>"` via a maintenance connection
-   * to the `postgres` system database.
+   * - For `"schema"` isolation: runs `DROP SCHEMA "<temp>" CASCADE`.
+   * - For `"database"` isolation: disconnects and runs `DROP DATABASE "<temp>"`
+   *   via a maintenance connection to the `postgres` system database.
    */
   override async destroyTestCopy(): Promise<void> {
+    if (this._testIsolation === "schema") {
+      return this._destroyTestCopySchema();
+    }
+    return this._destroyTestCopyDatabase();
+  }
+
+  private async _destroyTestCopySchema(): Promise<void> {
+    const tempSchemaName =
+      (this as PostgresBackend & { _tempSchemaName?: string })._tempSchemaName;
+
+    if (tempSchemaName) {
+      if (this._pool) {
+        await this._pool.query(
+          `DROP SCHEMA IF EXISTS "${tempSchemaName}" CASCADE`,
+        );
+
+        if (this._debug) {
+          console.log(
+            `[PostgresBackend] Dropped test schema: ${tempSchemaName}`,
+          );
+        }
+      }
+    }
+
+    await this.disconnect();
+  }
+
+  private async _destroyTestCopyDatabase(): Promise<void> {
     const tempDbName =
       (this as PostgresBackend & { _tempDbName?: string })._tempDbName;
     const maintenancePoolConfig = (

--- a/src/db/backends/postgres/types.ts
+++ b/src/db/backends/postgres/types.ts
@@ -81,6 +81,34 @@ export interface PostgresConfig extends DatabaseConfig {
   schema?: string;
 
   /**
+   * Test isolation strategy used by `migrate --test`.
+   *
+   * - `"database"` *(default)* — clones the database with
+   *   `CREATE DATABASE … TEMPLATE`.  Requires the `CREATEDB` privilege and is
+   *   not available on most managed PostgreSQL services (Deno Deploy, Supabase,
+   *   Railway, etc.).
+   * - `"schema"` — creates a temporary schema inside the **same** database
+   *   (`CREATE SCHEMA test_<timestamp>`).  Only requires normal table-creation
+   *   privileges and works on all managed environments.
+   *
+   * @default "database"
+   *
+   * @example
+   * ```ts
+   * // settings.ts — Deno Deploy / managed Postgres
+   * export const DATABASES = {
+   *   default: new PostgresBackend({
+   *     engine: "postgres",
+   *     name: "myapp",
+   *     connectionString: Deno.env.get("DATABASE_URL"),
+   *     testIsolation: "schema",
+   *   }),
+   * };
+   * ```
+   */
+  testIsolation?: "database" | "schema";
+
+  /**
    * Enable debug logging
    */
   debug?: boolean;

--- a/src/db/migrations/recorders/postgres_deprecation.ts
+++ b/src/db/migrations/recorders/postgres_deprecation.ts
@@ -8,6 +8,7 @@
  */
 
 import type { DatabaseBackend } from "../../backends/backend.ts";
+import type { PostgresBackend } from "../../backends/postgres/backend.ts";
 import type { DeprecationInfo } from "../schema_editor.ts";
 import type { DeprecationRecord, IDeprecationRecorder } from "./interfaces.ts";
 
@@ -44,10 +45,17 @@ import type { DeprecationRecord, IDeprecationRecorder } from "./interfaces.ts";
 export class PostgresDeprecationRecorder implements IDeprecationRecorder {
   private _backend: DatabaseBackend;
   private _tableName = "_alexi_deprecations";
+  private _schema: string;
   private _tableCreated = false;
 
   constructor(backend: DatabaseBackend) {
     this._backend = backend;
+    this._schema = (backend as unknown as PostgresBackend).schema ?? "public";
+  }
+
+  /** Fully schema-qualified table reference, e.g. `"public"."_alexi_deprecations"` */
+  private get _qualifiedTable(): string {
+    return `"${this._schema}"."${this._tableName}"`;
   }
 
   // ==========================================================================
@@ -70,7 +78,7 @@ export class PostgresDeprecationRecorder implements IDeprecationRecorder {
 
   private async _createTable(): Promise<void> {
     const sql = `
-      CREATE TABLE IF NOT EXISTS "${this._tableName}" (
+      CREATE TABLE IF NOT EXISTS ${this._qualifiedTable} (
         "id" SERIAL PRIMARY KEY,
         "type" VARCHAR(20) NOT NULL,
         "original_name" VARCHAR(255) NOT NULL,
@@ -98,7 +106,7 @@ export class PostgresDeprecationRecorder implements IDeprecationRecorder {
     await this.ensureTable();
 
     await this._backend.executeRaw(
-      `INSERT INTO "${this._tableName}" 
+      `INSERT INTO ${this._qualifiedTable} 
        ("type", "original_name", "deprecated_name", "migration_name", "table_name", "deprecated_at")
        VALUES ($1, $2, $3, $4, $5, $6)`,
       [
@@ -132,7 +140,7 @@ export class PostgresDeprecationRecorder implements IDeprecationRecorder {
     await this.ensureTable();
 
     await this._backend.executeRaw(
-      `DELETE FROM "${this._tableName}" WHERE "deprecated_name" = $1`,
+      `DELETE FROM ${this._qualifiedTable} WHERE "deprecated_name" = $1`,
       [deprecatedName],
     );
   }
@@ -186,7 +194,7 @@ export class PostgresDeprecationRecorder implements IDeprecationRecorder {
       cleaned_up: boolean;
       cleaned_up_at: string | null;
     }>(
-      `SELECT * FROM "${this._tableName}" ${whereClause} ORDER BY "deprecated_at" ASC`,
+      `SELECT * FROM ${this._qualifiedTable} ${whereClause} ORDER BY "deprecated_at" ASC`,
     );
 
     return results.map((row) => this._mapRow(row));
@@ -211,7 +219,7 @@ export class PostgresDeprecationRecorder implements IDeprecationRecorder {
       cleaned_up: boolean;
       cleaned_up_at: string | null;
     }>(
-      `SELECT * FROM "${this._tableName}" WHERE "migration_name" = $1 ORDER BY "deprecated_at" ASC`,
+      `SELECT * FROM ${this._qualifiedTable} WHERE "migration_name" = $1 ORDER BY "deprecated_at" ASC`,
       [migrationName],
     );
 
@@ -237,7 +245,7 @@ export class PostgresDeprecationRecorder implements IDeprecationRecorder {
       cleaned_up: boolean;
       cleaned_up_at: string | null;
     }>(
-      `SELECT * FROM "${this._tableName}" WHERE "table_name" = $1 ORDER BY "deprecated_at" ASC`,
+      `SELECT * FROM ${this._qualifiedTable} WHERE "table_name" = $1 ORDER BY "deprecated_at" ASC`,
       [tableName],
     );
 
@@ -257,7 +265,7 @@ export class PostgresDeprecationRecorder implements IDeprecationRecorder {
     await this.ensureTable();
 
     await this._backend.executeRaw(
-      `UPDATE "${this._tableName}" 
+      `UPDATE ${this._qualifiedTable} 
        SET "cleaned_up" = TRUE, "cleaned_up_at" = CURRENT_TIMESTAMP 
        WHERE "deprecated_name" = $1`,
       [deprecatedName],
@@ -288,7 +296,7 @@ export class PostgresDeprecationRecorder implements IDeprecationRecorder {
       cleaned_up: boolean;
       cleaned_up_at: string | null;
     }>(
-      `SELECT * FROM "${this._tableName}" 
+      `SELECT * FROM ${this._qualifiedTable} 
        WHERE "cleaned_up" = FALSE AND "deprecated_at" < $1 
        ORDER BY "deprecated_at" ASC`,
       [cutoffDate.toISOString()],
@@ -302,6 +310,6 @@ export class PostgresDeprecationRecorder implements IDeprecationRecorder {
    */
   async clear(): Promise<void> {
     await this.ensureTable();
-    await this._backend.executeRaw(`DELETE FROM "${this._tableName}"`);
+    await this._backend.executeRaw(`DELETE FROM ${this._qualifiedTable}`);
   }
 }

--- a/src/db/migrations/recorders/postgres_migration.ts
+++ b/src/db/migrations/recorders/postgres_migration.ts
@@ -8,6 +8,7 @@
  */
 
 import type { DatabaseBackend } from "../../backends/backend.ts";
+import type { PostgresBackend } from "../../backends/postgres/backend.ts";
 import type { IMigrationRecorder, MigrationRecord } from "./interfaces.ts";
 
 // ============================================================================
@@ -39,10 +40,17 @@ import type { IMigrationRecorder, MigrationRecord } from "./interfaces.ts";
 export class PostgresMigrationRecorder implements IMigrationRecorder {
   private _backend: DatabaseBackend;
   private _tableName = "_alexi_migrations";
+  private _schema: string;
   private _tableCreated = false;
 
   constructor(backend: DatabaseBackend) {
     this._backend = backend;
+    this._schema = (backend as unknown as PostgresBackend).schema ?? "public";
+  }
+
+  /** Fully schema-qualified table reference, e.g. `"public"."_alexi_migrations"` */
+  private get _qualifiedTable(): string {
+    return `"${this._schema}"."${this._tableName}"`;
   }
 
   // ==========================================================================
@@ -65,7 +73,7 @@ export class PostgresMigrationRecorder implements IMigrationRecorder {
 
   private async _createTable(): Promise<void> {
     const sql = `
-      CREATE TABLE IF NOT EXISTS "${this._tableName}" (
+      CREATE TABLE IF NOT EXISTS ${this._qualifiedTable} (
         "id" SERIAL PRIMARY KEY,
         "name" VARCHAR(255) NOT NULL UNIQUE,
         "app_label" VARCHAR(255) NOT NULL,
@@ -88,7 +96,7 @@ export class PostgresMigrationRecorder implements IMigrationRecorder {
     await this.ensureTable();
 
     const results = await this._backend.executeRaw<{ count: number }>(
-      `SELECT COUNT(*) as count FROM "${this._tableName}" WHERE "name" = $1`,
+      `SELECT COUNT(*) as count FROM ${this._qualifiedTable} WHERE "name" = $1`,
       [fullName],
     );
 
@@ -106,7 +114,7 @@ export class PostgresMigrationRecorder implements IMigrationRecorder {
       app_label: string;
       applied_at: string;
     }>(
-      `SELECT "name", "app_label", "applied_at" FROM "${this._tableName}" ORDER BY "applied_at" ASC`,
+      `SELECT "name", "app_label", "applied_at" FROM ${this._qualifiedTable} ORDER BY "applied_at" ASC`,
     );
 
     return results.map((row) => ({
@@ -129,7 +137,7 @@ export class PostgresMigrationRecorder implements IMigrationRecorder {
       app_label: string;
       applied_at: string;
     }>(
-      `SELECT "name", "app_label", "applied_at" FROM "${this._tableName}" 
+      `SELECT "name", "app_label", "applied_at" FROM ${this._qualifiedTable} 
        WHERE "app_label" = $1 ORDER BY "applied_at" ASC`,
       [appLabel],
     );
@@ -151,7 +159,7 @@ export class PostgresMigrationRecorder implements IMigrationRecorder {
     await this.ensureTable();
 
     await this._backend.executeRaw(
-      `INSERT INTO "${this._tableName}" ("name", "app_label", "applied_at") 
+      `INSERT INTO ${this._qualifiedTable} ("name", "app_label", "applied_at") 
        VALUES ($1, $2, CURRENT_TIMESTAMP)`,
       [fullName, appLabel],
     );
@@ -166,7 +174,7 @@ export class PostgresMigrationRecorder implements IMigrationRecorder {
     await this.ensureTable();
 
     await this._backend.executeRaw(
-      `DELETE FROM "${this._tableName}" WHERE "name" = $1`,
+      `DELETE FROM ${this._qualifiedTable} WHERE "name" = $1`,
       [fullName],
     );
   }
@@ -184,7 +192,7 @@ export class PostgresMigrationRecorder implements IMigrationRecorder {
       app_label: string;
       applied_at: string;
     }>(
-      `SELECT "name", "app_label", "applied_at" FROM "${this._tableName}" 
+      `SELECT "name", "app_label", "applied_at" FROM ${this._qualifiedTable} 
        WHERE "app_label" = $1 ORDER BY "applied_at" DESC LIMIT 1`,
       [appLabel],
     );
@@ -203,6 +211,6 @@ export class PostgresMigrationRecorder implements IMigrationRecorder {
    */
   async clear(): Promise<void> {
     await this.ensureTable();
-    await this._backend.executeRaw(`DELETE FROM "${this._tableName}"`);
+    await this._backend.executeRaw(`DELETE FROM ${this._qualifiedTable}`);
   }
 }


### PR DESCRIPTION
## Summary

- Adds `testIsolation: "schema"` option to `PostgresBackend` that uses `CREATE SCHEMA test_<timestamp>` instead of `CREATE DATABASE … TEMPLATE` for `migrate --test` isolation — works on Deno Deploy, Supabase, Railway and other managed environments where `CREATEDB` is not available
- Fixes `PostgresMigrationRecorder` and `PostgresDeprecationRecorder` to use schema-qualified table names (`"schema"."table"`), so recorder tables are created and queried in the correct schema when `testIsolation: "schema"` is used (also fixes a pre-existing bug where custom schema configs were ignored)

Closes #445