### PR TITLE
fix(admin): use updateFields in saveInstance() to avoid 500 on FK models

### DIFF
--- a/src/admin/tests/changeform_test.ts
+++ b/src/admin/tests/changeform_test.ts
@@ -814,6 +814,48 @@ Deno.test({
   },
 });
 
+Deno.test({
+  name:
+    "renderChangeForm: POST change with ForeignKey field succeeds (no 500) — #451",
+  async fn() {
+    const originalKey = Deno.env.get("SECRET_KEY");
+    if (originalKey) Deno.env.delete("SECRET_KEY");
+
+    const backend = await makeBackend();
+    try {
+      const category = await CategoryModel.objects.create({ name: "Tech" });
+      const categoryId = category.id.get() as number;
+      const article = await ArticleModel.objects.create({
+        title: "Original FK Article",
+        category: categoryId,
+      });
+      const id = String(article.id.get());
+
+      const site = makeSite();
+      site.register(ArticleModel, ModelAdmin);
+      // POST a change — category FK value submitted as plain integer string
+      const req = makePostRequest(
+        `/admin/articlemodel/${id}/`,
+        { title: "Updated FK Article", category: String(categoryId) },
+        makeValidToken(),
+      );
+      const res = await renderChangeForm(
+        { request: req, params: { id }, adminSite: site, backend },
+        "articlemodel",
+        id,
+      );
+      // Must redirect (302), not return 500
+      assertEquals(res.status, 302);
+
+      const updated = await ArticleModel.objects.get({ id: parseInt(id, 10) });
+      assertEquals(updated.title.get(), "Updated FK Article");
+    } finally {
+      await teardownBackend(backend);
+      if (originalKey) Deno.env.set("SECRET_KEY", originalKey);
+    }
+  },
+});
+
 // =============================================================================
 // readonlyFields support (#162)
 // =============================================================================

--- a/src/admin/views/changeform_views.ts
+++ b/src/admin/views/changeform_views.ts
@@ -541,7 +541,13 @@ async function saveInstance(
         }
       }
 
-      await (instance as { save(): Promise<void> }).save();
+      // Use updateFields to perform a partial update (PATCH-style). This
+      // avoids calling toDB() on ForeignKey fields that were not submitted
+      // (e.g. readonlyFields or unloaded relations), which would cause a
+      // runtime error. See: https://github.com/atzufuki/alexi/issues/451
+      await (instance as {
+        save(opts: { updateFields: string[] }): Promise<void>;
+      }).save({ updateFields: Object.keys(data) });
       const id = (instance as Record<string, { get(): unknown }>).id?.get();
       return { success: true, id };
     } else {


### PR DESCRIPTION
## Summary

- `saveInstance()` previously called `instance.save()` with no `updateFields`, causing a full `toDB()` on every field including unloaded `ForeignKey` relations → 500 on any admin change form POST for models with FK fields
- Fix: pass `save({ updateFields: Object.keys(data) })` so only the submitted (editable, non-readonly) fields are written — partial-update semantics that avoid touching unloaded FK relations
- Adds a regression test: `POST change with ForeignKey field succeeds (no 500) — #451`

Closes #451