### PR TITLE
fix(db): resolve FK column name in deprecateField and add dropModel

### DIFF
--- a/src/db/migrations/executor_integration_test.ts
+++ b/src/db/migrations/executor_integration_test.ts
@@ -955,3 +955,249 @@ Deno.test({
     }
   },
 });
+
+// ============================================================================
+// fix #455 — deprecateField with explicit field arg resolves FK column name
+// ============================================================================
+
+class ProviderModel455 extends Model {
+  id = new AutoField({ primaryKey: true });
+  name = new CharField({ maxLength: 100 });
+
+  static objects = new Manager(ProviderModel455);
+  static override meta = { dbTable: "providers_455" };
+}
+
+class TicketModel455 extends Model {
+  id = new AutoField({ primaryKey: true });
+  title = new CharField({ maxLength: 200 });
+  provider = new ForeignKey<ProviderModel455>("ProviderModel455", {
+    onDelete: OnDelete.CASCADE,
+  });
+
+  static objects = new Manager(TicketModel455);
+  static override meta = { dbTable: "tickets_455" };
+}
+
+class Migration455Base extends Migration {
+  name = "myapp455.0001_base";
+  override dependencies = [];
+
+  async forwards(schema: MigrationSchemaEditor): Promise<void> {
+    await schema.createModel(ProviderModel455);
+    await schema.createModel(TicketModel455);
+  }
+
+  override async backwards(schema: MigrationSchemaEditor): Promise<void> {
+    await schema.dropModel(TicketModel455);
+    await schema.dropModel(ProviderModel455);
+  }
+}
+
+/** Explicitly deprecates the FK field using the field instance */
+class Migration455DeprecateFk extends Migration {
+  name = "myapp455.0002_deprecate_provider";
+  override dependencies = ["myapp455.0001_base"];
+
+  async forwards(schema: MigrationSchemaEditor): Promise<void> {
+    await schema.deprecateField(
+      TicketModel455,
+      "provider",
+      new ForeignKey<ProviderModel455>("ProviderModel455", {
+        onDelete: OnDelete.CASCADE,
+      }),
+    );
+  }
+
+  override async backwards(schema: MigrationSchemaEditor): Promise<void> {
+    await schema.restoreField(TicketModel455, "provider_id");
+  }
+}
+
+Deno.test({
+  name:
+    "fix #455 — deprecateField with FK field arg renames provider_id, not provider",
+  async fn() {
+    const backend = new SQLiteBackend({ path: ":memory:" });
+    await backend.connect();
+
+    const loader = new MigrationLoader();
+    loader.register(new Migration455Base(), "myapp455");
+    loader.register(new Migration455DeprecateFk(), "myapp455");
+
+    const executor = new MigrationExecutor(backend, loader);
+
+    const db = (backend as unknown as {
+      _db: {
+        prepare: (s: string) => { all: () => Array<{ name: string }> };
+      };
+    })._db;
+
+    try {
+      // Apply forwards: create tables + deprecate provider_id
+      const fwdResults = await executor.migrate({ verbosity: 0 });
+      for (const r of fwdResults) {
+        assertEquals(r.success, true, `forwards failed: ${r.error}`);
+      }
+
+      // After forwards, provider_id must be renamed to _deprecated_*_provider_id
+      const colsAfterFwd: Array<{ name: string }> = db
+        .prepare(`PRAGMA table_info(tickets_455)`)
+        .all();
+
+      const hasProviderIdAfterFwd = colsAfterFwd.some(
+        (c) => c.name === "provider_id",
+      );
+      assertEquals(
+        hasProviderIdAfterFwd,
+        false,
+        "provider_id must be renamed after deprecateField forwards()",
+      );
+
+      const hasDeprecatedProviderId = colsAfterFwd.some(
+        (c) =>
+          c.name.startsWith("_deprecated_") &&
+          c.name.endsWith("_provider_id"),
+      );
+      assertEquals(
+        hasDeprecatedProviderId,
+        true,
+        "deprecated provider_id column must exist (fix #455: column was 'provider', not 'provider_id')",
+      );
+
+      // Roll back migration 0002
+      const bwdResults = await executor.migrate({
+        to: "myapp455.0001_base",
+        verbosity: 0,
+      });
+      for (const r of bwdResults) {
+        assertEquals(
+          r.success,
+          true,
+          `backwards failed: ${r.error}`,
+        );
+      }
+
+      // After backwards, provider_id must be restored
+      const colsAfterBwd: Array<{ name: string }> = db
+        .prepare(`PRAGMA table_info(tickets_455)`)
+        .all();
+      const hasProviderIdAfterBwd = colsAfterBwd.some(
+        (c) => c.name === "provider_id",
+      );
+      assertEquals(
+        hasProviderIdAfterBwd,
+        true,
+        "provider_id must be restored after backwards()",
+      );
+    } finally {
+      await backend.disconnect();
+    }
+  },
+});
+
+// ============================================================================
+// fix #456 — dropModel permanently drops the table
+// ============================================================================
+
+class ThreadModel456 extends Model {
+  id = new AutoField({ primaryKey: true });
+  body = new CharField({ maxLength: 1000 });
+
+  static objects = new Manager(ThreadModel456);
+  static override meta = { dbTable: "threads_456" };
+}
+
+class Migration456Create extends Migration {
+  name = "myapp456.0001_create_threads";
+  override dependencies = [];
+
+  async forwards(schema: MigrationSchemaEditor): Promise<void> {
+    await schema.createModel(ThreadModel456);
+  }
+
+  override async backwards(schema: MigrationSchemaEditor): Promise<void> {
+    await schema.dropModel(ThreadModel456);
+  }
+}
+
+Deno.test({
+  name: "fix #456 — dropModel permanently drops the table (not rename)",
+  async fn() {
+    const backend = new SQLiteBackend({ path: ":memory:" });
+    await backend.connect();
+
+    const loader = new MigrationLoader();
+    loader.register(new Migration456Create(), "myapp456");
+
+    const executor = new MigrationExecutor(backend, loader);
+
+    const db = (backend as unknown as {
+      _db: {
+        prepare: (s: string) => {
+          all: () => Array<{ name: string }>;
+          get: () => { count: number } | undefined;
+        };
+      };
+    })._db;
+
+    try {
+      // Apply forwards: create threads_456 table
+      const fwdResults = await executor.migrate({ verbosity: 0 });
+      for (const r of fwdResults) {
+        assertEquals(r.success, true, `forwards failed: ${r.error}`);
+      }
+
+      // Verify the table exists
+      const tableExistsAfterFwd = db
+        .prepare(
+          `SELECT count(*) as count FROM sqlite_master WHERE type='table' AND name='threads_456'`,
+        )
+        .get();
+      assertEquals(
+        tableExistsAfterFwd?.count,
+        1,
+        "threads_456 must exist after forwards()",
+      );
+
+      // Roll back: backwards() calls dropModel → should permanently delete
+      const bwdResults = await executor.migrate({
+        to: "zero",
+        verbosity: 0,
+      });
+      for (const r of bwdResults) {
+        assertEquals(
+          r.success,
+          true,
+          `backwards failed: ${r.error}`,
+        );
+      }
+
+      // Table must be gone entirely (not renamed to _deprecated_*)
+      const tableExistsAfterBwd = db
+        .prepare(
+          `SELECT count(*) as count FROM sqlite_master WHERE type='table' AND name='threads_456'`,
+        )
+        .get();
+      assertEquals(
+        tableExistsAfterBwd?.count,
+        0,
+        "threads_456 must be permanently dropped after backwards() dropModel()",
+      );
+
+      // Also confirm no _deprecated_* table was created
+      const deprecatedExists = db
+        .prepare(
+          `SELECT count(*) as count FROM sqlite_master WHERE type='table' AND name LIKE '_deprecated_%threads_456'`,
+        )
+        .get();
+      assertEquals(
+        deprecatedExists?.count,
+        0,
+        "No deprecated table must exist — dropModel drops permanently",
+      );
+    } finally {
+      await backend.disconnect();
+    }
+  },
+});

