### PR TITLE
fix(db,restframework): consistent FK filtering (#453)

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,13 +1,20 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@db/sqlite@0.12": "0.12.0",
+    "jsr:@denosaurs/plug@1": "1.1.0",
     "jsr:@luca/esbuild-deno-loader@~0.11.1": "0.11.1",
     "jsr:@std/assert@*": "1.0.19",
+    "jsr:@std/assert@0.217": "0.217.0",
     "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/bytes@^1.0.2": "1.0.6",
+    "jsr:@std/encoding@1": "1.0.10",
     "jsr:@std/encoding@^1.0.5": "1.0.10",
+    "jsr:@std/fmt@1": "1.0.9",
+    "jsr:@std/fs@1": "1.0.23",
     "jsr:@std/fs@^1.0.19": "1.0.23",
     "jsr:@std/internal@^1.0.12": "1.0.12",
+    "jsr:@std/path@0.217": "0.217.0",
     "jsr:@std/path@1": "1.1.4",
     "jsr:@std/path@^1.0.6": "1.1.4",
     "jsr:@std/path@^1.1.2": "1.1.4",
@@ -20,13 +27,32 @@
     "npm:playwright@^1.48.0": "1.58.2"
   },
   "jsr": {
+    "@db/sqlite@0.12.0": {
+      "integrity": "dd1ef7f621ad50fc1e073a1c3609c4470bd51edc0994139c5bf9851de7a6d85f",
+      "dependencies": [
+        "jsr:@denosaurs/plug",
+        "jsr:@std/path@0.217"
+      ]
+    },
+    "@denosaurs/plug@1.1.0": {
+      "integrity": "eb2f0b7546c7bca2000d8b0282c54d50d91cf6d75cb26a80df25a6de8c4bc044",
+      "dependencies": [
+        "jsr:@std/encoding@1",
+        "jsr:@std/fmt",
+        "jsr:@std/fs@1",
+        "jsr:@std/path@1"
+      ]
+    },
     "@luca/esbuild-deno-loader@0.11.1": {
       "integrity": "dc020d16d75b591f679f6b9288b10f38bdb4f24345edb2f5732affa1d9885267",
       "dependencies": [
         "jsr:@std/bytes",
-        "jsr:@std/encoding",
+        "jsr:@std/encoding@^1.0.5",
         "jsr:@std/path@^1.0.6"
       ]
+    },
+    "@std/assert@0.217.0": {
+      "integrity": "c98e279362ca6982d5285c3b89517b757c1e3477ee9f14eb2fdf80a45aaa9642"
     },
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
@@ -40,6 +66,9 @@
     "@std/encoding@1.0.10": {
       "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
     },
+    "@std/fmt@1.0.9": {
+      "integrity": "2487343e8899fb2be5d0e3d35013e54477ada198854e52dd05ed0422eddcabe0"
+    },
     "@std/fs@1.0.23": {
       "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
       "dependencies": [
@@ -50,6 +79,12 @@
     "@std/internal@1.0.12": {
       "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
     },
+    "@std/path@0.217.0": {
+      "integrity": "1217cc25534bca9a2f672d7fe7c6f356e4027df400c0e85c0ef3e4343bc67d11",
+      "dependencies": [
+        "jsr:@std/assert@0.217"
+      ]
+    },
     "@std/path@1.1.4": {
       "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
       "dependencies": [
@@ -59,7 +94,7 @@
     "@webui/deno-webui@2.5.13": {
       "integrity": "6f03345e19b943177766a30ed728a0e16c228757b5469bceee6092a7e18a25f9",
       "dependencies": [
-        "jsr:@std/fs",
+        "jsr:@std/fs@^1.0.19",
         "jsr:@std/path@^1.1.2",
         "jsr:@zip-js/zip-js"
       ]
@@ -318,8 +353,73 @@
     }
   },
   "remote": {
+    "https://deno.land/std@0.208.0/assert/_constants.ts": "8a9da298c26750b28b326b297316cdde860bc237533b07e1337c021379e6b2a9",
+    "https://deno.land/std@0.208.0/assert/_diff.ts": "58e1461cc61d8eb1eacbf2a010932bf6a05b79344b02ca38095f9b805795dc48",
+    "https://deno.land/std@0.208.0/assert/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
+    "https://deno.land/std@0.208.0/assert/assert.ts": "9a97dad6d98c238938e7540736b826440ad8c1c1e54430ca4c4e623e585607ee",
+    "https://deno.land/std@0.208.0/assert/assert_almost_equals.ts": "e15ca1f34d0d5e0afae63b3f5d975cbd18335a132e42b0c747d282f62ad2cd6c",
+    "https://deno.land/std@0.208.0/assert/assert_array_includes.ts": "6856d7f2c3544bc6e62fb4646dfefa3d1df5ff14744d1bca19f0cbaf3b0d66c9",
+    "https://deno.land/std@0.208.0/assert/assert_equals.ts": "d8ec8a22447fbaf2fc9d7c3ed2e66790fdb74beae3e482855d75782218d68227",
+    "https://deno.land/std@0.208.0/assert/assert_exists.ts": "407cb6b9fb23a835cd8d5ad804e2e2edbbbf3870e322d53f79e1c7a512e2efd7",
+    "https://deno.land/std@0.208.0/assert/assert_false.ts": "0ccbcaae910f52c857192ff16ea08bda40fdc79de80846c206bfc061e8c851c6",
+    "https://deno.land/std@0.208.0/assert/assert_greater.ts": "ae2158a2d19313bf675bf7251d31c6dc52973edb12ac64ac8fc7064152af3e63",
+    "https://deno.land/std@0.208.0/assert/assert_greater_or_equal.ts": "1439da5ebbe20855446cac50097ac78b9742abe8e9a43e7de1ce1426d556e89c",
+    "https://deno.land/std@0.208.0/assert/assert_instance_of.ts": "3aedb3d8186e120812d2b3a5dea66a6e42bf8c57a8bd927645770bd21eea554c",
+    "https://deno.land/std@0.208.0/assert/assert_is_error.ts": "c21113094a51a296ffaf036767d616a78a2ae5f9f7bbd464cd0197476498b94b",
+    "https://deno.land/std@0.208.0/assert/assert_less.ts": "aec695db57db42ec3e2b62e97e1e93db0063f5a6ec133326cc290ff4b71b47e4",
+    "https://deno.land/std@0.208.0/assert/assert_less_or_equal.ts": "5fa8b6a3ffa20fd0a05032fe7257bf985d207b85685fdbcd23651b70f928c848",
+    "https://deno.land/std@0.208.0/assert/assert_match.ts": "c4083f80600bc190309903c95e397a7c9257ff8b5ae5c7ef91e834704e672e9b",
+    "https://deno.land/std@0.208.0/assert/assert_not_equals.ts": "9f1acab95bd1f5fc9a1b17b8027d894509a745d91bac1718fdab51dc76831754",
+    "https://deno.land/std@0.208.0/assert/assert_not_instance_of.ts": "0c14d3dfd9ab7a5276ed8ed0b18c703d79a3d106102077ec437bfe7ed912bd22",
+    "https://deno.land/std@0.208.0/assert/assert_not_match.ts": "3796a5b0c57a1ce6c1c57883dd4286be13a26f715ea662318ab43a8491a13ab0",
+    "https://deno.land/std@0.208.0/assert/assert_not_strict_equals.ts": "4cdef83df17488df555c8aac1f7f5ec2b84ad161b6d0645ccdbcc17654e80c99",
+    "https://deno.land/std@0.208.0/assert/assert_object_match.ts": "d8fc2867cfd92eeacf9cea621e10336b666de1874a6767b5ec48988838370b54",
+    "https://deno.land/std@0.208.0/assert/assert_rejects.ts": "45c59724de2701e3b1f67c391d6c71c392363635aad3f68a1b3408f9efca0057",
+    "https://deno.land/std@0.208.0/assert/assert_strict_equals.ts": "b1f538a7ea5f8348aeca261d4f9ca603127c665e0f2bbfeb91fa272787c87265",
+    "https://deno.land/std@0.208.0/assert/assert_string_includes.ts": "b821d39ebf5cb0200a348863c86d8c4c4b398e02012ce74ad15666fc4b631b0c",
+    "https://deno.land/std@0.208.0/assert/assert_throws.ts": "63784e951475cb7bdfd59878cd25a0931e18f6dc32a6077c454b2cd94f4f4bcd",
+    "https://deno.land/std@0.208.0/assert/assertion_error.ts": "4d0bde9b374dfbcbe8ac23f54f567b77024fb67dbb1906a852d67fe050d42f56",
+    "https://deno.land/std@0.208.0/assert/equal.ts": "9f1a46d5993966d2596c44e5858eec821859b45f783a5ee2f7a695dfc12d8ece",
+    "https://deno.land/std@0.208.0/assert/fail.ts": "c36353d7ae6e1f7933d45f8ea51e358c8c4b67d7e7502028598fe1fea062e278",
+    "https://deno.land/std@0.208.0/assert/mod.ts": "37c49a26aae2b254bbe25723434dc28cd7532e444cf0b481a97c045d110ec085",
+    "https://deno.land/std@0.208.0/assert/unimplemented.ts": "d56fbeecb1f108331a380f72e3e010a1f161baa6956fd0f7cf3e095ae1a4c75a",
+    "https://deno.land/std@0.208.0/assert/unreachable.ts": "4600dc0baf7d9c15a7f7d234f00c23bca8f3eba8b140286aaca7aa998cf9a536",
+    "https://deno.land/std@0.208.0/fmt/colors.ts": "34b3f77432925eb72cf0bfb351616949746768620b8e5ead66da532f93d10ba2",
     "https://deno.land/std@0.208.0/testing/_test_suite.ts": "30f018feeb3835f12ab198d8a518f9089b1bcb2e8c838a8b615ab10d5005465c",
-    "https://deno.land/std@0.208.0/testing/bdd.ts": "c41f019786c4a9112aadb7e5a7bbcc711f58429ac5904b3855fa248ba5fa0ba6"
+    "https://deno.land/std@0.208.0/testing/bdd.ts": "c41f019786c4a9112aadb7e5a7bbcc711f58429ac5904b3855fa248ba5fa0ba6",
+    "https://deno.land/std@0.224.0/assert/_constants.ts": "a271e8ef5a573f1df8e822a6eb9d09df064ad66a4390f21b3e31f820a38e0975",
+    "https://deno.land/std@0.224.0/assert/assert.ts": "09d30564c09de846855b7b071e62b5974b001bb72a4b797958fe0660e7849834",
+    "https://deno.land/std@0.224.0/assert/assert_almost_equals.ts": "9e416114322012c9a21fa68e187637ce2d7df25bcbdbfd957cd639e65d3cf293",
+    "https://deno.land/std@0.224.0/assert/assert_array_includes.ts": "14c5094471bc8e4a7895fc6aa5a184300d8a1879606574cb1cd715ef36a4a3c7",
+    "https://deno.land/std@0.224.0/assert/assert_equals.ts": "3bbca947d85b9d374a108687b1a8ba3785a7850436b5a8930d81f34a32cb8c74",
+    "https://deno.land/std@0.224.0/assert/assert_exists.ts": "43420cf7f956748ae6ed1230646567b3593cb7a36c5a5327269279c870c5ddfd",
+    "https://deno.land/std@0.224.0/assert/assert_false.ts": "3e9be8e33275db00d952e9acb0cd29481a44fa0a4af6d37239ff58d79e8edeff",
+    "https://deno.land/std@0.224.0/assert/assert_greater.ts": "5e57b201fd51b64ced36c828e3dfd773412c1a6120c1a5a99066c9b261974e46",
+    "https://deno.land/std@0.224.0/assert/assert_greater_or_equal.ts": "9870030f997a08361b6f63400273c2fb1856f5db86c0c3852aab2a002e425c5b",
+    "https://deno.land/std@0.224.0/assert/assert_instance_of.ts": "e22343c1fdcacfaea8f37784ad782683ec1cf599ae9b1b618954e9c22f376f2c",
+    "https://deno.land/std@0.224.0/assert/assert_is_error.ts": "f856b3bc978a7aa6a601f3fec6603491ab6255118afa6baa84b04426dd3cc491",
+    "https://deno.land/std@0.224.0/assert/assert_less.ts": "60b61e13a1982865a72726a5fa86c24fad7eb27c3c08b13883fb68882b307f68",
+    "https://deno.land/std@0.224.0/assert/assert_less_or_equal.ts": "d2c84e17faba4afe085e6c9123a63395accf4f9e00150db899c46e67420e0ec3",
+    "https://deno.land/std@0.224.0/assert/assert_match.ts": "ace1710dd3b2811c391946954234b5da910c5665aed817943d086d4d4871a8b7",
+    "https://deno.land/std@0.224.0/assert/assert_not_equals.ts": "78d45dd46133d76ce624b2c6c09392f6110f0df9b73f911d20208a68dee2ef29",
+    "https://deno.land/std@0.224.0/assert/assert_not_instance_of.ts": "3434a669b4d20cdcc5359779301a0588f941ffdc2ad68803c31eabdb4890cf7a",
+    "https://deno.land/std@0.224.0/assert/assert_not_match.ts": "df30417240aa2d35b1ea44df7e541991348a063d9ee823430e0b58079a72242a",
+    "https://deno.land/std@0.224.0/assert/assert_not_strict_equals.ts": "37f73880bd672709373d6dc2c5f148691119bed161f3020fff3548a0496f71b8",
+    "https://deno.land/std@0.224.0/assert/assert_object_match.ts": "411450fd194fdaabc0089ae68f916b545a49d7b7e6d0026e84a54c9e7eed2693",
+    "https://deno.land/std@0.224.0/assert/assert_rejects.ts": "4bee1d6d565a5b623146a14668da8f9eb1f026a4f338bbf92b37e43e0aa53c31",
+    "https://deno.land/std@0.224.0/assert/assert_strict_equals.ts": "b4f45f0fd2e54d9029171876bd0b42dd9ed0efd8f853ab92a3f50127acfa54f5",
+    "https://deno.land/std@0.224.0/assert/assert_string_includes.ts": "496b9ecad84deab72c8718735373feb6cdaa071eb91a98206f6f3cb4285e71b8",
+    "https://deno.land/std@0.224.0/assert/assert_throws.ts": "c6508b2879d465898dab2798009299867e67c570d7d34c90a2d235e4553906eb",
+    "https://deno.land/std@0.224.0/assert/assertion_error.ts": "ba8752bd27ebc51f723702fac2f54d3e94447598f54264a6653d6413738a8917",
+    "https://deno.land/std@0.224.0/assert/equal.ts": "bddf07bb5fc718e10bb72d5dc2c36c1ce5a8bdd3b647069b6319e07af181ac47",
+    "https://deno.land/std@0.224.0/assert/fail.ts": "0eba674ffb47dff083f02ced76d5130460bff1a9a68c6514ebe0cdea4abadb68",
+    "https://deno.land/std@0.224.0/assert/mod.ts": "48b8cb8a619ea0b7958ad7ee9376500fe902284bb36f0e32c598c3dc34cbd6f3",
+    "https://deno.land/std@0.224.0/assert/unimplemented.ts": "8c55a5793e9147b4f1ef68cd66496b7d5ba7a9e7ca30c6da070c1a58da723d73",
+    "https://deno.land/std@0.224.0/assert/unreachable.ts": "5ae3dbf63ef988615b93eb08d395dda771c96546565f9e521ed86f6510c29e19",
+    "https://deno.land/std@0.224.0/fmt/colors.ts": "508563c0659dd7198ba4bbf87e97f654af3c34eb56ba790260f252ad8012e1c5",
+    "https://deno.land/std@0.224.0/internal/diff.ts": "6234a4b493ebe65dc67a18a0eb97ef683626a1166a1906232ce186ae9f65f4e6",
+    "https://deno.land/std@0.224.0/internal/format.ts": "0a98ee226fd3d43450245b1844b47003419d34d210fa989900861c79820d21c2",
+    "https://deno.land/std@0.224.0/internal/mod.ts": "534125398c8e7426183e12dc255bb635d94e06d0f93c60a297723abe69d3b22e"
   },
   "workspace": {
     "dependencies": [

--- a/src/db/backends/rest/backend.ts
+++ b/src/db/backends/rest/backend.ts
@@ -65,6 +65,7 @@
 import { DatabaseBackend } from "../backend.ts";
 import type { SchemaEditor, Transaction } from "../backend.ts";
 import { Model } from "../../models/model.ts";
+import { ForeignKey } from "../../fields/relations.ts";
 import type {
   Aggregations,
   CompiledQuery,
@@ -1039,9 +1040,18 @@ export class RestBackend extends DatabaseBackend {
     const params = new URLSearchParams();
 
     for (const filter of state.filters) {
+      // Reverse-translate column names back to field names before emitting as
+      // URL params. The queryset translates ForeignKey field names to column
+      // names (e.g. "author" → "author_id") for SQL/KV backends. However,
+      // REST APIs (and DRF's QueryParamFilterBackend) expect the field name
+      // form ("author"), not the column name form ("author_id").
+      const fieldName = this._getFieldNameFromColumnName(
+        state.model as unknown as new () => Model,
+        filter.field,
+      );
       const paramName = filter.lookup === "exact"
-        ? filter.field
-        : `${filter.field}__${filter.lookup}`;
+        ? fieldName
+        : `${fieldName}__${filter.lookup}`;
       params.set(paramName, String(filter.value));
     }
 
@@ -1554,6 +1564,48 @@ export class RestBackend extends DatabaseBackend {
     if (this._debug) {
       console.log("[RestBackend]", ...args);
     }
+  }
+
+  /**
+   * Reverse-translate a column name to the canonical field name on the model.
+   *
+   * The queryset pre-translates ForeignKey field names to column names
+   * (e.g. `"author"` → `"author_id"`) so SQL/KV backends receive the correct
+   * column identifier.  For REST requests we need the original field name
+   * because REST APIs (and DRF's `QueryParamFilterBackend`) expect field names,
+   * not column names, as URL query parameters.
+   *
+   * If `columnName` is already a plain field name (no FK mapping found) it is
+   * returned unchanged.
+   *
+   * @param modelClass - The model class whose fields are inspected.
+   * @param columnName - The column name to resolve (e.g. `"author_id"`).
+   * @returns The field name (e.g. `"author"`) or `columnName` unchanged.
+   */
+  private _getFieldNameFromColumnName(
+    modelClass: new () => Model,
+    columnName: string,
+  ): string {
+    try {
+      const instance = new modelClass();
+      const fields = instance.getFields() as Record<string, unknown>;
+
+      // Fast path: column name IS already a field name
+      if (fields[columnName] !== undefined) return columnName;
+
+      // Reverse-map: find any FK whose getColumnName() matches columnName
+      for (const [fieldName, field] of Object.entries(fields)) {
+        if (
+          field instanceof ForeignKey &&
+          field.getColumnName() === columnName
+        ) {
+          return fieldName;
+        }
+      }
+    } catch {
+      // If model introspection fails, return as-is
+    }
+    return columnName;
   }
 
   // ============================================================================

--- a/src/db/backends/sqlite/query_builder.ts
+++ b/src/db/backends/sqlite/query_builder.ts
@@ -368,8 +368,9 @@ export class SQLiteQueryBuilder<T extends Model> {
 
     return ordering
       .map((o) => {
-        // QueryState uses `descending: boolean`; reversed flips the direction.
-        const descending = this.state.reversed ? !o.descending : o.descending;
+        // ParsedOrdering uses `direction: "ASC" | "DESC"`; reversed flips the direction.
+        const isDesc = o.direction === "DESC";
+        const descending = this.state.reversed ? !isDesc : isDesc;
         return `${this.quote(o.field)} ${descending ? "DESC" : "ASC"}`;
       })
       .join(", ");

--- a/src/db/query/queryset.ts
+++ b/src/db/query/queryset.ts
@@ -435,6 +435,10 @@ export class QuerySet<T extends Model> implements AsyncIterable<T> {
   /**
    * Get the value of a field from a model instance
    * Supports nested field access (e.g., "author__name")
+   *
+   * Handles both the field name form ("author") and the column name form
+   * ("author_id") so that in-memory filtering after `.fetch()` works correctly
+   * for ForeignKey fields regardless of which form was stored in the filter.
    */
   private _getFieldValue(item: T, fieldPath: string): unknown {
     const parts = fieldPath.split("__");
@@ -446,11 +450,32 @@ export class QuerySet<T extends Model> implements AsyncIterable<T> {
         return null;
       }
 
-      // Check if it's a Field instance
+      // Check if it's a Field instance by its property name
       if (current[part] && typeof current[part].get === "function") {
         current = current[part].get();
-      } else {
+      } else if (current[part] !== undefined) {
         current = current[part];
+      } else {
+        // `part` was not found directly — it may be the column name of a FK
+        // (e.g. "author_id").  Walk the object's fields looking for a
+        // ForeignKey whose getColumnName() matches `part`.
+        let resolved = false;
+        if (typeof current === "object") {
+          for (const key of Object.keys(current)) {
+            const fieldObj = current[key];
+            if (
+              fieldObj instanceof ForeignKey &&
+              fieldObj.getColumnName() === part
+            ) {
+              current = fieldObj.id;
+              resolved = true;
+              break;
+            }
+          }
+        }
+        if (!resolved) {
+          current = undefined;
+        }
       }
     }
 

--- a/src/db/query/types.ts
+++ b/src/db/query/types.ts
@@ -209,7 +209,7 @@ export interface QueryState<T extends Model> {
   /** Filter conditions */
   filters: ParsedFilter[];
   /** Ordering specifications */
-  ordering: Array<{ field: string; descending: boolean }>;
+  ordering: ParsedOrdering[];
   /** Fields to select (empty = all) */
   selectFields: string[];
   /** Fields to defer loading */
@@ -289,7 +289,7 @@ export interface CompiledQuery {
     type: "select" | "insert" | "update" | "delete" | "count";
     table: string;
     filters: ParsedFilter[];
-    ordering: Array<{ field: string; descending: boolean }>;
+    ordering: ParsedOrdering[];
     fields: string[];
     limit: number | null;
     offset: number | null;

--- a/src/db/tests/foreignkey_test.ts
+++ b/src/db/tests/foreignkey_test.ts
@@ -1793,3 +1793,71 @@ Deno.test({
     }
   },
 });
+
+// ============================================================================
+// Issue #453: In-memory FK filtering after fetch()
+// ============================================================================
+
+Deno.test({
+  name:
+    "QuerySet - in-memory filter({ fkField: id }) works after fetch() (Issue #453)",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const backend = new DenoKVBackend({
+      name: "fk453-inmemory-1",
+      path: ":memory:",
+    });
+    await backend.connect();
+    registerBackend("default", backend);
+
+    try {
+      const org1 = await Organisation.objects.create({
+        name: "Org One",
+        country: "Finland",
+      });
+      const org2 = await Organisation.objects.create({
+        name: "Org Two",
+        country: "Sweden",
+      });
+
+      await Project.objects.create({
+        name: "Project A",
+        organisation: org1,
+      });
+      await Project.objects.create({
+        name: "Project B",
+        organisation: org2,
+      });
+      await Project.objects.create({
+        name: "Project C",
+        organisation: org1,
+      });
+
+      // Fetch all, then in-memory filter by FK field name
+      const allProjects = await Project.objects.all().fetch();
+      assertEquals(allProjects.array().length, 3);
+
+      // Filter using FK field name form ("organisation")
+      const org1Projects = allProjects.filter({ organisation: org1.id.get() });
+      assertEquals(
+        org1Projects.array().length,
+        2,
+        "filter({ organisation: id }) should return 2 projects for org1",
+      );
+
+      // Filter using FK column name form ("organisation_id")
+      const org2Projects = allProjects.filter({
+        organisation_id: org2.id.get(),
+      });
+      assertEquals(
+        org2Projects.array().length,
+        1,
+        "filter({ organisation_id: id }) should return 1 project for org2",
+      );
+    } finally {
+      await reset();
+      await backend.disconnect();
+    }
+  },
+});

--- a/src/db/tests/rest_backend_extract_test.ts
+++ b/src/db/tests/rest_backend_extract_test.ts
@@ -4,6 +4,9 @@
  * Tests that ForeignKey fields are correctly serialized using .id
  * instead of .get() which throws when the relation is not loaded.
  *
+ * Also covers Issue #453: FK column names must be reverse-translated back to
+ * field names when building URL query parameters for REST requests.
+ *
  * @module
  */
 
@@ -17,7 +20,8 @@ import {
   Model,
 } from "../mod.ts";
 import { ForeignKey, OnDelete } from "../fields/relations.ts";
-import { RestBackend } from "../backends/rest/mod.ts";
+import { ModelEndpoint, RestBackend } from "../backends/rest/mod.ts";
+import { createQueryState } from "../query/types.ts";
 
 // ============================================================================
 // Test Models
@@ -61,6 +65,34 @@ class ProjectRole extends Model {
   static override meta = {
     dbTable: "project_roles",
   };
+}
+
+// ============================================================================
+// Test Helper: Intercept fetch calls (Fix #453)
+// ============================================================================
+
+type FetchCall = { url: string; options?: RequestInit };
+
+class ProjectEndpoint extends ModelEndpoint {
+  model = Project;
+  path = "/projects/";
+}
+
+class TrackingRestBackend extends RestBackend {
+  fetchCalls: FetchCall[] = [];
+
+  constructor(apiUrl = "http://test.local/api") {
+    super({ apiUrl, endpoints: [ProjectEndpoint] });
+  }
+
+  // deno-lint-ignore require-await
+  protected override async request<T>(
+    path: string,
+    options?: RequestInit,
+  ): Promise<T> {
+    this.fetchCalls.push({ url: path, options });
+    return [] as unknown as T;
+  }
 }
 
 // ============================================================================
@@ -223,5 +255,81 @@ Deno.test({
     assertEquals(data.name, "Lead Developer");
     assertEquals(data.description, "Leads the dev team");
     assertEquals(data.project, 99);
+  },
+});
+
+// ============================================================================
+// RestBackend execute() — FK column name reverse-translation (Issue #453)
+// ============================================================================
+
+Deno.test({
+  name:
+    "RestBackend execute() — FK filter emitted as field name, not column name (Issue #453)",
+  async fn() {
+    // When a queryset has filter({ organisation: 1 }), the queryset pre-translates
+    // it to { field: "organisation_id", value: 1 } in state.filters.
+    // The REST backend must reverse-translate "organisation_id" back to
+    // "organisation" when building the URL, so the server receives ?organisation=1
+    // instead of ?organisation_id=1.
+    const backend = new TrackingRestBackend();
+    await backend.connect();
+
+    const state = createQueryState(Project);
+    // Simulate the translated filter that queryset produces for filter({ organisation: 1 })
+    state.filters = [{
+      field: "organisation_id",
+      lookup: "exact",
+      value: 1,
+      negated: false,
+    }];
+
+    await backend.execute(state);
+
+    assertEquals(backend.fetchCalls.length, 1);
+    const requestedUrl = backend.fetchCalls[0].url;
+
+    // Must use field name "organisation", not column name "organisation_id"
+    assertEquals(
+      requestedUrl.includes("organisation=1"),
+      true,
+      `Expected ?organisation=1 in URL but got: ${requestedUrl}`,
+    );
+    assertEquals(
+      requestedUrl.includes("organisation_id=1"),
+      false,
+      `URL must not contain organisation_id=1: ${requestedUrl}`,
+    );
+
+    await backend.disconnect();
+  },
+});
+
+Deno.test({
+  name:
+    "RestBackend execute() — non-FK filter field name unchanged (Issue #453)",
+  async fn() {
+    // Plain (non-FK) field names must pass through unchanged.
+    const backend = new TrackingRestBackend();
+    await backend.connect();
+
+    const state = createQueryState(Project);
+    state.filters = [{
+      field: "name",
+      lookup: "exact",
+      value: "Test",
+      negated: false,
+    }];
+
+    await backend.execute(state);
+
+    assertEquals(backend.fetchCalls.length, 1);
+    const requestedUrl = backend.fetchCalls[0].url;
+    assertEquals(
+      requestedUrl.includes("name=Test"),
+      true,
+      `Expected ?name=Test in URL but got: ${requestedUrl}`,
+    );
+
+    await backend.disconnect();
   },
 });

--- a/src/restframework/filters/filter_backend.ts
+++ b/src/restframework/filters/filter_backend.ts
@@ -7,7 +7,7 @@
  * @module @alexi/restframework/filters/filter_backend
  */
 
-import type { Model, QuerySet } from "@alexi/db";
+import { ForeignKey, type Model, type QuerySet } from "@alexi/db";
 import type { ViewSetContext } from "../viewsets/viewset.ts";
 
 export type { Model, QuerySet } from "@alexi/db";
@@ -143,13 +143,17 @@ export class QueryParamFilterBackend implements FilterBackend {
       // Parse the key to extract field name and lookup
       const { field, lookup } = this.parseFilterKey(key);
 
-      // Only allow filtering on configured fields
-      if (!allowedFields.includes(field)) {
+      // Only allow filtering on configured fields.
+      // Accept both the field name ("author") and the column name ("author_id")
+      // so that the REST backend's FK column-name translation is transparent.
+      const resolvedField = this.resolveFieldName(field, queryset);
+      if (!allowedFields.includes(resolvedField)) {
         continue;
       }
 
-      // Build the filter key (with lookup if present)
-      const filterKey = lookup ? `${field}__${lookup}` : field;
+      // Build the filter key using the resolved (field-name) form so the ORM
+      // can do its own FK translation correctly downstream.
+      const filterKey = lookup ? `${resolvedField}__${lookup}` : resolvedField;
 
       // Parse and set the value
       filterConditions[filterKey] = this.parseFilterValue(value, lookup);
@@ -161,6 +165,46 @@ export class QueryParamFilterBackend implements FilterBackend {
     }
 
     return queryset;
+  }
+
+  /**
+   * Resolve a URL param field name to the canonical field name on the model.
+   *
+   * If `field` matches the column name of a ForeignKey (e.g. `"author_id"`),
+   * returns the corresponding field name (e.g. `"author"`).  Otherwise returns
+   * `field` unchanged.
+   *
+   * This makes `filtersetFields = ["author"]` accept both `?author=5` and
+   * `?author_id=5`, matching Django's behaviour.
+   */
+  private resolveFieldName<T extends Model>(
+    field: string,
+    queryset: QuerySet<T>,
+  ): string {
+    try {
+      // deno-lint-ignore no-explicit-any
+      const state = (queryset as any)._state;
+      if (!state?.model) return field;
+      const instance = new state.model();
+      const fields = instance.getFields() as Record<string, unknown>;
+
+      // Check direct match first (most common path)
+      if (fields[field] !== undefined) return field;
+
+      // Check if field is a column-name alias for any FK field
+      for (const [fieldName, fieldObj] of Object.entries(fields)) {
+        if (
+          fieldObj instanceof ForeignKey &&
+          fieldObj.getColumnName() === field
+        ) {
+          return fieldName;
+        }
+      }
+    } catch {
+      // If model introspection fails, return field as-is
+    }
+
+    return field;
   }
 
   /**

--- a/src/restframework/tests/filters_test.ts
+++ b/src/restframework/tests/filters_test.ts
@@ -19,8 +19,11 @@ import {
   BooleanField,
   CharField,
   DateTimeField,
+  ForeignKey,
   IntegerField,
+  Manager,
   Model,
+  OnDelete,
   QuerySet,
 } from "@alexi/db";
 
@@ -473,3 +476,104 @@ Deno.test("SearchFilter - returns unfiltered when search param is whitespace onl
 
   assertEquals(filtered.state.filters.length, 0);
 });
+
+// ============================================================================
+// ForeignKey Filter Tests (Issue #453)
+// ============================================================================
+
+class TestAuthorModel extends Model {
+  id = new AutoField({ primaryKey: true });
+  name = new CharField({ maxLength: 100 });
+
+  static objects = new Manager(TestAuthorModel);
+  static override meta = { dbTable: "test_authors" };
+}
+
+class TestArticleModel extends Model {
+  id = new AutoField({ primaryKey: true });
+  title = new CharField({ maxLength: 200 });
+  author = new ForeignKey<TestAuthorModel>(TestAuthorModel, {
+    onDelete: OnDelete.CASCADE,
+  });
+
+  static objects = new Manager(TestArticleModel);
+  static override meta = { dbTable: "test_articles" };
+}
+
+Deno.test(
+  "QueryParamFilterBackend - FK field name accepted when filtersetFields uses field name",
+  () => {
+    // ?author=5 with filtersetFields = ["author"] → should filter
+    const backend = new QueryParamFilterBackend();
+    const queryset = new QuerySet(TestArticleModel);
+    const context = createMockContext(
+      "http://localhost/api/articles/?author=5",
+    );
+    const viewset = createMockViewSet({ filtersetFields: ["author"] });
+
+    const filtered = backend.filterQueryset(queryset, context, viewset);
+
+    // Filter should be accepted and translated to the FK field name
+    assertEquals(filtered.state.filters.length, 1);
+    assertEquals(filtered.state.filters[0].field, "author_id");
+    assertEquals(filtered.state.filters[0].value, 5);
+  },
+);
+
+Deno.test(
+  "QueryParamFilterBackend - FK column name accepted when filtersetFields uses field name (Issue #453)",
+  () => {
+    // ?author_id=5 with filtersetFields = ["author"]
+    // Before the fix this was silently dropped, causing a data leak.
+    const backend = new QueryParamFilterBackend();
+    const queryset = new QuerySet(TestArticleModel);
+    const context = createMockContext(
+      "http://localhost/api/articles/?author_id=5",
+    );
+    const viewset = createMockViewSet({ filtersetFields: ["author"] });
+
+    const filtered = backend.filterQueryset(queryset, context, viewset);
+
+    // author_id must resolve to "author" in the allow-list check and then
+    // be passed to the queryset as "author" so the ORM translates it to
+    // "author_id" internally.
+    assertEquals(filtered.state.filters.length, 1);
+    assertEquals(filtered.state.filters[0].field, "author_id");
+    assertEquals(filtered.state.filters[0].value, 5);
+  },
+);
+
+Deno.test(
+  "QueryParamFilterBackend - FK column name with lookup accepted (Issue #453)",
+  () => {
+    // ?author_id__in=1,2,3 with filtersetFields = ["author"]
+    const backend = new QueryParamFilterBackend();
+    const queryset = new QuerySet(TestArticleModel);
+    const context = createMockContext(
+      "http://localhost/api/articles/?author_id__in=1,2,3",
+    );
+    const viewset = createMockViewSet({ filtersetFields: ["author"] });
+
+    const filtered = backend.filterQueryset(queryset, context, viewset);
+
+    assertEquals(filtered.state.filters.length, 1);
+    assertEquals(filtered.state.filters[0].field, "author_id");
+    assertEquals(filtered.state.filters[0].lookup, "in");
+  },
+);
+
+Deno.test(
+  "QueryParamFilterBackend - non-FK fields still rejected if not in filtersetFields",
+  () => {
+    const backend = new QueryParamFilterBackend();
+    const queryset = new QuerySet(TestArticleModel);
+    const context = createMockContext(
+      "http://localhost/api/articles/?secret=hidden",
+    );
+    const viewset = createMockViewSet({ filtersetFields: ["author"] });
+
+    const filtered = backend.filterQueryset(queryset, context, viewset);
+
+    assertEquals(filtered.state.filters.length, 0);
+  },
+);


### PR DESCRIPTION
## Summary

- **`QueryParamFilterBackend`**: add `resolveFieldName()` to reverse-map FK column names (e.g. `author_id`) back to field names (`author`) for the `filtersetFields` allow-list check. Previously `filtersetFields = ["author"]` silently dropped `?author_id=1` params, returning all records instead of filtering — a data-leak bug.
- **`RestBackend`**: add `_getFieldNameFromColumnName()` to reverse-map column names back to field names before building URL query params. The ORM's `_parseConditionKey` pre-translates FK field names to column names, so the server was receiving `?author_id=1` instead of the expected `?author=1`.
- **`QuerySet._getFieldValue`**: add FK column-name fallback so in-memory filtering after `.fetch()` correctly matches `ForeignKey` instances by their stored ID instead of silently returning 0 matches.
- **`QueryState.ordering` type**: fix to use `ParsedOrdering[]` (`direction: "ASC" | "DESC"`) aligning the type declaration with what `_parseOrdering()` actually stores; update SQLite `query_builder` and `RestBackend` ordering serialisation to use `o.direction` consistently. This also fixes 13 pre-existing TypeScript errors.

Closes #453