### PR TITLE
fix(db): auto-resolve FK column name in deprecateField without field arg

### DIFF
--- a/src/db/migrations/schema_editor.ts
+++ b/src/db/migrations/schema_editor.ts
@@ -443,12 +443,14 @@ export class MigrationSchemaEditor {
    *
    * For `ForeignKey` and `OneToOneField` fields the actual database column has
    * an `_id` suffix (e.g. field `"provider"` → column `"provider_id"`).
-   * Pass the optional `field` argument so the correct column name is resolved
-   * automatically; without it the JS field name is used as-is.
+   * The correct column name is resolved automatically by instantiating the
+   * model snapshot and inspecting the field. The optional `field` argument
+   * is kept for backward compatibility but is no longer required.
    *
    * @param model - Model class
    * @param fieldName - JS field name to deprecate (e.g. `"provider"`)
-   * @param field - Optional field instance used to resolve the column name
+   * @param field - Optional field instance; if omitted the field is looked up
+   *   from a model instance automatically
    * @returns Deprecation info for tracking
    */
   async deprecateField(
@@ -457,8 +459,13 @@ export class MigrationSchemaEditor {
     field?: AnyField,
   ): Promise<DeprecationInfo> {
     const tableName = this._getTableName(model);
-    const columnName = field
-      ? this._resolveColumnName(fieldName, field)
+    // Resolve the field instance: prefer the caller-supplied one, then fall back
+    // to looking it up on a fresh model instance (handles FK _id suffix, etc.)
+    const resolvedField: AnyField | undefined = field ??
+      // deno-lint-ignore no-explicit-any
+      (new (model as any)())[fieldName] as AnyField | undefined;
+    const columnName = resolvedField
+      ? this._resolveColumnName(fieldName, resolvedField)
       : fieldName;
     const deprecatedName = this._getDeprecatedName(columnName);
 

--- a/src/db/migrations/schema_editor_test.ts
+++ b/src/db/migrations/schema_editor_test.ts
@@ -55,6 +55,17 @@ class CategoryModel extends Model {
   static objects = new Manager(CategoryModel);
 }
 
+/** Snapshot model with a ForeignKey field — used to test auto-resolution. */
+class TicketModel extends Model {
+  static override meta = { dbTable: "tickets" };
+  id = new AutoField({ primaryKey: true });
+  title = new CharField({ maxLength: 200 });
+  provider = new ForeignKey<CategoryModel>("CategoryModel", {
+    onDelete: OnDelete.CASCADE,
+  });
+  static objects = new Manager(TicketModel);
+}
+
 // ---------------------------------------------------------------------------
 // Helper
 // ---------------------------------------------------------------------------
@@ -415,6 +426,45 @@ Deno.test(
     // autoReverse should call restoreField without error (recordOnly)
     const bwdEditor = makeEditor("0003_remove_fk");
     await bwdEditor.autoReverse(log); // must not throw
+  },
+);
+
+// ============================================================================
+// fix #458 — deprecateField auto-resolves FK column name without field arg
+// ============================================================================
+
+Deno.test(
+  "MigrationSchemaEditor: deprecateField without field arg auto-resolves FK column name",
+  async () => {
+    // Reproduces the exact failure from #458:
+    // schema.deprecateField(Ticket, "provider") — no third argument —
+    // should resolve to column "provider_id", not "provider".
+    const editor = makeEditor();
+    await editor.deprecateField(TicketModel, "provider");
+
+    const log = editor.getOperationLog();
+    assertEquals(log.length, 1);
+    assertEquals(log[0].type, "deprecateField");
+    if (log[0].type === "deprecateField") {
+      assertEquals(log[0].fieldName, "provider");
+      // Must be auto-resolved to provider_id (FK suffix)
+      assertEquals(log[0].columnName, "provider_id");
+    }
+  },
+);
+
+Deno.test(
+  "MigrationSchemaEditor: deprecateField without field arg keeps plain fieldName for non-FK",
+  async () => {
+    // Non-FK fields should not gain an _id suffix even without a field arg.
+    const editor = makeEditor();
+    await editor.deprecateField(TicketModel, "title");
+
+    const log = editor.getOperationLog();
+    assertEquals(log.length, 1);
+    if (log[0].type === "deprecateField") {
+      assertEquals(log[0].columnName, "title");
+    }
   },
 );
 


### PR DESCRIPTION
## Summary

- `deprecateField(model, fieldName)` now automatically looks up the field
  instance from the model snapshot when no `field` argument is supplied,
  then calls `_resolveColumnName()` — so FK fields (e.g. `"provider"`) are
  correctly mapped to their DB column (`"provider_id"`) without any extra
  work from the caller.
- The optional third `field` argument is kept for backward compatibility.
- Added two new unit tests that cover the auto-resolution path (FK and
  non-FK) without a `field` argument.

Closes #458