--- a/src/db/migrations/schema_editor.ts
+++ b/src/db/migrations/schema_editor.ts
@@ -34,13 +34,19 @@ export type ForwardsOp =
     model: typeof Model;
     tableName: string;
   }
+  | { type: "dropModel"; tableName: string }
   | {
     type: "addField";
     model: typeof Model;
     fieldName: string;
     field: AnyField;
   }
-  | { type: "deprecateField"; model: typeof Model; fieldName: string }
+  | {
+    type: "deprecateField";
+    model: typeof Model;
+    fieldName: string;
+    columnName: string;
+  }
   | {
     type: "alterField";
     model: typeof Model;
@@ -318,6 +324,40 @@ export class MigrationSchemaEditor {
   }
 
   /**
+   * Drop a model's table permanently.
+   *
+   * **Warning:** This permanently deletes the table and all its data.
+   * Use {@link deprecateModel} instead if you want to preserve data.
+   *
+   * This is the correct operation to use in `backwards()` to reverse a
+   * `createModel` call in `forwards()` — the table did not exist before
+   * the migration ran, so it should be dropped entirely rather than renamed.
+   *
+   * @param model - Model class whose table should be dropped
+   *
+   * @example
+   * ```ts
+   * async forwards(schema: MigrationSchemaEditor): Promise<void> {
+   *   await schema.createModel(TicketThreadModel);
+   * }
+   *
+   * async backwards(schema: MigrationSchemaEditor): Promise<void> {
+   *   await schema.dropModel(TicketThreadModel);
+   * }
+   * ```
+   */
+  async dropModel(model: typeof Model): Promise<void> {
+    const tableName = this._getTableName(model);
+
+    this._log(`Dropping table for ${model.name}...`);
+    if (!this._recordOnly) {
+      await this._backendEditor.dropTable(tableName);
+    }
+    this._operationLog.push({ type: "dropModel", tableName });
+    this._logVerbose(`  Dropped table: ${tableName}`);
+  }
+
+  /**
    * Restore a deprecated model (reverse deprecation)
    *
    * @param originalTableName - Original table name before deprecation
@@ -401,16 +441,26 @@ export class MigrationSchemaEditor {
    *
    * This preserves the data but frees the column name for reuse.
    *
+   * For `ForeignKey` and `OneToOneField` fields the actual database column has
+   * an `_id` suffix (e.g. field `"provider"` → column `"provider_id"`).
+   * Pass the optional `field` argument so the correct column name is resolved
+   * automatically; without it the JS field name is used as-is.
+   *
    * @param model - Model class
-   * @param fieldName - Field name to deprecate
+   * @param fieldName - JS field name to deprecate (e.g. `"provider"`)
+   * @param field - Optional field instance used to resolve the column name
    * @returns Deprecation info for tracking
    */
   async deprecateField(
     model: typeof Model,
     fieldName: string,
+    field?: AnyField,
   ): Promise<DeprecationInfo> {
     const tableName = this._getTableName(model);
-    const deprecatedName = this._getDeprecatedName(fieldName);
+    const columnName = field
+      ? this._resolveColumnName(fieldName, field)
+      : fieldName;
+    const deprecatedName = this._getDeprecatedName(columnName);
 
     this._log(`Deprecating field ${fieldName} on ${model.name}...`);
 
@@ -429,14 +479,14 @@ export class MigrationSchemaEditor {
       }
       await this._backendEditor.renameColumn(
         tableName,
-        fieldName,
+        columnName,
         deprecatedName,
       );
     }
 
     const info: DeprecationInfo = {
       type: "field",
-      originalName: fieldName,
+      originalName: columnName,
       deprecatedName,
       migrationName: this._migrationName,
       tableName,
@@ -444,8 +494,13 @@ export class MigrationSchemaEditor {
     };
 
     this._deprecations.push(info);
-    this._operationLog.push({ type: "deprecateField", model, fieldName });
-    this._logVerbose(`  Renamed ${fieldName} → ${deprecatedName}`);
+    this._operationLog.push({
+      type: "deprecateField",
+      model,
+      fieldName,
+      columnName,
+    });
+    this._logVerbose(`  Renamed ${columnName} → ${deprecatedName}`);
 
     return info;
   }
@@ -689,6 +744,7 @@ export class MigrationSchemaEditor {
    * |---|---|
    * | `createModel` | `deprecateModel` |
    * | `deprecateModel` | `restoreModel` |
+   * | `dropModel` | *(skipped — table was permanently dropped)* |
    * | `addField` | `deprecateField` |
    * | `deprecateField` | `restoreField` |
    * | `alterField(new)` | restores original column from deprecated slot |
@@ -719,6 +775,13 @@ export class MigrationSchemaEditor {
           await this.restoreModel(op.tableName, this._migrationName);
           break;
 
+        case "dropModel":
+          // Table was permanently dropped — cannot auto-recreate.
+          this._logVerbose(
+            `  Skipping auto-reverse of dropModel(${op.tableName}) — table was permanently dropped`,
+          );
+          break;
+
         case "addField":
           await this.deprecateField(
             op.model,
@@ -727,7 +790,11 @@ export class MigrationSchemaEditor {
           break;
 
         case "deprecateField":
-          await this.restoreField(op.model, op.fieldName, this._migrationName);
+          await this.restoreField(
+            op.model,
+            op.columnName,
+            this._migrationName,
+          );
           break;
 
         case "alterField": {

--- a/src/db/migrations/schema_editor_test.ts
+++ b/src/db/migrations/schema_editor_test.ts
@@ -13,7 +13,14 @@ import { assertEquals, assertRejects } from "jsr:@std/assert@1";
 import type { IBackendSchemaEditor } from "./schema_editor.ts";
 import { MigrationSchemaEditor } from "./schema_editor.ts";
 import type { DatabaseBackend } from "../backends/backend.ts";
-import { AutoField, CharField, Manager, Model } from "../mod.ts";
+import {
+  AutoField,
+  CharField,
+  ForeignKey,
+  Manager,
+  Model,
+  OnDelete,
+} from "../mod.ts";
 
 // ============================================================================
 // Stubs
@@ -39,6 +46,13 @@ class UserModel extends Model {
   id = new AutoField({ primaryKey: true });
   name = new CharField({ maxLength: 100 });
   static objects = new Manager(UserModel);
+}
+
+class CategoryModel extends Model {
+  static override meta = { dbTable: "categories" };
+  id = new AutoField({ primaryKey: true });
+  name = new CharField({ maxLength: 100 });
+  static objects = new Manager(CategoryModel);
 }
 
 // ---------------------------------------------------------------------------
@@ -321,5 +335,119 @@ Deno.test(
     if (bwdLog[1].type === "deprecateModel") {
       assertEquals(bwdLog[1].tableName, "users");
     }
+  },
+);
+
+// ============================================================================
+// fix #455 — deprecateField resolves FK column name (_id suffix)
+// ============================================================================
+
+Deno.test(
+  "MigrationSchemaEditor: deprecateField without field arg uses fieldName as-is",
+  async () => {
+    const editor = makeEditor();
+    await editor.deprecateField(ArticleModel, "title");
+
+    const log = editor.getOperationLog();
+    assertEquals(log.length, 1);
+    assertEquals(log[0].type, "deprecateField");
+    if (log[0].type === "deprecateField") {
+      assertEquals(log[0].fieldName, "title");
+      // No field provided → columnName equals fieldName
+      assertEquals(log[0].columnName, "title");
+    }
+  },
+);
+
+Deno.test(
+  "MigrationSchemaEditor: deprecateField with ForeignKey field resolves _id suffix",
+  async () => {
+    const editor = makeEditor();
+    const fkField = new ForeignKey<CategoryModel>("CategoryModel", {
+      onDelete: OnDelete.CASCADE,
+    });
+    await editor.deprecateField(ArticleModel, "category", fkField);
+
+    const log = editor.getOperationLog();
+    assertEquals(log.length, 1);
+    assertEquals(log[0].type, "deprecateField");
+    if (log[0].type === "deprecateField") {
+      assertEquals(log[0].fieldName, "category");
+      // ForeignKey → column name must be category_id
+      assertEquals(log[0].columnName, "category_id");
+    }
+  },
+);
+
+Deno.test(
+  "MigrationSchemaEditor: deprecateField with CharField field keeps fieldName",
+  async () => {
+    const editor = makeEditor();
+    const field = new CharField({ maxLength: 50 });
+    await editor.deprecateField(ArticleModel, "slug", field);
+
+    const log = editor.getOperationLog();
+    assertEquals(log.length, 1);
+    if (log[0].type === "deprecateField") {
+      assertEquals(log[0].columnName, "slug");
+    }
+  },
+);
+
+Deno.test(
+  "MigrationSchemaEditor.autoReverse: reverses deprecateField FK → restoreField uses columnName",
+  async () => {
+    // If a FK field was deprecated in forwards(), autoReverse must
+    // restore using the DB column name (category_id), not the JS field
+    // name (category).
+    const fwdEditor = makeEditor("0003_remove_fk");
+    const fkField = new ForeignKey<CategoryModel>("CategoryModel", {
+      onDelete: OnDelete.CASCADE,
+    });
+    await fwdEditor.deprecateField(ArticleModel, "category", fkField);
+    const log = fwdEditor.getOperationLog();
+
+    // Verify the recorded columnName is category_id
+    if (log[0].type === "deprecateField") {
+      assertEquals(log[0].columnName, "category_id");
+    }
+
+    // autoReverse should call restoreField without error (recordOnly)
+    const bwdEditor = makeEditor("0003_remove_fk");
+    await bwdEditor.autoReverse(log); // must not throw
+  },
+);
+
+// ============================================================================
+// fix #456 — dropModel method
+// ============================================================================
+
+Deno.test("MigrationSchemaEditor: records dropModel op", async () => {
+  const editor = makeEditor();
+  await editor.dropModel(ArticleModel);
+
+  const log = editor.getOperationLog();
+  assertEquals(log.length, 1);
+  assertEquals(log[0].type, "dropModel");
+  if (log[0].type === "dropModel") {
+    assertEquals(log[0].tableName, "articles");
+  }
+});
+
+Deno.test(
+  "MigrationSchemaEditor.autoReverse: skips dropModel (cannot recreate permanently dropped table)",
+  async () => {
+    // If a migration calls dropModel() in forwards(), autoReverse() must
+    // not attempt to recreate the table — it just skips silently.
+    const fwdEditor = makeEditor("0004_drop_articles");
+    await fwdEditor.dropModel(ArticleModel);
+    const log = fwdEditor.getOperationLog();
+
+    const bwdEditor = makeEditor("0004_drop_articles");
+    await bwdEditor.autoReverse(log); // must not throw
+
+    // The bwdLog should be empty — nothing can be done to reverse a permanent drop
+    const bwdLog = bwdEditor.getOperationLog();
+    assertEquals(bwdLog.length, 0);
   },
 );


### PR DESCRIPTION
## Summary

- `deprecateField()` now accepts an optional `field` argument and calls `_resolveColumnName()` to derive the correct database column name for `ForeignKey`/`OneToOneField` fields (e.g. `provider` → `provider_id`), fixing the _"column does not exist"_ error. Closes #455
- Added `dropModel()` as the permanent-drop counterpart to `deprecateModel()`, so `backwards()` can correctly reverse a `createModel()` call without renaming the table. Closes #456
- `autoReverse()` updated to use the resolved `op.columnName` when restoring deprecated FK fields, and logs a skip notice for `dropModel` entries (table was permanently dropped and cannot be auto-recreated).